### PR TITLE
Add "Print student reports" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Additional, useful resources:
 * Webpack parses URLs in CSS too, so it will either copy resources automatically to `/dist` or inline them in CSS file. That applies to images and fonts (take a look at webpack config).
 * All the styles are included by related components in JS files. Please make sure that those styles are scoped to the top-level component class, so we don't pollute the whole page. It's not very important right now, but might become important if this page becomes part of the larger UI. And I believe it's a good practice anyway. 
 * I would try to make sure that each component specifies all its necessary styles to look reasonably good and it doesn't depend on styles defined somewhere else (e.g. in parent components). Parent components or global styles could be used to theme components, but they should work just fine without them too.
+* When you modify the component style, please check how it looks while printed.
 
 ## License 
 

--- a/css/activity.less
+++ b/css/activity.less
@@ -1,0 +1,17 @@
+.activity {
+  @media print {
+    padding-left: 0.7em;
+  }
+
+  h3 {
+    color: #86b355;
+    font-size: 1em;
+    font-weight: normal;
+    margin-bottom: 0;
+    @media print {
+      color: #000;
+      font-size: 1.15em;
+      font-weight: normal;
+    }
+  }
+}

--- a/css/answers-table.less
+++ b/css/answers-table.less
@@ -1,13 +1,19 @@
-table.answers {
+.answers-table {
   width: 100%;
   text-align: left;
   border-collapse: collapse;
   font-size: .9em;
   margin-top: 2em;
+  @media print {
+    margin-top: 1em;
+  }
   
   th, td {
     padding: 1em;
     border-bottom: solid 2px #fff;
+    @media print {
+      padding: 0.2em;
+    }
   }
 
   th {
@@ -26,6 +32,15 @@ table.answers {
 
   .select-header {
     width: 10em;
+    @media print {
+      display: none;
+    }
+  }
+
+  .select-answer-column {
+    @media print {
+      display: none;
+    }
   }
 
   a.select-answer {

--- a/css/app.less
+++ b/css/app.less
@@ -12,6 +12,10 @@
     width: 100%;
     height: 100px;
 
+    @media print {
+      display: none;
+    }
+
     .header-content {
       width: @report-width;
       min-width: @min-report-width;
@@ -51,4 +55,8 @@
       color: #da5936;
     }
   }
+}
+
+@page {
+  margin: 1cm;
 }

--- a/css/app.less
+++ b/css/app.less
@@ -6,12 +6,14 @@
   font: @font;
   margin: 0;
   padding: 0;
+  @media print {
+    font-size: 10pt !important;
+  }
 
   .header {
     background: #bddfdf;
     width: 100%;
     height: 100px;
-
     @media print {
       display: none;
     }

--- a/css/bootstrap-components.less
+++ b/css/bootstrap-components.less
@@ -5,6 +5,7 @@
 @import '~bootstrap/less/mixins.less';
 @import '~bootstrap/less/component-animations.less';
 @import '~bootstrap/less/modals.less';
+@import '~bootstrap/less/forms.less';
 
 .modal-content {
   color: @color;

--- a/css/image-answer.less
+++ b/css/image-answer.less
@@ -4,5 +4,8 @@
     height: auto;
     margin-bottom: 1em;
     cursor: pointer;
+    @media print {
+      width: 200px;
+    }
   }
 }

--- a/css/image-question-details.less
+++ b/css/image-question-details.less
@@ -3,6 +3,10 @@
 
   // Customize carousel:
   .carousel {
+    @media print {
+      display: none;
+    }
+
     li {
       cursor: default;
 

--- a/css/investigation.less
+++ b/css/investigation.less
@@ -1,0 +1,16 @@
+.investigation {
+  @media print {
+    padding-left: 0.1em;
+  }
+
+  h2 {
+    font-size: 1.25em;
+    margin-top: 0;
+    margin-bottom: .25em;
+    @media print {
+      color: #000;
+      font-size: 1.15em;
+      font-weight: normal;
+    }
+  }
+}

--- a/css/multiple-choice-details.less
+++ b/css/multiple-choice-details.less
@@ -14,6 +14,9 @@ table.multiple-choice-details {
   td {
     padding: 1em;
     border-bottom: solid 2px #fff;
+    @media print {
+      padding: 0.2em;
+    }
   }
 
   td.number {
@@ -26,7 +29,10 @@ table.multiple-choice-details {
 
   .bar {
     height: 1.3em;
-    background: @defColor;
+    background-color: @defColor;
+    @media print {
+      background-color: @defColor !important;
+    }
   }
 
   .correct {

--- a/css/page.less
+++ b/css/page.less
@@ -1,0 +1,21 @@
+.page {
+  @media print {
+    padding-left: 0.7em;
+  }
+
+  h4 {
+    color: #da5936;
+    font-size: 1em;
+    font-weight: normal;
+    margin-left: 1em;
+    padding: 1em;
+    @media print {
+      color: #000;
+      margin-left: 0;
+      margin-bottom: 0.5em;
+      padding: 0;
+      font-size: 1.15em;
+      font-weight: normal;
+    }
+  }
+}

--- a/css/page.less
+++ b/css/page.less
@@ -12,7 +12,7 @@
     @media print {
       color: #000;
       margin-left: 0;
-      margin-bottom: 0.5em;
+      margin-bottom: 0.4em;
       padding: 0;
       font-size: 1.15em;
       font-weight: normal;

--- a/css/question.less
+++ b/css/question.less
@@ -1,9 +1,26 @@
 .question {
   box-shadow: 1px 1px 4px rgba(102, 102, 102, .5);
-  min-height: 200px;
   padding: 1em;
   margin: 0 auto 1em auto;
   position: relative;
+
+  .question-header {
+    background: #8cbbb8;
+    color: #fff;
+    font-size: 1em;
+    font-weight: normal;
+    margin: -1em -1em .5em -1em;
+    padding: 1em;
+
+    input[type=checkbox] {
+      margin-right: .5em;
+    }
+  }
+
+  .prompt {
+    font-weight: bold;
+    margin-bottom: 0.5em;
+  }
 
   .answers-toggle {
     float: right;

--- a/css/question.less
+++ b/css/question.less
@@ -4,6 +4,19 @@
   margin: 0 auto 1em auto;
   position: relative;
 
+  @media print {
+    box-shadow: none;
+    padding: 0.5em;
+    border: 0.5px solid #ccc;
+    padding-left: 0.7em;
+  }
+
+  &.for-student {
+    @media print {
+      page-break-inside: avoid;
+    }
+  }
+
   .question-header {
     background: #8cbbb8;
     color: #fff;
@@ -11,9 +24,18 @@
     font-weight: normal;
     margin: -1em -1em .5em -1em;
     padding: 1em;
+    @media print {
+      padding: 0;
+      margin: 0;
+      background: none;
+      color: #000;
+    }
 
     input[type=checkbox] {
       margin-right: .5em;
+      @media print {
+        display: none;
+      }
     }
   }
 
@@ -26,5 +48,8 @@
     float: right;
     font-size: 0.85em;
     color: #fff;
+    @media print {
+      display: none;
+    }
   }
 }

--- a/css/question.less
+++ b/css/question.less
@@ -6,7 +6,8 @@
 
   @media print {
     box-shadow: none;
-    padding: 0.5em;
+    padding: 0.2em;
+    margin-bottom: 0.4em;
     border: 0.5px solid #ccc;
     padding-left: 0.7em;
   }

--- a/css/report.less
+++ b/css/report.less
@@ -12,15 +12,23 @@
     margin-top: 1em;
     margin-bottom: 1em;
 
-    h1, .controls {
-      display: inline-block;
-    }
     .controls {
+      display: inline-block;
       float: right;
-      a {
+
+      a, select {
         margin: 0 0.5em;
       }
+
+      select {
+        display: inline-block;
+        width: auto;
+      }
     }
+  }
+
+  .report-content {
+    margin-bottom: 4em;
   }
 
   h1, h2, h3, h5 {
@@ -50,21 +58,5 @@
     font-weight: normal;
     margin-left: 1em;
     padding: 1em;
-  }
-  h5 {
-    background: #8cbbb8;
-    color: #fff;
-    font-size: 1em;
-    font-weight: normal;
-    margin: -1em -1em .5em -1em;
-    padding: 1em;
-  }
-  h5 input[type=checkbox] {
-    margin-right: .5em;
-  }
-  h6 {
-    font-size: 1em;
-    font-weight: normal;
-    margin-bottom: .5em;
   }
 }

--- a/css/report.less
+++ b/css/report.less
@@ -15,6 +15,9 @@
     .controls {
       display: inline-block;
       float: right;
+      @media print {
+        display: none;
+      }
 
       a, select {
         margin: 0 0.5em;
@@ -29,34 +32,22 @@
 
   .report-content {
     margin-bottom: 4em;
-  }
+    @media print {
+      margin-bottom: 2em;
+      page-break-after: always;
+    }
 
-  h1, h2, h3, h5 {
-    margin-bottom: 1em;
-  }
-  h1 {
-    margin-bottom: .5em;
-    text-transform: uppercase;
-    color: #777;
-    font-size: 1em;
-    font-weight: normal;
-  }
-  h2 {
-    font-size: 1.25em;
-    margin-top: 0;
-    margin-bottom: .25em;
-  }
-  h3 {
-    color: #86b355;
-    font-size: 1em;
-    font-weight: normal;
-    margin-bottom: 0;
-  }
-  h4 {
-    color: #da5936;
-    font-size: 1em;
-    font-weight: normal;
-    margin-left: 1em;
-    padding: 1em;
+    h1 {
+      margin-bottom: .5em;
+      text-transform: uppercase;
+      color: #777;
+      font-size: 1em;
+      font-weight: normal;
+      @media print {
+        color: #000;
+        font-size: 1.5em;
+        font-weight: bold;
+      }
+    }
   }
 }

--- a/css/section.less
+++ b/css/section.less
@@ -1,0 +1,5 @@
+.section {
+  @media print {
+    padding-left: 0.7em;
+  }
+}

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -5,6 +5,7 @@ export const INVALIDATE_DATA = 'INVALIDATE_DATA'
 export const REQUEST_DATA = 'REQUEST_DATA'
 export const RECEIVE_DATA = 'RECEIVE_DATA'
 export const RECEIVE_ERROR = 'RECEIVE_ERROR'
+export const SET_TYPE = 'SET_TYPE'
 export const SET_ANONYMOUS = 'SET_ANONYMOUS'
 export const SET_QUESTION_SELECTED = 'SET_QUESTION_SELECTED'
 export const SHOW_SELECTED_QUESTIONS = 'SHOW_SELECTED_QUESTIONS'
@@ -99,6 +100,13 @@ export function showAllQuestions() {
         }
       }
     }
+  }
+}
+
+export function setType(value) {
+  return {
+    type: SET_TYPE,
+    value
   }
 }
 

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -1,4 +1,4 @@
-import { fetchReportData, updateReportSettings } from './api'
+import { fetchReportData, updateReportSettings, APIError } from './api'
 
 // This middleware is executed only if action includes .callAPI object.
 // It calls API action defined in callAPI.type.
@@ -9,7 +9,13 @@ export default store => next => action => {
     const { type, data, successAction, errorAction } = action.callAPI
     callApi(type, data)
       .then(response => successAction && next(successAction(response)))
-      .catch(error => errorAction && next(errorAction(error.response)))
+      .catch(error => {
+        if (error instanceof APIError && errorAction) {
+          return next(errorAction(error.response))
+        }
+        // Remember to throw original error, as otherwise we would swallow every kind of error.
+        throw error
+      })
   }
   return next(action)
 }

--- a/js/api.js
+++ b/js/api.js
@@ -41,12 +41,17 @@ export function updateReportSettings(data) {
   })
 }
 
+export class APIError {
+  constructor(statusText, response) {
+    this.message = statusText
+    this.response = response
+  }
+}
+
 function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response
   } else {
-    var error = new Error(response.statusText)
-    error.response = response
-    throw error
+    throw new APIError(response.statusText, response)
   }
 }

--- a/js/components/activity.js
+++ b/js/components/activity.js
@@ -5,12 +5,12 @@ import Section from './section'
 @pureRender
 export default class Activity extends Component {
   render() {
-    const { activity } = this.props
+    const { activity, reportFor } = this.props
     return (
       <div className={`activity ${activity.get('visible') ? '' : 'hidden'}`}>
         <h3>{activity.get('name')}</h3>
         <div>
-          {activity.get('children').map(s => <Section key={s.get('id')} section={s}/>)}
+          {activity.get('children').map(s => <Section key={s.get('id')} section={s} reportFor={reportFor}/>)}
         </div>
       </div>
     )

--- a/js/components/activity.js
+++ b/js/components/activity.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Section from './section'
 
+import '../../css/activity.less'
+
 @pureRender
 export default class Activity extends Component {
   render() {

--- a/js/components/answer.js
+++ b/js/components/answer.js
@@ -15,7 +15,7 @@ const AnswerComponent = {
 }
 
 @pureRender
-export default class AnswersTable extends Component {
+export default class Answer extends Component {
   render() {
     const { answer, alwaysOpen } = this.props
     const AComponent = AnswerComponent[answer.get('type')]

--- a/js/components/answers-table.js
+++ b/js/components/answers-table.js
@@ -4,14 +4,14 @@ import Answer from './answer'
 import { CompareAnswerCheckboxContainer } from '../containers/compare-answer'
 import ShowCompareContainer from '../containers/show-compare'
 
-import '../../css/answers.less'
+import '../../css/answers-table.less'
 
 @pureRender
 export default class AnswersTable extends Component {
   render() {
     const { answers, hidden } = this.props
     return (
-      <table className={`answers ${hidden ? 'hidden' : ''}`}>
+      <table className={`answers-table ${hidden ? 'hidden' : ''}`}>
         <tbody>
           <tr>
             <th className='student-header'>Student</th>
@@ -29,7 +29,7 @@ const AnswerRow = ({answer}) => (
   <tr>
     <td>{answer.getIn(['student', 'name'])}</td>
     <td><Answer answer={answer}/></td>
-    <td>
+    <td className='select-answer-column'>
       {answer.get('type') !== 'NoAnswer' ?
         <div>
           <CompareAnswerCheckboxContainer answer={answer}/>

--- a/js/components/investigation.js
+++ b/js/components/investigation.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Activity from './activity'
 
+import '../../css/investigation.less'
+
 @pureRender
 export default class Investigation extends Component {
   render() {

--- a/js/components/investigation.js
+++ b/js/components/investigation.js
@@ -5,12 +5,12 @@ import Activity from './activity'
 @pureRender
 export default class Investigation extends Component {
   render() {
-    const { investigation } = this.props
+    const { investigation, reportFor } = this.props
     return (
       <div className='investigation'>
         <h2>{investigation.get('name')}</h2>
         <div>
-          {investigation.get('children').map(a => <Activity key={a.get('id')} activity={a}/>)}
+          {investigation.get('children').map(a => <Activity key={a.get('id')} activity={a} reportFor={reportFor}/>)}
         </div>
       </div>
     )

--- a/js/components/page.js
+++ b/js/components/page.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Question from '../containers/question'
 
+import '../../css/page.less'
+
 @pureRender
 export default class Page extends Component {
   render() {

--- a/js/components/page.js
+++ b/js/components/page.js
@@ -5,13 +5,13 @@ import Question from '../containers/question'
 @pureRender
 export default class Page extends Component {
   render() {
-    const { page } = this.props
+    const { page, reportFor } = this.props
     return (
       <div className={`page ${page.get('visible') ? '' : 'hidden'}`}>
         <h4>Page: {page.get('name')}</h4>
         <div>
           {page.get('children').map((question, idx) => {
-              return <Question key={question.get('key')} question={question} number={idx + 1}/>
+              return <Question key={question.get('key')} question={question} number={idx + 1} reportFor={reportFor}/>
           })}
         </div>
       </div>

--- a/js/components/question-for-class.js
+++ b/js/components/question-for-class.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react'
+import pureRender from 'pure-render-decorator'
+import MultipleChoiceDetails from './multiple-choice-details'
+import ImageQuestionDetails from './image-question-details'
+import QuestionSummary from './question-summary'
+import AnswersTable from './answers-table'
+
+import '../../css/question.less'
+
+const QuestionComponent = {
+  'Embeddable::MultipleChoice': MultipleChoiceDetails,
+  'Embeddable::ImageQuestion': ImageQuestionDetails
+}
+
+@pureRender
+export default class QuestionForClass extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      answersVisible: false
+    }
+    this.toggleAnswersVisibility = this.toggleAnswersVisibility.bind(this)
+    this.handleCheckboxChange = this.handleCheckboxChange.bind(this)
+  }
+
+  toggleAnswersVisibility() {
+    this.setState({answersVisible: !this.state.answersVisible})
+  }
+
+  handleCheckboxChange(event) {
+    const { question, onSelectChange } = this.props
+    onSelectChange(question.get('key'), event.target.checked)
+  }
+
+  render() {
+    const { question, number } = this.props
+    const { answersVisible } = this.state
+    return (
+      <div className={`question ${question.get('visible') ? '' : 'hidden'}`}>
+        <div className='question-header'>
+          <input type='checkbox' checked={question.get('selected')} onChange={this.handleCheckboxChange}/>
+          Question #{number}
+          <a className='answers-toggle' onClick={this.toggleAnswersVisibility}>
+            {answersVisible ? 'Hide responses' : 'Show responses'}
+          </a>
+        </div>
+        <QuestionSummary question={question}/>
+        <QuestionDetails question={question}/>
+        {answersVisible ? <AnswersTable answers={question.get('responses')}/> : ''}
+      </div>
+    )
+  }
+}
+
+const QuestionDetails = ({question}) => {
+  const QComponent = QuestionComponent[question.get('type')]
+  if (!QComponent) {
+    return <span></span>
+  }
+  return <QComponent question={question}/>
+}

--- a/js/components/question-for-student.js
+++ b/js/components/question-for-student.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react'
+import pureRender from 'pure-render-decorator'
+import Answer from './answer'
+
+import '../../css/question.less'
+
+@pureRender
+export default class QuestionForStudent extends Component {
+  constructor(props) {
+    super(props)
+    this.handleCheckboxChange = this.handleCheckboxChange.bind(this)
+  }
+
+  handleCheckboxChange(event) {
+    const { question, onSelectChange } = this.props
+    onSelectChange(question.get('key'), event.target.checked)
+  }
+
+  render() {
+    const { question, student, number } = this.props
+    const studentId = student.get('id')
+    const answer = question.get('responses').filter(a => a.get('studentId') === studentId).first()
+    return (
+      <div className={`question ${question.get('visible') ? '' : 'hidden'}`}>
+        <div className='question-header'>
+          <input type='checkbox' checked={question.get('selected')} onChange={this.handleCheckboxChange}/>
+          Question #{number}
+        </div>
+        <div className='prompt'>{question.get('prompt') || question.get('name')}</div>
+        <Answer answer={answer}/>
+      </div>
+    )
+  }
+}

--- a/js/components/question-for-student.js
+++ b/js/components/question-for-student.js
@@ -21,7 +21,7 @@ export default class QuestionForStudent extends Component {
     const studentId = student.get('id')
     const answer = question.get('responses').filter(a => a.get('studentId') === studentId).first()
     return (
-      <div className={`question ${question.get('visible') ? '' : 'hidden'}`}>
+      <div className={`question for-student ${question.get('visible') ? '' : 'hidden'}`}>
         <div className='question-header'>
           <input type='checkbox' checked={question.get('selected')} onChange={this.handleCheckboxChange}/>
           Question #{number}

--- a/js/components/question.js
+++ b/js/components/question.js
@@ -1,65 +1,16 @@
 import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
-import MultipleChoiceDetails from './multiple-choice-details'
-import ImageQuestionDetails from './image-question-details'
-import QuestionSummary from './question-summary'
-import AnswersTable from './answers-table'
-
-import '../../css/question.less'
-
-const QuestionComponent = {
-  'Embeddable::MultipleChoice': MultipleChoiceDetails,
-  'Embeddable::ImageQuestion': ImageQuestionDetails
-}
+import QuestionForClass from './question-for-class'
+import QuestionForStudent from './question-for-student'
 
 @pureRender
 export default class Question extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      answersVisible: false
-    }
-    this.toggleAnswersVisibility = this.toggleAnswersVisibility.bind(this)
-    this.handleCheckboxChange = this.handleCheckboxChange.bind(this)
-  }
-
-  toggleAnswersVisibility() {
-    this.setState({answersVisible: !this.state.answersVisible})
-  }
-
-  handleCheckboxChange(event) {
-    const { question, onSelectChange } = this.props
-    onSelectChange(question.get('key'), event.target.checked)
-  }
-
   render() {
-    const { question, number } = this.props
-    const { answersVisible } = this.state
-    return (
-      <div className={`question ${question.get('visible') ? '' : 'hidden'}`}>
-        <div className='question-header'>
-          <h5>
-            <input type='checkbox' checked={question.get('selected')} onChange={this.handleCheckboxChange}/>
-            Question #{number}
-            <a className='answers-toggle' onClick={this.toggleAnswersVisibility}>
-              {answersVisible ? 'Hide responses' : 'Show responses'}
-            </a>
-          </h5>
-        </div>
-        <QuestionSummary question={question}/>
-        <div className='details-container'>
-          <QuestionDetails question={question}/>
-        </div>
-        {answersVisible ? <AnswersTable answers={question.get('responses')}/> : ''}
-      </div>
-    )
+    const { question, number, reportFor, onSelectChange } = this.props
+    if (reportFor === 'class') {
+      return <QuestionForClass question={question} number={number} onSelectChange={onSelectChange}/>
+    } else {
+      return <QuestionForStudent question={question} student={reportFor} number={number} onSelectChange={onSelectChange}/>
+    }
   }
-}
-
-const QuestionDetails = ({question}) => {
-  const QComponent = QuestionComponent[question.get('type')]
-  if (!QComponent) {
-    return <span></span>
-  }
-  return <QComponent question={question}/>
 }

--- a/js/components/report.js
+++ b/js/components/report.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react'
+import pureRender from 'pure-render-decorator'
+import Investigation from './investigation'
+import Button from './button'
+
+import '../../css/report.less'
+
+@pureRender
+export default class Report extends Component {
+  renderClassReport() {
+    const { report } = this.props
+    return (
+      <div className='report-content'>
+        <h1>Report for: {report.get('clazzName')}</h1>
+        <Investigation investigation={report.get('investigation')} reportFor={'class'}/>
+      </div>
+    )
+  }
+
+  renderStudentReport() {
+    const { report } = this.props
+    return [...report.get('students').values()].filter(s => s.get('startedOffering')).map(s =>
+      <div key={s.get('id')} className='report-content'>
+        <h1>Report for: {s.get('name')}</h1>
+        <Investigation investigation={report.get('investigation')} reportFor={s}/>
+      </div>
+    )
+  }
+
+  render() {
+    const { report, showSelectedQuestions, showAllQuestions, setType, setAnonymous } = this.props
+    const isAnonymous = report.get('anonymous')
+    return (
+      <div>
+        <div className='report-header'>
+          <div className='controls'>
+            <select className='form-control' value={report.get('type')} onChange={(e) => setType(e.target.value)}>
+              <option value='class'>Report for class</option>
+              <option value='student'>Report for student</option>
+            </select>
+            <Button onClick={showSelectedQuestions}>Show selected</Button>
+            <Button onClick={showAllQuestions}>Show all</Button>
+            <Button onClick={() => setAnonymous(!isAnonymous)}>{isAnonymous ? 'Show names' : 'Hide names'}</Button>
+          </div>
+        </div>
+        {report.get('type') === 'class' ? this.renderClassReport() : this.renderStudentReport()}
+      </div>
+    )
+  }
+}

--- a/js/components/report.js
+++ b/js/components/report.js
@@ -41,6 +41,7 @@ export default class Report extends Component {
             <Button onClick={showSelectedQuestions}>Show selected</Button>
             <Button onClick={showAllQuestions}>Show all</Button>
             <Button onClick={() => setAnonymous(!isAnonymous)}>{isAnonymous ? 'Show names' : 'Hide names'}</Button>
+            <Button onClick={() => window.print()}>Print</Button>
           </div>
         </div>
         {report.get('type') === 'class' ? this.renderClassReport() : this.renderStudentReport()}

--- a/js/components/section.js
+++ b/js/components/section.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Page from './page'
 
+import '../../css/section.less'
+
 @pureRender
 export default class Section extends Component {
   render() {

--- a/js/components/section.js
+++ b/js/components/section.js
@@ -5,12 +5,12 @@ import Page from './page'
 @pureRender
 export default class Section extends Component {
   render() {
-    const { section } = this.props
+    const { section, reportFor } = this.props
     return (
       <div className={`section ${section.get('visible') ? '' : 'hidden'}`}>
         <span className={section.get('nameHidden') ? 'hidden' : ''}>{section.get('name')}</span>
         <div>
-          {section.get('children').map(p => <Page key={p.get('id')} page={p}/>)}
+          {section.get('children').map(p => <Page key={p.get('id')} page={p} reportFor={reportFor}/>)}
         </div>
       </div>
     )

--- a/js/containers/app.js
+++ b/js/containers/app.js
@@ -2,11 +2,11 @@ import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import { connect } from 'react-redux'
 import { selectReport, fetchDataIfNeeded, invalidateData, hideCompareView,
-         showSelectedQuestions, showAllQuestions, setAnonymous } from '../actions'
+         showSelectedQuestions, showAllQuestions, setType, setAnonymous } from '../actions'
 import { Modal } from 'react-bootstrap'
 import Button from '../components/button'
 import CompareView from '../components/compare-view'
-import Investigation from '../components/investigation'
+import Report from '../components/report'
 import DataFetchError from '../components/data-fetch-error'
 import LoadingIcon from '../components/loading-icon'
 import ccLogoSrc from '../../img/cc-logo.png'
@@ -15,7 +15,6 @@ import reportData from '../core/report-data'
 import compareViewData from '../core/compare-view-data'
 
 import '../../css/app.less'
-import '../../css/report.less'
 
 @pureRender
 class App extends Component {
@@ -48,23 +47,9 @@ class App extends Component {
   }
 
   renderReport() {
-    const { clazzName, report, isAnonymous,
-            showSelectedQuestions, showAllQuestions, setAnonymous } = this.props
-    return (
-      <div>
-        <div className='report-header'>
-          <h1>
-            Report for: {clazzName}
-          </h1>
-          <div className='controls'>
-            <Button onClick={showSelectedQuestions}>Show selected</Button>
-            <Button onClick={showAllQuestions}>Show all</Button>
-            <Button onClick={() => setAnonymous(!isAnonymous)}>{isAnonymous ? 'Show names' : 'Hide names'}</Button>
-          </div>
-        </div>
-        <Investigation investigation={report}/>
-      </div>
-    )
+    const { report, showSelectedQuestions, showAllQuestions, setType, setAnonymous } = this.props
+    return <Report report={report} showSelectedQuestions={showSelectedQuestions} showAllQuestions={showAllQuestions}
+                   setType={setType} setAnonymous={setAnonymous}/>
   }
 
   renderCompareView() {
@@ -103,13 +88,12 @@ function mapStateToProps(state) {
   const data = state.get('data')
   const reportState = state.get('report')
   const compareViewAnswers = reportState && reportState.get('compareViewAnswers')
+  const dataDownloaded = !!data.get('lastUpdated')
   return {
     isFetching: data.get('isFetching'),
     lastUpdated: data.get('lastUpdated'),
     error: data.get('error'),
-    clazzName: reportState && reportState.get('clazzName'),
-    isAnonymous: reportState && reportState.get('anonymousReport'),
-    report: reportState && reportData(reportState),
+    report: dataDownloaded && reportData(reportState),
     compareViewAnswers: compareViewAnswers && compareViewData(reportState)
   }
 }
@@ -120,7 +104,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     invalidateData: () => dispatch(invalidateData()),
     showSelectedQuestions: () => dispatch(showSelectedQuestions()),
     showAllQuestions: () => dispatch(showAllQuestions()),
-    setAnonymous: (value) => dispatch(setAnonymous(value)),
+    setType: value => dispatch(setType(value)),
+    setAnonymous: value => dispatch(setAnonymous(value)),
     hideCompareView: () => dispatch(hideCompareView())
   }
 }

--- a/js/core/report-data.js
+++ b/js/core/report-data.js
@@ -1,9 +1,15 @@
+import { Map } from 'immutable'
+
 // Generates tree that is consumed by React components from reportState (ImmutableJS Map).
 // It includes all the properties provided by API + calculates a few additional ones.
 export default function reportData(reportState) {
+  return reportState.set('investigation', investigation(reportState))
+}
+
+export function investigation(state) {
   // There is always only one investigation.
-  const investigation = reportState.get('investigations').values().next().value
-  return investigation.set('children', investigation.get('children').map(id => activity(reportState, id)))
+  const investigation = state.get('investigations').values().next().value
+  return investigation.set('children', investigation.get('children').map(id => activity(state, id)))
 }
 
 export function activity(state, id) {
@@ -48,9 +54,5 @@ export function answer(state, key) {
 }
 
 export function student(state, id) {
-  const student = state.get('students').get(id.toString())
-  if (state.get('anonymousReport')) {
-    return student.set('name', 'Student ' + student.get('id'))
-  }
-  return student
+  return state.get('students').get(id.toString())
 }

--- a/js/core/transform-json-response.js
+++ b/js/core/transform-json-response.js
@@ -66,6 +66,7 @@ export default function transformJSONResponse(json) {
   }
   applyVisibilityFilter(response.entities.questions, response.result.visibilityFilter)
   copyAnswerKeysToObjects(response.entities.answers)
+  saveStudentsRealNames(response.entities.students)
   return response
 }
 
@@ -84,5 +85,12 @@ function applyVisibilityFilter(questions, visibilityFilter) {
 function copyAnswerKeysToObjects(answers) {
   Object.keys(answers).forEach(key => {
     answers[key].key = key
+  })
+}
+
+// Provide additional property in student hash, it's useful for anonymization.
+function saveStudentsRealNames(students) {
+  Object.values(students).forEach(student => {
+    student.realName = student.name
   })
 }

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -490,7 +490,7 @@
     ]
   },
   "class": {
-    "name": "test",
+    "name": "Test Class",
     "students": [
       {
         "id": 13,

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -44,7 +44,7 @@ function report(state = INITIAL_REPORT_STATE, action) {
                   .set('clazzName', data.result.class.name)
                   .set('visibilityFilterActive', data.result.visibilityFilter.active)
                   .set('anonymous', data.result.anonymousReport)
-                  .set('hideSectionNames', data.result.isOfferingExterna)
+                  .set('hideSectionNames', data.result.isOfferingExternal)
     case SET_TYPE:
       return state.set('type', action.value)
     case SET_QUESTION_SELECTED:

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -1,6 +1,6 @@
 import Immutable, { Map, Set } from 'immutable'
 import {
-  REQUEST_DATA, RECEIVE_DATA, RECEIVE_ERROR, INVALIDATE_DATA, SET_ANONYMOUS,
+  REQUEST_DATA, RECEIVE_DATA, RECEIVE_ERROR, INVALIDATE_DATA, SET_TYPE, SET_ANONYMOUS,
   SET_QUESTION_SELECTED, SHOW_SELECTED_QUESTIONS, SHOW_ALL_QUESTIONS,
   SET_ANSWER_SELECTED_FOR_COMPARE, SHOW_COMPARE_VIEW, HIDE_COMPARE_VIEW} from '../actions'
 
@@ -27,23 +27,26 @@ function data(state = Map(), action) {
   }
 }
 
-function report(state = null, action) {
+const INITIAL_REPORT_STATE = Map({
+  type: 'class'
+})
+function report(state = INITIAL_REPORT_STATE, action) {
   switch (action.type) {
     case RECEIVE_DATA:
       const data = transformJSONResponse(action.response)
-      return Map({
-        students: Immutable.fromJS(data.entities.students),
-        investigations: Immutable.fromJS(data.entities.investigations),
-        activities: Immutable.fromJS(data.entities.activities),
-        sections: Immutable.fromJS(data.entities.sections),
-        pages: Immutable.fromJS(data.entities.pages),
-        questions: Immutable.fromJS(data.entities.questions),
-        answers: Immutable.fromJS(data.entities.answers),
-        clazzName: data.result.class.name,
-        visibilityFilterActive: data.result.visibilityFilter.active,
-        anonymousReport: data.result.anonymousReport,
-        hideSectionNames: data.result.isOfferingExternal
-      })
+      return state.set('students', Immutable.fromJS(data.entities.students))
+                  .set('investigations', Immutable.fromJS(data.entities.investigations))
+                  .set('activities', Immutable.fromJS(data.entities.activities))
+                  .set('sections', Immutable.fromJS(data.entities.sections))
+                  .set('pages', Immutable.fromJS(data.entities.pages))
+                  .set('questions', Immutable.fromJS(data.entities.questions))
+                  .set('answers', Immutable.fromJS(data.entities.answers))
+                  .set('clazzName', data.result.class.name)
+                  .set('visibilityFilterActive', data.result.visibilityFilter.active)
+                  .set('anonymous', data.result.anonymousReport)
+                  .set('hideSectionNames', data.result.isOfferingExterna)
+    case SET_TYPE:
+      return state.set('type', action.value)
     case SET_QUESTION_SELECTED:
       return state.setIn(['questions', action.key, 'selected'], action.value)
     case SHOW_SELECTED_QUESTIONS:
@@ -58,7 +61,10 @@ function report(state = null, action) {
     case SHOW_ALL_QUESTIONS:
       return state.set('visibilityFilterActive', false)
     case SET_ANONYMOUS:
-      return state.set('anonymousReport', action.value)
+      let idx = 1
+      const newStudents = state.get('students').map(s => s.set('name', action.value ? `Student ${idx++}` : s.get('realName')))
+      return state.set('anonymous', action.value)
+                  .set('students', newStudents)
     case SET_ANSWER_SELECTED_FOR_COMPARE:
       const compareViewAns = state.get('compareViewAnswers')
       if (compareViewAns) {


### PR DESCRIPTION
We need to render a different report type behind the scenes - per student instead of per class. This PR implements that, add a new button and bunch of `@media print` styles. It also includes a small refactoring of data structure and components. 

Deployed demo:
http://concord-consortium.github.io/portal-report/