### PR TITLE
Add page links in report back to runtime.

### DIFF
--- a/css/page.less
+++ b/css/page.less
@@ -9,6 +9,12 @@
     font-weight: normal;
     margin-left: 1em;
     padding: 1em;
+    a {
+      color: #da5936;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
     @media print {
       color: #000;
       margin-left: 0;

--- a/css/question.less
+++ b/css/question.less
@@ -4,6 +4,14 @@
   margin: 0 auto 1em auto;
   position: relative;
 
+  .page-link {
+    a {
+      color: #fff;
+      cursor: pointer;
+      text-decoration: none;
+    }
+  }
+
   @media print {
     box-shadow: none;
     padding: 0.2em;

--- a/js/components/maybe-link.js
+++ b/js/components/maybe-link.js
@@ -1,0 +1,12 @@
+ import React, { PureComponent } from 'react'
+
+ export default class MaybeLink extends PureComponent {
+   render() {
+     const {children, url} = this.props
+     const target = this.props.target || "_blank"
+     if (url) {
+       return <a href={url} target={target}>{children}</a>
+     }
+     return children
+   }
+ }

--- a/js/components/page.js
+++ b/js/components/page.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import Question from '../components/question'
+import MaybeLink from '../components/maybe-link'
 import Sticky from 'react-stickynode';
 import '../../css/page.less'
 
@@ -7,14 +8,19 @@ export default class Page extends PureComponent {
   render() {
     const { page, reportFor } = this.props
     const pageName = page.get('name')
+    const url =  page.get('url')
     return (
       <div className={`page ${page.get('visible') ? '' : 'hidden'}`}>
         <Sticky top={80}>
-          <h4>Page: {pageName}</h4>
+          <h4>
+            <MaybeLink url={url}>
+              <span>Page: {pageName}</span>
+            </MaybeLink>
+          </h4>
         </Sticky>
         <div>
           {page.get('children').map((question) => {
-              return <Question key={question.get('key')} question={question} reportFor={reportFor} />
+              return <Question key={question.get('key')} question={question} reportFor={reportFor} url={page.get('url')} />
           })}
         </div>
       </div>

--- a/js/components/question-for-class.js
+++ b/js/components/question-for-class.js
@@ -3,6 +3,7 @@ import MultipleChoiceDetails from './multiple-choice-details'
 import ImageQuestionDetails from './image-question-details'
 import QuestionSummary from './question-summary'
 import AnswersTable from '../containers/answers-table'
+import MaybeLink from './maybe-link'
 import SelectionCheckbox from '../containers/selection-checkbox'
 
 import '../../css/question.less'
@@ -26,8 +27,14 @@ export default class QuestionForClass extends PureComponent {
   }
 
   renderQuestionHeader() {
-    const { question } = this.props
-    return <span>Question #{question.get('questionNumber')}</span>
+    const { question, url } = this.props
+    return (
+      <span className="page-link">
+        <MaybeLink url={url}>
+          <span> Question #{question.get('questionNumber')} </span>
+        </MaybeLink>
+      </span>
+    )
   }
 
   render() {

--- a/js/components/question-for-student.js
+++ b/js/components/question-for-student.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import Answer from './answer'
+import MaybeLink from './maybe-link'
 import SelectionCheckbox from '../containers/selection-checkbox'
 import Feedback from '../containers/feedback'
 
@@ -7,6 +8,17 @@ import '../../css/question.less'
 import Prompt from './prompt'
 
 export default class QuestionForStudent extends PureComponent {
+
+  renderQuestionHeader() {
+    const { question, url } = this.props
+    return (
+      <span className="page-link">
+        <MaybeLink url={url}>
+          <span> Question #{question.get('questionNumber')} </span>
+        </MaybeLink>
+      </span>
+    )
+  }
 
   render() {
     const { question, student } = this.props
@@ -16,9 +28,9 @@ export default class QuestionForStudent extends PureComponent {
       <div className={`question for-student ${question.get('visible') ? '' : 'hidden'}`}>
         <div className='question-header'>
           <SelectionCheckbox selected={question.get('selected')} questionKey={question.get('key')} />
-          Question #{question.get('questionNumber')}
+          {this.renderQuestionHeader()}
         </div>
-        <Prompt question={question} />
+        <Prompt question={question}/>
         <Answer answer={answer}/>
         <Feedback answer={answer} question={question} htmlFor="student"/>
       </div>

--- a/js/components/question.js
+++ b/js/components/question.js
@@ -4,11 +4,11 @@ import QuestionForStudent from './question-for-student'
 
 export default class Question extends PureComponent {
   render() {
-    const { question, reportFor} = this.props
+    const { question, reportFor, url} = this.props
     if (reportFor === 'class') {
-      return <QuestionForClass question={question}/>
+      return <QuestionForClass question={question} url={url}/>
     } else {
-      return <QuestionForStudent question={question} student={reportFor}/>
+      return <QuestionForStudent question={question} student={reportFor} url={url}/>
     }
   }
 }

--- a/js/core/migrations.js
+++ b/js/core/migrations.js
@@ -36,6 +36,26 @@ function addFeedback(dataMap) {
   handleQuestion(dataMap.report)
 }
 
+function addPageUrl(dataMap) {
+  const pageType = "Page"
+  const report = dataMap.report
+  const defaultUrl = null
+  const processPage = function (item) {
+    if (!item.url) {
+      item.url = defaultUrl
+    }
+  }
+  const processChildren = function (item) {
+    if (item.children) {
+      item.children.forEach((child) => processChildren(child))
+    }
+    if (item.type === pageType) {
+      processPage(item)
+    }
+  }
+  processChildren(report)
+}
+
 const migrations = [
   { version: '1.0.0',
     migrations:[]
@@ -45,6 +65,12 @@ const migrations = [
     migrations:[
       addStudentNames,
       addFeedback
+    ]
+  },
+  {
+    version: '1.0.2',
+    migrations:[
+      addPageUrl
     ]
   }
 ]

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -1,5 +1,5 @@
 {
-  "report_version": "1.0.1",
+  "report_version": "1.0.2",
   "report_for": "class",
   "report": {
     "id": 18,
@@ -20,6 +20,7 @@
                 "id": 242,
                 "type": "Page",
                 "name": "1",
+                "url": "http://authoring.concord.org/activities/802/pages/4532/",
                 "children": [
                   {
                     "id": 116,
@@ -225,6 +226,7 @@
                 "id": 243,
                 "type": "Page",
                 "name": "1",
+                "url": "http://authoring.concord.org/activities/802/pages/4589",
                 "children": [
                   {
                     "id": 117,
@@ -412,6 +414,7 @@
                 "id": 244,
                 "type": "Page",
                 "name": "2",
+                "url": "http://authoring.concord.org/activities/802/pages/4543",
                 "children": [
                   {
                     "id": 12,
@@ -591,6 +594,7 @@
                 "id": 245,
                 "type": "Page",
                 "name": "1",
+                "url": "http://authoring.concord.org/activities/802/pages/4590",
                 "children": [
                   {
                     "id": 13,


### PR DESCRIPTION
This PR adds a new `url` parameter to the 'Page' entities sent in report JSON.

This allows teachers to click on links in the report to open the activity in LARA.

Portal and LARA side of this work has already been merged.

[#112613409]
https://www.pivotaltracker.com/story/show/112613409