### PR TITLE
Add note to image answer carousel [#116559551]

### DIFF
--- a/css/image-answer.less
+++ b/css/image-answer.less
@@ -8,4 +8,8 @@
       width: 200px;
     }
   }
+
+  .image-answer-note {
+    font-style: italic;
+  }
 }

--- a/js/components/image-answer.js
+++ b/js/components/image-answer.js
@@ -20,7 +20,7 @@ export default class ImageAnswer extends Component {
       <div>
         <div className='image-answer'>
           <img src={imgAnswer.get('imageUrl')} onClick={() => this.setState({modalOpen: true})}/>
-          <div>{imgAnswer.get('note')}</div>
+          <div className='image-answer-note'>{imgAnswer.get('note')}</div>
         </div>
         <ImageAnswerModal answer={answer} show={this.state.modalOpen} onHide={() => this.setState({modalOpen: false})}/>
       </div>

--- a/js/components/image-question-details.js
+++ b/js/components/image-question-details.js
@@ -6,12 +6,14 @@ import ImageAnswerModal from './image-answer-modal'
 import '../../css/react-responsive-carousel.css'
 import '../../css/image-question-details.less'
 
-function renderImage(src, legend, key) {
+function renderImage(src, legend, key, note) {
   return (
     <div key={key}>
       <img src={src}/>
       <p className='legend'>
         {legend}
+        <br/>
+        <em>{note}</em>
       </p>
     </div>
   )
@@ -53,7 +55,7 @@ export default class ImageQuestionDetails extends Component {
 
   renderImages() {
     return this.images.map(a => {
-      return renderImage(a.getIn(['answer', 'imageUrl']), a.getIn(['student', 'name']), a.getIn(['student', 'id']))
+      return renderImage(a.getIn(['answer', 'imageUrl']), a.getIn(['student', 'name']), a.getIn(['student', 'id']), a.getIn(['answer', 'note']))
     }).toJS()
   }
 


### PR DESCRIPTION
(I was changing some of my github credentials around and I created the previous PR with the wrong account).

The react-responsive-carousel did not like having text and images together so I added the note to the legend instead of next to the image.