### PR TITLE
fix: Names are not still hidden when you re-open the report

### DIFF
--- a/js/core/report-data.js
+++ b/js/core/report-data.js
@@ -43,9 +43,7 @@ export function question(state, key) {
   const question = state.get('questions').get(key.toString())
                   // Sort answers by student name, so views don't have to care about it.
   return question.set('answers', question.get('answers').map(key => answer(state, key))
-                                                          .sortBy(a => a.getIn(['student', 'name'])))
-                 // Question is visible if it's selected or visibility filter is inactive.
-                 .set('visible', question.get('visible') || !state.get('visibilityFilterActive'))
+                                                        .sortBy(a => a.getIn(['student', 'name'])))
 }
 
 export function answer(state, key) {

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -31,10 +31,15 @@ const INITIAL_REPORT_STATE = Map({
   type: 'class'
 })
 function report(state = INITIAL_REPORT_STATE, action) {
+  let idx = 1
   switch (action.type) {
     case RECEIVE_DATA:
       const data = transformJSONResponse(action.response)
-      return state.set('students', Immutable.fromJS(data.entities.students))
+      const anonymous = data.result.anonymousReport
+      // student names must be rewritten if report is loaded as anonmyous.
+      const students = Immutable.fromJS(data.entities.students)
+        .map(s => s.set('name', anonymous ? `Student ${idx++}` : s.get('realName')))
+      return state.set('students', students)
                   .set('investigations', Immutable.fromJS(data.entities.investigations))
                   .set('activities', Immutable.fromJS(data.entities.activities))
                   .set('sections', Immutable.fromJS(data.entities.sections))
@@ -61,7 +66,6 @@ function report(state = INITIAL_REPORT_STATE, action) {
     case SHOW_ALL_QUESTIONS:
       return state.set('visibilityFilterActive', false)
     case SET_ANONYMOUS:
-      let idx = 1
       const newStudents = state.get('students').map(s => s.set('name', action.value ? `Student ${idx++}` : s.get('realName')))
       return state.set('anonymous', action.value)
                   .set('students', newStudents)

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -27,48 +27,54 @@ function data(state = Map(), action) {
   }
 }
 
+function setAnonymous(state, anonymous) {
+  let idx = 1
+  const newStudents = state.get('students').map(s => s.set('name', anonymous ? `Student ${idx++}` : s.get('realName')))
+  return state.set('anonymous', anonymous)
+              .set('students', newStudents)
+}
+
+function setVisibilityFilterActive(state, filterActive) {
+  return state.withMutations(state => {
+    state.set('visibilityFilterActive', filterActive)
+    state.get('questions').forEach((value, key) => {
+      const questionSelected = state.getIn(['questions', key, 'selected'])
+      // Question is visible if it's selected or visibility filter is inactive.
+      state = state.setIn(['questions', key, 'visible'], questionSelected || !filterActive)
+    })
+    return state
+  })
+}
+
 const INITIAL_REPORT_STATE = Map({
   type: 'class'
 })
 function report(state = INITIAL_REPORT_STATE, action) {
-  let idx = 1
   switch (action.type) {
     case RECEIVE_DATA:
       const data = transformJSONResponse(action.response)
-      const anonymous = data.result.anonymousReport
-      // student names must be rewritten if report is loaded as anonmyous.
-      const students = Immutable.fromJS(data.entities.students)
-        .map(s => s.set('name', anonymous ? `Student ${idx++}` : s.get('realName')))
-      return state.set('students', students)
-                  .set('investigations', Immutable.fromJS(data.entities.investigations))
-                  .set('activities', Immutable.fromJS(data.entities.activities))
-                  .set('sections', Immutable.fromJS(data.entities.sections))
-                  .set('pages', Immutable.fromJS(data.entities.pages))
-                  .set('questions', Immutable.fromJS(data.entities.questions))
-                  .set('answers', Immutable.fromJS(data.entities.answers))
-                  .set('clazzName', data.result.class.name)
-                  .set('visibilityFilterActive', data.result.visibilityFilter.active)
-                  .set('anonymous', data.result.anonymousReport)
-                  .set('hideSectionNames', data.result.isOfferingExternal)
+      state = state.set('students', Immutable.fromJS(data.entities.students))
+                   .set('investigations', Immutable.fromJS(data.entities.investigations))
+                   .set('activities', Immutable.fromJS(data.entities.activities))
+                   .set('sections', Immutable.fromJS(data.entities.sections))
+                   .set('pages', Immutable.fromJS(data.entities.pages))
+                   .set('questions', Immutable.fromJS(data.entities.questions))
+                   .set('answers', Immutable.fromJS(data.entities.answers))
+                   .set('clazzName', data.result.class.name)
+                   .set('hideSectionNames', data.result.isOfferingExternal)
+      state = setAnonymous(state, data.result.anonymousReport)
+      state = setVisibilityFilterActive(state, data.result.visibilityFilter.active)
+      return state
     case SET_TYPE:
       return state.set('type', action.value)
     case SET_QUESTION_SELECTED:
       return state.setIn(['questions', action.key, 'selected'], action.value)
     case SHOW_SELECTED_QUESTIONS:
-      // For each question: visible = selected
-      return state.withMutations(state => {
-        state.set('visibilityFilterActive', true)
-        state.get('questions').forEach((value, key) => {
-          state = state.setIn(['questions', key, 'visible'], state.getIn(['questions', key, 'selected']))
-        })
-        return state
-      })
+      return setVisibilityFilterActive(state, true)
     case SHOW_ALL_QUESTIONS:
-      return state.set('visibilityFilterActive', false)
+      return setVisibilityFilterActive(state, false)
     case SET_ANONYMOUS:
-      const newStudents = state.get('students').map(s => s.set('name', action.value ? `Student ${idx++}` : s.get('realName')))
-      return state.set('anonymous', action.value)
-                  .set('students', newStudents)
+      return setAnonymous(state, action.value)
     case SET_ANSWER_SELECTED_FOR_COMPARE:
       const compareViewAns = state.get('compareViewAnswers')
       if (compareViewAns) {


### PR DESCRIPTION
small PR when you get a chance @pjanik 

This small fix obfuscates student names when first loaded if `anonymousReport` is true.  

[#115799893]

https://www.pivotaltracker.com/story/show/115799893