### PR TITLE
Fix: Print for student report not showing images of image questions.

### DIFF
--- a/css/report.less
+++ b/css/report.less
@@ -49,5 +49,8 @@
         font-weight: bold;
       }
     }
+    &.hidden {
+      display: none;
+    }
   }
 }

--- a/js/components/report.js
+++ b/js/components/report.js
@@ -16,8 +16,9 @@ export default class Report extends Component {
 
   renderClassReport() {
     const { report } = this.props
+    const className  = report.get('type') == 'class' ? 'report-content' : 'report-content hidden'
     return (
-      <div className='report-content'>
+      <div className={className}>
         <h1>Report for: {report.get('clazzName')}</h1>
         <Investigation investigation={report.get('investigation')} reportFor={'class'}/>
       </div>
@@ -26,8 +27,9 @@ export default class Report extends Component {
 
   renderStudentReports() {
     const { report } = this.props
+    const className  = report.get('type') ==='student' ? 'report-content' : 'report-content hidden'
     return [...report.get('students').values()].filter(s => s.get('startedOffering')).map(s =>
-      <div key={s.get('id')} className='report-content'>
+      <div key={s.get('id')} className={className}>
         <h1>Report for: {s.get('name')}</h1>
         <Investigation investigation={report.get('investigation')} reportFor={s}/>
       </div>
@@ -82,7 +84,8 @@ export default class Report extends Component {
             <Button onClick={this.printStudentReports}>Print student reports</Button>
           </div>
         </div>
-        {report.get('type') === 'class' ? this.renderClassReport() : this.renderStudentReports()}
+        {this.renderClassReport()}
+        {this.renderStudentReports()}
       </div>
     )
   }


### PR DESCRIPTION
This problem was intermittant, and the result of images not being (consistently) loaded on
the student page shortly after the print button was pressed.

After taking a deep dive into using image onLoad callbacks &etc, I decided it was simpler to hide the student view (instead of not rendering), so the images would be pre-loaded for printing.  

There may be performance issues with this down the road if we have a lot of student data, but I am not very worried at the moment.

NB: There is an issue with firefox not firing the media query events after the print dialog is closed,
so that we remain on the students report page.  I put this in as an issue ( #12 )

[#115800099]
https://www.pivotaltracker.com/story/show/115800099