### PR TITLE
Redo sticky navigation header.

### DIFF
--- a/css/button.less
+++ b/css/button.less
@@ -20,4 +20,7 @@
     cursor: default;
     opacity: .5 !important;
   }
+  &:hover {
+    opacity: .8
+  }
 }

--- a/css/question.less
+++ b/css/question.less
@@ -18,11 +18,6 @@
     }
   }
 
-  .sticky {
-    background: #eb8723 !important;
-    z-index: 1020;
-  }
-
   .question-header {
     background: #8cbbb8;
     color: #fff;

--- a/css/report.less
+++ b/css/report.less
@@ -1,5 +1,34 @@
 @import "variables";
 
+.sticky-outer-wrapper {
+  &.active {
+    .sticky-inner-wrapper {
+      position: fixed;
+      left: 0px;
+      right: 0px !important;
+      width: 100% !important;
+      top: 0px;
+      z-index: 1000;
+      background-color: #fee9aa;
+      opacity: 0.95;
+      height: 22px;
+      font-size: 14px;
+      padding-left: 5%;
+      padding-right: 5%;
+      .report-header {
+        padding-top: 4px;
+      }
+    }
+    &.main {
+      .sticky-inner-wrapper {
+        background: #bddfdf;
+        height: 40px;
+      }
+    }
+    h1, h2, h3, h4  {font-size: 14px; margin: 0px; padding: 0px;}
+  }
+}
+
 .report {
   width: @report-width;
   min-width: @min-report-width;
@@ -9,12 +38,12 @@
   margin: 0 auto;
 
   .report-header {
-    margin-top: 1em;
-    margin-bottom: 1em;
-
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-right: 10%;
     .controls {
-      display: inline-block;
-      float: right;
       @media print {
         display: none;
       }

--- a/js/components/activity.js
+++ b/js/components/activity.js
@@ -1,17 +1,18 @@
 import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Section from './section'
-
+import Sticky from 'react-stickynode';
 import '../../css/activity.less'
 
-@pureRender
 export default class Activity extends Component {
   render() {
     const { activity, reportFor, investigationName } = this.props
     const activityName = activity.get('name')
     return (
       <div className={`activity ${activity.get('visible') ? '' : 'hidden'}`}>
-        <h3>{activityName}</h3>
+        <Sticky top={60}>
+          <h3>{activityName}</h3>
+        </Sticky>
         <div>
           {activity.get('children').map(s => <Section key={s.get('id')} section={s} reportFor={reportFor} investigationName={investigationName} activityName={activityName} />)}
         </div>

--- a/js/components/investigation.js
+++ b/js/components/investigation.js
@@ -1,19 +1,20 @@
 import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Activity from './activity'
-
+import Sticky from 'react-stickynode';
 import '../../css/investigation.less'
 
-@pureRender
 export default class Investigation extends Component {
   render() {
     const { investigation, reportFor } = this.props
     const investigationName = investigation.get('name')
     return (
-      <div className='investigation'>
-        <h2>{investigationName}</h2>
+      <div>
+        <Sticky top={40} className='investigation'>
+            <h2>{investigationName}</h2>
+        </Sticky>
         <div>
-          {investigation.get('children').map(a => <Activity key={a.get('id')} activity={a} reportFor={reportFor} investigationName={investigationName}/>)}
+            {investigation.get('children').map(a => <Activity key={a.get('id')} activity={a} reportFor={reportFor} investigationName={investigationName}/>)}
         </div>
       </div>
     )

--- a/js/components/page.js
+++ b/js/components/page.js
@@ -1,17 +1,18 @@
 import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Question from '../components/question'
-
+import Sticky from 'react-stickynode';
 import '../../css/page.less'
 
-@pureRender
 export default class Page extends Component {
   render() {
     const { page, reportFor, investigationName, activityName, sectionName } = this.props
     const pageName = page.get('name')
     return (
       <div className={`page ${page.get('visible') ? '' : 'hidden'}`}>
-        <h4>Page: {pageName}</h4>
+        <Sticky top={80}>
+          <h4>Page: {pageName}</h4>
+        </Sticky>
         <div>
           {page.get('children').map((question) => {
               return <Question key={question.get('key')} question={question} reportFor={reportFor} investigationName={investigationName} activityName={activityName} sectionName={sectionName} pageName={pageName} />

--- a/js/components/report.js
+++ b/js/components/report.js
@@ -4,6 +4,8 @@ import Investigation from './investigation'
 import Button from './button'
 
 import '../../css/report.less'
+import Sticky from 'react-stickynode';
+
 import { noSelection } from '../calculations'
 
 @pureRender
@@ -23,13 +25,26 @@ export default class Report extends Component {
     document.title = `${investigation.get('name')} ${title}`
   }
 
+  renderReportHeader(clazzName) {
+    return (
+      <Sticky top={0} className="main" activeClass="active">
+        <div className="report-header">
+          <div className="title">
+            <h1>Report for: {clazzName}</h1>
+          </div>
+          {this.renderControls()}
+        </div>
+      </Sticky>
+    )
+  }
+
   renderClassReport() {
     const { report } = this.props
     const nowShowing = report.get('nowShowing')
     const className  = nowShowing === 'class' ? 'report-content' : 'report-content hidden'
     return (
       <div className={className}>
-        <h1>Report for: {report.get('clazzName')}</h1>
+        {this.renderReportHeader(report.get('clazzName'))}
         <Investigation investigation={report.get('investigation')} reportFor={'class'}/>
       </div>
     )
@@ -37,11 +52,11 @@ export default class Report extends Component {
 
   renderStudentReports() {
     const { report } = this.props
-    const nowShowing = report.get('nowShowing')
-    const className  = nowShowing ==='student' ? 'report-content' : 'report-content hidden'
+    const nowShowing = report.get('nowShowing') === 'student'
+    const className  = nowShowing ? 'report-content' : 'report-content hidden'
     return [...report.get('students').values()].filter(s => s.get('startedOffering')).map(s =>
       <div key={s.get('id')} className={className}>
-        <h1>Report for: {s.get('name')}</h1>
+        {this.renderReportHeader(s.get('name'))}
         <Investigation investigation={report.get('investigation')} reportFor={s}/>
       </div>
     )
@@ -107,9 +122,6 @@ export default class Report extends Component {
   render() {
     return (
       <div>
-        <div className='report-header'>
-          {this.renderControls()}
-        </div>
         {this.renderClassReport()}
         {this.renderStudentReports()}
       </div>

--- a/js/components/section.js
+++ b/js/components/section.js
@@ -1,17 +1,18 @@
 import React, { Component } from 'react'
 import pureRender from 'pure-render-decorator'
 import Page from './page'
-
+import Sticky from 'react-stickynode';
 import '../../css/section.less'
 
-@pureRender
 export default class Section extends Component {
   render() {
     const { section, reportFor, investigationName, activityName } = this.props
     const sectionName = section.get('name')
     return (
       <div className={`section ${section.get('visible') ? '' : 'hidden'}`}>
-        <span className={section.get('nameHidden') ? 'hidden' : ''}>{sectionName}</span>
+        <Sticky top={60} className={section.get('nameHidden') ? 'hidden' : ''}>
+          {sectionName}
+        </Sticky>
         <div>
           {section.get('children').map(p => <Page key={p.get('id')} page={p} reportFor={reportFor} investigationName={investigationName} activityName={activityName} sectionName={sectionName} />)}
         </div>

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.0",
     "react-responsive-carousel": "^3.0.10",
-    "react-sticky": "^4.0.2",
+    "react-stickynode": "^1.0.19",
     "redux": "^3.3.1",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^1.0.3"


### PR DESCRIPTION
This PR changes sticky behavior to match the mockups.

Replace `react-sticky`  with the simpler `react-stickynode`

Style adjustments accordingly. 

[#115343939]
https://www.pivotaltracker.com/story/show/115343939