### PR TITLE
Add support of InteractiveState answer type

### DIFF
--- a/js/components/iframe-answer.js
+++ b/js/components/iframe-answer.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import InteractiveIframe from './interactive-iframe'
 
 import '../../css/iframe-answer.less'
 
@@ -27,14 +28,23 @@ export default class IframeAnswer extends PureComponent {
 
   renderIframe() {
     const { answer, alwaysOpen } = this.props
+    let url
+    let state
+    // There are two supported answer types handled by iframe question: simple link or interactive state.
+    if (answer.get('answerType') === 'Saveable::ExternalLinkUrl') {
+      // Answer field is just the reportable URL. We don't need any state.
+      url = answer.get('answer')
+      state = null
+    } else if (answer.get('answerType') === 'Saveable::InteractiveState') {
+      // URL field is provided together with answer. Answer field is a state that will be passed
+      // to the iframe using iframe-phone.
+      url = answer.get('url')
+      state = answer.get('answer')
+    }
     return (
         <div>
           {!alwaysOpen ? <div><a href='#' onClick={this.toggleIframe}>Hide</a></div> : ''}
-          <iframe src={answer.get('answer')}
-                  width={answer.get('width') || '300px'}
-                  height={answer.get('height') || '300px'}
-                  style={{border: 'none', marginTop: '0.5em'}}>
-          </iframe>
+          <InteractiveIframe src={url} state={state} width={answer.get('width')} height={answer.get('height')}/>
         </div>
       )
   }
@@ -44,7 +54,7 @@ export default class IframeAnswer extends PureComponent {
     const { iframeVisible } = this.state
     return (
       <div className='iframe-answer'>
-        {iframeVisible || alwaysOpen ? this.renderIframe() : this.renderLink()}
+        {(iframeVisible || alwaysOpen) ? this.renderIframe() : this.renderLink()}
       </div>
     )
   }

--- a/js/components/interactive-iframe.js
+++ b/js/components/interactive-iframe.js
@@ -1,0 +1,42 @@
+import React, { PureComponent } from 'react'
+import iframePhone from 'iframe-phone'
+
+export default class InteractiveIframe extends PureComponent {
+
+  componentDidMount() {
+    this.connect()
+  }
+
+  componentWillUnmount() {
+    this.disconnect()
+  }
+
+  connect() {
+    const { state } = this.props
+    if (!state) return;
+
+    const phoneAnswered = () => {
+      this.iframePhone.post('initInteractive', typeof state === 'string' ? JSON.parse(state) : state)
+    }
+    this.iframePhone = new iframePhone.ParentEndpoint(this.refs.iframe, phoneAnswered)
+  }
+
+  disconnect() {
+    if (this.iframePhone) {
+      this.iframePhone.disconnect()
+      this.iframePhone = null
+    }
+  }
+
+  render() {
+    const { src, width, height } = this.props
+    return (
+      <iframe ref='iframe'
+              src={src}
+              width={width || '300px'}
+              height={height || '300px'}
+              style={{border: 'none', marginTop: '0.5em'}}>
+      </iframe>
+    )
+  }
+}

--- a/js/components/question-for-class.js
+++ b/js/components/question-for-class.js
@@ -2,8 +2,8 @@ import React, { PureComponent } from 'react'
 import MultipleChoiceDetails from './multiple-choice-details'
 import ImageQuestionDetails from './image-question-details'
 import QuestionSummary from './question-summary'
+import QuestionHeader from './question-header'
 import AnswersTable from '../containers/answers-table'
-import MaybeLink from './maybe-link'
 import SelectionCheckbox from '../containers/selection-checkbox'
 
 import '../../css/question.less'
@@ -26,31 +26,19 @@ export default class QuestionForClass extends PureComponent {
     this.setState({answersVisible: !this.state.answersVisible})
   }
 
-  renderQuestionHeader() {
-    const { question, url } = this.props
-    return (
-      <span className="page-link">
-        <MaybeLink url={url}>
-          <span> Question #{question.get('questionNumber')} </span>
-        </MaybeLink>
-      </span>
-    )
-  }
-
   render() {
-    const { question } = this.props
+    const { question, url } = this.props
     const { answersVisible } = this.state
-    const answers = question.get('answers').sortBy( (a) =>
+    const answers = question.get('answers').sortBy(a =>
       (a.getIn(['student', 'lastName']) + a.getIn(['student', 'firstName'])).toLowerCase()
     )
-
 
     return (
       <div>
         <div className={`question ${question.get('visible') ? '' : 'hidden'}`}>
           <div className="question-header">
             <SelectionCheckbox selected={question.get('selected')} questionKey={question.get('key')}/>
-            { this.renderQuestionHeader() }
+            <QuestionHeader question={question} url={url}/>
             <a className='answers-toggle' onClick={this.toggleAnswersVisibility}>
               {answersVisible ? 'Hide responses' : 'Show responses'}
             </a>

--- a/js/components/question-for-student.js
+++ b/js/components/question-for-student.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import Answer from './answer'
-import MaybeLink from './maybe-link'
+import QuestionHeader from './question-header'
 import SelectionCheckbox from '../containers/selection-checkbox'
 import Feedback from '../containers/feedback'
 
@@ -8,27 +8,15 @@ import '../../css/question.less'
 import Prompt from './prompt'
 
 export default class QuestionForStudent extends PureComponent {
-
-  renderQuestionHeader() {
-    const { question, url } = this.props
-    return (
-      <span className="page-link">
-        <MaybeLink url={url}>
-          <span> Question #{question.get('questionNumber')} </span>
-        </MaybeLink>
-      </span>
-    )
-  }
-
   render() {
-    const { question, student } = this.props
+    const { question, url, student } = this.props
     const studentId = student.get('id')
     const answer = question.get('answers').filter(a => a.get('studentId') === studentId).first()
     return (
       <div className={`question for-student ${question.get('visible') ? '' : 'hidden'}`}>
         <div className='question-header'>
           <SelectionCheckbox selected={question.get('selected')} questionKey={question.get('key')} />
-          {this.renderQuestionHeader()}
+          <QuestionHeader question={question} url={url}/>
         </div>
         <Prompt question={question}/>
         <Answer answer={answer}/>

--- a/js/components/question-header.js
+++ b/js/components/question-header.js
@@ -1,0 +1,25 @@
+import React, { PureComponent } from 'react'
+import MaybeLink from './maybe-link'
+
+export default class QuestionHeader extends PureComponent {
+
+  get questionName() {
+    // Provide question name only for the iframe question type.
+    const { question } = this.props
+    if (question.get('type') === 'Embeddable::Iframe') {
+      return `: ${question.get('name')}`
+    }
+    return ''
+  }
+
+  render() {
+    const { question, url} = this.props
+    return (
+      <span className="page-link">
+        <MaybeLink url={url}>
+          <span>Question #{question.get('questionNumber')}{this.questionName}</span>
+        </MaybeLink>
+      </span>
+    )
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-polyfill": "^6.6.1",
     "bootstrap": "^3.3.6",
     "humps": "^2.0.0",
+    "iframe-phone": "^1.1.3",
     "immutable": "^3.7.6",
     "isomorphic-fetch": "^2.2.1",
     "normalizr": "^2.0.0",


### PR DESCRIPTION
This PR adds support of `InteractiveState` answer type. When this kind of answer is found, an iframe will be initialized using iframe-phone `initInteractive` call. `ExternalLinkUrl` is still supported. Both answer types work in a very similar way - "View work" link is shown. When it's clicked, an iframe is displayed.

Example:
<img width="686" alt="screen shot 2017-03-12 at 19 59 49" src="https://cloud.githubusercontent.com/assets/767857/23836333/cdd4542a-0776-11e7-8ddf-9e6ae7b64155.png">

This PR is related to https://github.com/concord-consortium/rigse/pull/303.
