### PR TITLE
Individual activity report from a sequence shows in the new format

### DIFF
--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -5,7 +5,7 @@ export const INVALIDATE_DATA = 'INVALIDATE_DATA'
 export const REQUEST_DATA = 'REQUEST_DATA'
 export const RECEIVE_DATA = 'RECEIVE_DATA'
 export const RECEIVE_ERROR = 'RECEIVE_ERROR'
-export const SET_TYPE = 'SET_TYPE'
+export const SET_NOW_SHOWING = 'SET_NOW_SHOWING'
 export const SET_ANONYMOUS = 'SET_ANONYMOUS'
 export const SET_QUESTION_SELECTED = 'SET_QUESTION_SELECTED'
 export const SHOW_SELECTED_QUESTIONS = 'SHOW_SELECTED_QUESTIONS'
@@ -118,9 +118,9 @@ export function showAllQuestions() {
   }
 }
 
-export function setType(value) {
+export function setNowShowing(value) {
   return {
-    type: SET_TYPE,
+    type: SET_NOW_SHOWING,
     value
   }
 }

--- a/js/components/report.js
+++ b/js/components/report.js
@@ -22,7 +22,8 @@ export default class Report extends Component {
 
   renderClassReport() {
     const { report } = this.props
-    const className  = report.get('type') == 'class' ? 'report-content' : 'report-content hidden'
+    const nowShowing = report.get('nowShowing')
+    const className  = nowShowing === 'class' ? 'report-content' : 'report-content hidden'
     return (
       <div className={className}>
         <h1>Report for: {report.get('clazzName')}</h1>
@@ -33,7 +34,8 @@ export default class Report extends Component {
 
   renderStudentReports() {
     const { report } = this.props
-    const className  = report.get('type') ==='student' ? 'report-content' : 'report-content hidden'
+    const nowShowing = report.get('nowShowing')
+    const className  = nowShowing ==='student' ? 'report-content' : 'report-content hidden'
     return [...report.get('students').values()].filter(s => s.get('startedOffering')).map(s =>
       <div key={s.get('id')} className={className}>
         <h1>Report for: {s.get('name')}</h1>
@@ -44,8 +46,8 @@ export default class Report extends Component {
 
   printStudentReports() {
     // Change report style to "per student" style.
-    const { setType } = this.props
-    setType('student')
+    const { setNowShowing } = this.props
+    setNowShowing('student')
     // setTimeout is necessary, as and re-render is async. Not the nicest way, but it's simple and self-contained.
     setTimeout(() => window.print(), 1)
     this.setupAfterPrintListener()
@@ -53,8 +55,9 @@ export default class Report extends Component {
 
   afterPrint() {
     // Go back to the default report style ("per class").
-    const { setType } = this.props
-    setType('class')
+    const { setNowShowing, report } = this.props
+    const type = report.get('type')
+    setNowShowing(type)
     this.cleanupAfterPrintListener()
   }
 

--- a/js/containers/app.js
+++ b/js/containers/app.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import { connect } from 'react-redux'
 import { selectReport, fetchDataIfNeeded, invalidateData, hideCompareView,
-         showSelectedQuestions, showAllQuestions, setType, setAnonymous } from '../actions'
+         showSelectedQuestions, showAllQuestions, setNowShowing, setAnonymous } from '../actions'
 import { Modal } from 'react-bootstrap'
 import Button from '../components/button'
 import CompareView from '../components/compare-view'
@@ -47,9 +47,11 @@ class App extends Component {
   }
 
   renderReport() {
-    const { report, showSelectedQuestions, showAllQuestions, setType, setAnonymous } = this.props
-    return <Report report={report} showSelectedQuestions={showSelectedQuestions} showAllQuestions={showAllQuestions}
-                   setType={setType} setAnonymous={setAnonymous}/>
+    const { report, showSelectedQuestions, showAllQuestions, setNowShowing, setAnonymous } = this.props
+    return <Report report={report}
+                   howSelectedQuestions={showSelectedQuestions}
+                   showAllQuestions={showAllQuestions}
+                   setNowShowing={setNowShowing} setAnonymous={setAnonymous}/>
   }
 
   renderCompareView() {
@@ -105,7 +107,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     invalidateData: () => dispatch(invalidateData()),
     showSelectedQuestions: () => dispatch(showSelectedQuestions()),
     showAllQuestions: () => dispatch(showAllQuestions()),
-    setType: value => dispatch(setType(value)),
+    setNowShowing: value => dispatch(setNowShowing(value)),
     setAnonymous: value => dispatch(setAnonymous(value)),
     hideCompareView: () => dispatch(hideCompareView())
   }

--- a/js/containers/app.js
+++ b/js/containers/app.js
@@ -49,7 +49,7 @@ class App extends Component {
   renderReport() {
     const { report, showSelectedQuestions, showAllQuestions, setNowShowing, setAnonymous } = this.props
     return <Report report={report}
-                   howSelectedQuestions={showSelectedQuestions}
+                   showSelectedQuestions={showSelectedQuestions}
                    showAllQuestions={showAllQuestions}
                    setNowShowing={setNowShowing} setAnonymous={setAnonymous}/>
   }

--- a/js/core/transform-json-response.js
+++ b/js/core/transform-json-response.js
@@ -1,6 +1,7 @@
 import { normalize, Schema, arrayOf } from 'normalizr'
 import humps from 'humps'
 
+const DEFAULT_REPORT_FOR = 'class'
 // Transforms deeply nested structure of report:
 // {
 //  "report": {
@@ -64,6 +65,7 @@ export default function transformJSONResponse(json) {
       }
     }
   }
+  response.type  = camelizedJson.reportFor || DEFAULT_REPORT_FOR
   applyVisibilityFilter(response.entities.questions, response.result.visibilityFilter)
   copyAnswerKeysToObjects(response.entities.answers || [])
   saveStudentsRealNames(response.entities.students)

--- a/js/core/transform-json-response.js
+++ b/js/core/transform-json-response.js
@@ -78,8 +78,13 @@ function applyVisibilityFilter(questions, visibilityFilter) {
     question.visible = false
   })
   visibilityFilter.questions.forEach(key => {
-    questions[key].selected = true
-    questions[key].visible = true
+    // in some cases, we will only be looking at a subset of questions,
+    // for example when viewing the activity report for a sequence.
+    // There may not be a question for the key. Check first.
+    if (questions[key]) {
+      questions[key].selected = true
+      questions[key].visible = true
+    }
   })
 }
 

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -1,4 +1,5 @@
 {
+  "report_for": "class",
   "report": {
     "id": 18,
     "type": "Investigation",

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -1,6 +1,6 @@
 import Immutable, { Map, Set } from 'immutable'
 import {
-  REQUEST_DATA, RECEIVE_DATA, RECEIVE_ERROR, INVALIDATE_DATA, SET_TYPE, SET_ANONYMOUS,
+  REQUEST_DATA, RECEIVE_DATA, RECEIVE_ERROR, INVALIDATE_DATA, SET_NOW_SHOWING, SET_ANONYMOUS,
   SET_QUESTION_SELECTED, SHOW_SELECTED_QUESTIONS, SHOW_ALL_QUESTIONS,
   SET_ANSWER_SELECTED_FOR_COMPARE, SHOW_COMPARE_VIEW, HIDE_COMPARE_VIEW} from '../actions'
 
@@ -59,20 +59,23 @@ function report(state = INITIAL_REPORT_STATE, action) {
   switch (action.type) {
     case RECEIVE_DATA:
       const data = transformJSONResponse(action.response)
-      state = state.set('students', Immutable.fromJS(data.entities.students))
-                   .set('investigations', Immutable.fromJS(data.entities.investigations))
-                   .set('activities', Immutable.fromJS(data.entities.activities))
-                   .set('sections', Immutable.fromJS(data.entities.sections))
-                   .set('pages', Immutable.fromJS(data.entities.pages))
-                   .set('questions', Immutable.fromJS(data.entities.questions))
-                   .set('answers', Immutable.fromJS(data.entities.answers))
-                   .set('clazzName', data.result.class.name)
-                   .set('hideSectionNames', data.result.isOfferingExternal)
+      state = state
+        .set('students', Immutable.fromJS(data.entities.students))
+        .set('investigations', Immutable.fromJS(data.entities.investigations))
+        .set('activities', Immutable.fromJS(data.entities.activities))
+        .set('sections', Immutable.fromJS(data.entities.sections))
+        .set('pages', Immutable.fromJS(data.entities.pages))
+        .set('questions', Immutable.fromJS(data.entities.questions))
+        .set('answers', Immutable.fromJS(data.entities.answers))
+        .set('clazzName', data.result.class.name)
+        .set('hideSectionNames', data.result.isOfferingExternal)
+        .set('type', data.type)
+        .set('nowShowing', data.type)
       state = setAnonymous(state, data.result.anonymousReport)
       state = setVisibilityFilterActive(state, data.result.visibilityFilter.active)
       return state
-    case SET_TYPE:
-      return state.set('type', action.value)
+    case SET_NOW_SHOWING:
+      return state.set('nowShowing', action.value)
     case SET_QUESTION_SELECTED:
       return state.setIn(['questions', action.key, 'selected'], action.value)
     case SHOW_SELECTED_QUESTIONS:


### PR DESCRIPTION
Small change to support this story "Individual activity report from a sequence shows in the new format"

This is PR should probably wait for #22 -- which is waiting on the RIGSE PR of the same name.

See concord-consortium/rigse 761c6b3 for the portal side of *this* PR.

[#115801707]

https://www.pivotaltracker.com/story/show/115801707