### PR TITLE
Auto-scoring bug fixes

### DIFF
--- a/js/components/activity-feedback-row.js
+++ b/js/components/activity-feedback-row.js
@@ -63,14 +63,23 @@ export default class ActivityFeedbackRow extends PureComponent {
   }
 
   fieldValues() {
-    const studentActivityFeedback  = this.props.studentActivityFeedback
-    const feedbackRecord           = studentActivityFeedback.get('feedbacks').first()
+    const { studentActivityFeedback }  = this.props
+    const feedbackRecord  = studentActivityFeedback.get('feedbacks').first()
+    let scoreString, feedback = ""
+    let complete = false
+    if (feedbackRecord) {
+      scoreString = feedbackRecord.get('score')
+      feedback = feedbackRecord.get('feedback')
+      complete = feedbackRecord.get('hasBeenReviewed')
+    }
+    const score = parseInt(scoreString, 10) || 0
+
     return {
       learnerId:          this.props.studentActivityFeedback.get("learnerId"),
       activityFeedbackId: this.props.activityFeedbackId,
-      score:              parseInt(feedbackRecord ? feedbackRecord.get('score') : "0"),
-      feedback:           feedbackRecord ? feedbackRecord.get('feedback') : "",
-      complete:           feedbackRecord ? feedbackRecord.get('hasBeenReviewed')  : false
+      score:              score,
+      feedback:           feedback,
+      complete:           complete
     }
   }
 

--- a/js/core/activity-feedback-data.js
+++ b/js/core/activity-feedback-data.js
@@ -82,7 +82,9 @@ export function calculateStudentScores(state, questions) {
   }
 
 
-  const scores = questions.map( q => q.get('answers'))
+  const scores = questions
+    .filter(question => question.get('scoreEnabled'))
+    .map( q => q.get('answers'))
     .flatten()
     .map(answerId => report.getIn(['answers', answerId]))
     .groupBy(answer => answer.get('studentId'))
@@ -97,8 +99,9 @@ export function calculateStudentScores(state, questions) {
 
 export function getComputedMaxScore(questions) {
   return questions
+    .filter(question => question.get('scoreEnabled'))
     .map(question  => question.get('maxScore') || 0)
-    .reduce( (total, score) => total + score)
+    .reduce( (total, score) => total + score) || 0
 }
 
 export function getActivityFeedbacks(state, activityId) {

--- a/js/core/activity-feedback-data.js
+++ b/js/core/activity-feedback-data.js
@@ -93,7 +93,7 @@ export function calculateStudentScores(state, questions) {
       .map(ans => ans.get('feedbacks').last())
       .map( feedbackId => getFeedbackScore(feedbackId))
     )
-    const sums = scores.map(s => s.reduce( (sum,v) => (sum||0) + v))
+    const sums = scores.map(s => s.reduce( (sum,v) => sum + v, 0))
   return sums
 }
 
@@ -101,7 +101,7 @@ export function getComputedMaxScore(questions) {
   return questions
     .filter(question => question.get('scoreEnabled'))
     .map(question  => question.get('maxScore') || 0)
-    .reduce( (total, score) => total + score) || 0
+    .reduce( (total, score) => total + score, 0)
 }
 
 export function getActivityFeedbacks(state, activityId) {

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -234,7 +234,6 @@
         "name": "Test Activity 2 (sequence part)",
         "enable_text_feedback": true,
         "score_type": "none",
-        "enable_auto_score": true,
         "max_score": 10,
         "activity_feedback":[
           {


### PR DESCRIPTION
Trying to present a smaller PR this time ;)

These are related to this auto-scoring story:
https://www.pivotaltracker.com/story/show/151224400

It fixes a bug where a student's activity level `automatic score` were summing question scores that included questions that were no longer being scored.  (Teacher changed their mind but we save the students scores incase the teacher decides to re-enable scoring)

Now when computing automatic scores for the activity or calculating the `maxScore` we check `scoreEnabled` first.

Also a fix for 'NaN' in a score field for `parseInt('')`,  and a change in the default `report.json` to show auto scoring working for an activity.


