### PR TITLE
Add a clear way to close the enlarged image window [#116559811]

### DIFF
--- a/css/image-answer.less
+++ b/css/image-answer.less
@@ -13,3 +13,14 @@
     font-style: italic;
   }
 }
+
+.modal-header {
+  text-align: right;
+  border-bottom: 0 !important;
+
+  button.close {
+    font-size: 24px;
+    font-weight: bold;
+    color: #f00;
+  }
+}

--- a/js/components/image-answer-modal.js
+++ b/js/components/image-answer-modal.js
@@ -4,11 +4,29 @@ import { Modal } from 'react-bootstrap'
 
 @pureRender
 export default class ImageAnswerModal extends Component {
+
+  componentDidMount() {
+    window.addEventListener('click', this.windowClicked.bind(this), true)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('click', this.windowClicked.bind(this))
+  }
+
+  windowClicked() {
+    const { show, onHide } = this.props
+    if (show) {
+      // hide the modal with any click in the window and not just the modal background
+      onHide();
+    }
+  }
+
   render() {
     const { answer, show, onHide } = this.props
     if (!answer) return null
     return (
       <Modal show={show} onHide={onHide}>
+        <Modal.Header closeButton={true} />
         <Modal.Body>
           <img src={answer.getIn(['answer', 'imageUrl'])} style={{display: 'block', margin: '0 auto'}}/>
         </Modal.Body>


### PR DESCRIPTION
Since the React modal component has no click handler for the image itself I had to mount a click handler on the window when the component mounts.