### PR TITLE
The report should handle case where no students have yet started the activity

### DIFF
--- a/js/core/transform-json-response.js
+++ b/js/core/transform-json-response.js
@@ -65,7 +65,7 @@ export default function transformJSONResponse(json) {
     }
   }
   applyVisibilityFilter(response.entities.questions, response.result.visibilityFilter)
-  copyAnswerKeysToObjects(response.entities.answers)
+  copyAnswerKeysToObjects(response.entities.answers || [])
   saveStudentsRealNames(response.entities.students)
   return response
 }


### PR DESCRIPTION


This was throwing `transform-json-response.js:86Uncaught (in promise) TypeError: Cannot convert undefined or null to object(…)`

```
// Keys are generated by normalizr above, so just copy them to the object hashes.
function copyAnswerKeysToObjects(answers) {
  Object.keys(answers).forEach(key => {
    answers[key].key = key
  })
}
```
[#116249081]

https://www.pivotaltracker.com/story/show/116249081