### PR TITLE
Beginning to add Rubric features.

### DIFF
--- a/css/feedback-panel.less
+++ b/css/feedback-panel.less
@@ -125,6 +125,8 @@
     padding: 10px 15px;
     display: flex;
     flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
     &:nth-child(even) {
       background: #f0f0f0;
     }

--- a/css/rubric-box.less
+++ b/css/rubric-box.less
@@ -1,0 +1,19 @@
+.rubric-box {
+  table {
+    border-collapse: collapse;
+    th {
+      padding: 0.5em;
+      border: 1px solid black;
+    }
+    td {
+      padding: 0.5em;
+      border: 1px solid black;
+      .center {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+  }
+}

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import { fetchReportData } from '../api'
-
+import { requestRubric } from "./load-rubric";
 export const INVALIDATE_DATA = 'INVALIDATE_DATA'
 export const REQUEST_DATA = 'REQUEST_DATA'
 export const RECEIVE_DATA = 'RECEIVE_DATA'
@@ -23,22 +23,27 @@ export const ENABLE_ACTIVITY_FEEDBACK = 'ENABLE_ACTIVITY_FEEDBACK'
 // REQUEST_DATA action will be processed by the reducer immediately.
 // See: api-middleware.js
 function requestData() {
-  return {
-    type: REQUEST_DATA,
-    callAPI: {
-      type: 'fetchReportData',
-      successAction: receiveData,
-      errorAction: receiveError
-    }
+  return (dispatch, getState) => {
+    dispatch({
+      type: REQUEST_DATA,
+      callAPI: {
+        type: 'fetchReportData',
+        successAction: receiveData,
+        errorAction: receiveError
+      }
+    });
   }
 }
 
 function receiveData(response) {
-  return {
-    type: RECEIVE_DATA,
-    response: response,
-    receivedAt: Date.now()
-  }
+  return (dispatch, getState) => {
+    dispatch({
+      type: RECEIVE_DATA,
+      response: response,
+      receivedAt: Date.now()
+    });
+    dispatch(requestRubric())
+  };
 }
 
 function receiveError(response) {

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -191,6 +191,7 @@ export function updateFeedback(answerKey, feedback) {
 export function enableFeedback(embeddableKey, feedbackFlags) {
   const mappings = {
     feedbackEnabled: 'enable_text_feedback',
+    rubricEnabled: 'rubric_enabled',
     scoreEnabled: 'enable_score',
     maxScore: 'max_score'
   }

--- a/js/actions/load-rubric.js
+++ b/js/actions/load-rubric.js
@@ -1,0 +1,63 @@
+export const LOAD_RUBRIC = 'LOAD_RUBRIC'
+export const REQUEST_RUBRIC = 'REQUEST_RUBRIC'
+
+const urlCache = {}
+const addRubric = (data) => {
+  const {url, rubric} = data;
+  return (dispatch, getState) => {
+    urlCache[url] = rubric;
+    dispatch({
+      type: LOAD_RUBRIC,
+      url,
+      rubric
+    })
+  };
+}
+
+const notInCache = (url) => {
+  return(!!!urlCache[url]);
+}
+
+export function loadRubric(data) {
+  const isUrl = (string) => string && string.length && string.length > 0;
+  const rubricUrl = data;
+  return new Promise((resolve, reject) => {
+    if(isUrl(rubricUrl)) {
+      if(notInCache(rubricUrl)) {
+        fetch(rubricUrl)
+        .then(response => response.json())
+        .then((newRurbic) => {
+          resolve({url: rubricUrl, rubric: newRurbic});
+        })
+        .catch((e) => {
+          console.error(e);
+          console.error(`unable to load rubric at: ${rubricUrl}`);
+          reject(e);
+        });
+      }
+      else {
+        resolve({rubricUrl, rubric: urlCache[rubricUrl]});
+      }
+    }
+    else {
+      resolve({})
+    }
+  });
+}
+
+export function requestRubric() {
+  return (dispatch, getState) => {
+    const state = getState();
+    const urls = state.getIn(['report', 'activities']).map(a => a.get('rubricUrl'));
+    urls.filter(u => u).forEach((u) => {
+      dispatch({
+        type: REQUEST_RUBRIC,
+        callAPI: {
+          type: 'loadRubric',
+          data: u,
+          successAction: addRubric
+        }
+      });
+    });
+  };
+}

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -1,4 +1,5 @@
 import { fetchReportData, updateReportSettings, APIError } from './api'
+import { loadRubric } from './actions/load-rubric'
 
 // This middleware is executed only if action includes .callAPI object.
 // It calls API action defined in callAPI.type.
@@ -26,5 +27,7 @@ function callApi(type, data) {
       return fetchReportData()
     case 'updateReportSettings':
       return updateReportSettings(data)
+    case 'loadRubric':
+      return loadRubric(data)
   }
 }

--- a/js/components/activity-feedback-row.js
+++ b/js/components/activity-feedback-row.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-import Answer from './answer'
+import RubricBox from "./rubric-box"
 import FeedbackBox from './feedback-box'
 import ScoreBox from './score-box'
 import StudentReportLink from './student-report-link'
@@ -22,7 +22,7 @@ export default class ActivityFeedbackRow extends PureComponent {
   }
 
   scoreChange(e, answerKey) {
-    const value = parseInt(e.target.value) || 0
+    const value = parseInt(e.target.value, 10) || 0
     this.changeFeedback(answerKey, {score: value})
   }
 
@@ -65,7 +65,8 @@ export default class ActivityFeedbackRow extends PureComponent {
   fieldValues() {
     const { studentActivityFeedback }  = this.props
     const feedbackRecord  = studentActivityFeedback.get('feedbacks').first()
-    let scoreString, feedback = ""
+    let scoreString = ""
+    let feedback = ""
     let complete = false
     if (feedbackRecord) {
       scoreString = feedbackRecord.get('score')
@@ -75,11 +76,11 @@ export default class ActivityFeedbackRow extends PureComponent {
     const score = parseInt(scoreString, 10) || 0
 
     return {
-      learnerId:          this.props.studentActivityFeedback.get("learnerId"),
-      activityFeedbackId: this.props.activityFeedbackId,
-      score:              score,
-      feedback:           feedback,
-      complete:           complete
+      score,
+      feedback,
+      complete,
+      learnerId: this.props.studentActivityFeedback.get("learnerId"),
+      activityFeedbackId: this.props.activityFeedbackId
     }
   }
 
@@ -87,31 +88,47 @@ export default class ActivityFeedbackRow extends PureComponent {
     const activityFeedbackKey  = studentFeedback.get('key')
 
     const {feedback, score, complete, learnerId }  = this.fieldValues()
-    const { feedbackEnabled, scoreType, autoScore} = this.props
+    const {useRubric, feedbackEnabled, scoreType, autoScore} = this.props
     const scoreEnabled     = scoreType != 'none'
     const automaticScoring = scoreType == 'auto'
 
-    const disableFeedback  = (!learnerId) || complete
-    const disableScore     = (disableFeedback || automaticScoring )
+    const disableFeedback  = !learnerId || complete
+    const disableScore     = disableFeedback || automaticScoring
     const scoreToRender    = automaticScoring ? autoScore : score
 
     return (
       <div className="feedback-interface">
         <h4>Your Feedback</h4>
         <div className="feedback-content">
-          { feedbackEnabled ? this.renderFeedbackForm(activityFeedbackKey, disableFeedback, feedback) :  ""}
-          { scoreEnabled ? this.renderScore(activityFeedbackKey, disableScore, scoreToRender) : "" }
-          { feedbackEnabled || scoreEnabled ? this.renderComplete(activityFeedbackKey, complete) : ""}
+          {
+            useRubric
+              ? <RubricBox rubric={this.props.rubric} />
+              : null
+          }
+          {
+            feedbackEnabled
+              ? this.renderFeedbackForm(activityFeedbackKey, disableFeedback, feedback)
+              :  ""
+          }
+          {
+            scoreEnabled
+              ? this.renderScore(activityFeedbackKey, disableScore, scoreToRender)
+              : ""
+          }
+          {
+            feedbackEnabled || scoreEnabled || useRubric
+              ? this.renderComplete(activityFeedbackKey, complete)
+              : ""
+          }
         </div>
       </div>
     )
   }
 
   render() {
-    const studentActivityFeedback  = this.props.studentActivityFeedback
+    const { studentActivityFeedback } = this.props
     const student = studentActivityFeedback.get("student")
     const name = student.get("realName")
-    const link = "http://google.com/"
     const learnerId = studentActivityFeedback.get("learnerId")
 
     const noFeedbackSection =
@@ -135,6 +152,4 @@ export default class ActivityFeedbackRow extends PureComponent {
       </div>
     )
   }
-
 }
-

--- a/js/components/feedback-options.js
+++ b/js/components/feedback-options.js
@@ -1,0 +1,174 @@
+import React, { PureComponent } from 'react' // eslint-disable-line
+import { RadioGroup, Radio } from 'react-radio-group'
+import ReactTooltip from 'react-tooltip'
+
+import '../../css/feedback-panel.less'
+import '../../css/tooltip.less'
+
+import {
+  NO_SCORE,
+  MANUAL_SCORE_L,
+  MANUAL_SCORE,
+  AUTOMATIC_SCORE_L,
+  AUTOMATIC_SCORE
+} from "../util/scoring-constants"
+
+export default class FeedbackOptions extends PureComponent {
+  constructor(props) {
+    super(props)
+    this.state = {lastScoreType: null }
+    this.enableText  = this.enableText.bind(this)
+    this.enableRubric  = this.enableRubric.bind(this)
+    this.setMaxScore = this.setMaxScore.bind(this)
+    this.changeScoreType = this.changeScoreType.bind(this)
+  }
+
+  enableText(event) {
+    const activityId = this.props.activity.get('id')
+    const activityFeedbackId = this.props.activity.get('activityFeedbackId')
+    this.props.enableActivityFeedback(
+      activityId, {
+        activityFeedbackId,
+        enableTextFeedback: event.target.checked
+      })
+  }
+
+  enableRubric(event) {
+    const activityId = this.props.activity.get('id')
+    const activityFeedbackId = this.props.activity.get('activityFeedbackId')
+    this.props.enableActivityFeedback(
+      activityId, {
+        activityFeedbackId,
+        useRubric: event.target.checked
+      })
+  }
+
+  setMaxScore(event) {
+    const value = parseInt(event.target.value, 10) || null
+    const activityId = this.props.activity.get('id')
+    const activityFeedbackId = this.props.activity.get('activityFeedbackId')
+    this.props.enableActivityFeedback(activityId, {
+      activityFeedbackId,
+      maxScore: value
+    })
+  }
+
+  changeScoreType(newV) {
+    const activityId = this.props.activity.get('id').toString()
+    const activityFeedbackId = this.props.activity.get('activityFeedbackId')
+    const newFlags = {activityFeedbackId, scoreType: newV }
+    if(newV != NO_SCORE) {
+      this.setState({lastScoreType: newV})
+    }
+    if(newV == AUTOMATIC_SCORE) {
+      newFlags.maxScore = this.props.computedMaxScore;
+    }
+    this.props.enableActivityFeedback(activityId, newFlags);
+  }
+
+
+  render() {
+    const { activity, computedMaxScore}  = this.props;
+    const scoreType = activity.get("scoreType") || NO_SCORE
+    const showText = activity.get("enableTextFeedback")
+    const rubricUrl = activity.get("rubricUrl")
+    const rubricAvailable = rubricUrl && rubricUrl.length > 0
+    const useRubric = rubricAvailable && activity.get("useRubric")
+    const scoreEnabled = scoreType != NO_SCORE
+    const maxScore = scoreType == "auto"
+      ? computedMaxScore
+      : activity.get("maxScore")
+    const scoreClassName = scoreEnabled
+      ? "enabled"
+      : "disabled"
+    const toggleScoreEnabled = () => {
+      if(scoreEnabled) {
+        this.changeScoreType(NO_SCORE)
+      } else {
+        this.changeScoreType(this.state.lastScoreType || MANUAL_SCORE)
+      }
+    }
+
+    return (
+      <div className="feedback-options">
+        <input id="rubricEnabled"
+          type="checkbox"
+          checked={useRubric}
+          disabled={!rubricAvailable}
+          onChange={this.enableRubric}/>
+        <label
+          disabled={!rubricAvailable}
+          className={ !rubricAvailable
+            ? "disabled"
+            : "" }
+          htmlFor="rubricEnabled">
+
+          Use rubric</label>
+        <br/>
+        <input id="feedbackEnabled" type="checkbox" checked={showText} onChange={this.enableText}/>
+        <label htmlFor="feedbackEnabled">Provide written feedback</label>
+        <br/>
+        <input id="giveScore" name="giveScore" type="checkbox" checked={scoreEnabled} onChange={toggleScoreEnabled}/>
+        <label htmlFor="giveScore">Give Score</label>
+        <br/>
+        <div className={scoreClassName} style={{marginLeft: '1em'}}>
+            <RadioGroup
+              name="scoreType"
+              selectedValue={scoreType}
+              onChange={this.changeScoreType}
+            >
+              <div>
+                <Radio value={MANUAL_SCORE} />
+                <span
+                  className="tooltip"
+                  data-tip data-for="MANUAL_SCORE">
+                    {MANUAL_SCORE_L}
+                </span>
+              </div>
+              <div>
+                <Radio value={AUTOMATIC_SCORE} />
+                <span className="tooltip" data-tip data-for="AUTOMATIC_SCORE">
+                  {AUTOMATIC_SCORE_L}
+                </span>
+              </div>
+
+              <ReactTooltip
+                id="NO_SCORE"
+                place="top"
+                type="dark"
+                delayShow={500}>
+                  No activity level score.
+              </ReactTooltip>
+
+              <ReactTooltip
+                id="MANUAL_SCORE"
+                place="top"
+                type="dark"
+                delayShow={500}>
+                  Provide your own activity level score.
+              </ReactTooltip>
+
+              <ReactTooltip
+                id="AUTOMATIC_SCORE"
+                place="top"
+                type="dark"
+                delayShow={500}>
+                Sum scores from individual questions.
+              </ReactTooltip>
+            </RadioGroup>
+
+            { scoreType == MANUAL_SCORE
+            ? <div>
+                <label className="max-score">Max. Score</label>
+                <input className="max-score-input" value={maxScore} onChange={this.setMaxScore}/>
+              </div>
+            : <div>
+                <label className="max-score disabled">Max. Score</label>
+                <input className="max-score-input disabled" disabled={true} value={maxScore} onChange={this.setMaxScore}/>
+              </div>
+          }
+        </div>
+      </div>
+    )
+  }
+}

--- a/js/components/feedback-overview.js
+++ b/js/components/feedback-overview.js
@@ -1,12 +1,10 @@
-import React, { PureComponent } from 'react'
+import React, { PureComponent } from 'react' // eslint-disable-line
 import '../../css/feedback-overview.less'
 
 export default class FeedbackOverview extends PureComponent {
 
   render() {
-    const numNoAnswers     = this.props.numNoAnswers
-    const numNeedsFeedback = this.props.numNeedsFeedback
-    const numFeedbackGiven = this.props.numFeedbackGiven
+    const { numNoAnswers, numNeedsFeedback, numFeedbackGiven } = this.props
     return (
       <div className="feedback-overview">
         <div>

--- a/js/components/rubric-box.js
+++ b/js/components/rubric-box.js
@@ -1,60 +1,6 @@
 import React, { PureComponent } from 'react'
 import '../../css/rubric-box.less'
 
-const sampleData =
-{
-  "id": "RBK1",
-  "version": "12",
-  "updatedMsUTC": 1519424087822,
-  "originUrl": "http://concord.org/rubrics/RBK1.json",
-  "scoreUsingPoints": false,
-  "showRatingDescriptions": false,
-  "criteria": [
-    {
-      "id": "C1",
-      "description": "Use mathematical and/or computational representations to support explanations of factors that affect carrying capacity of ecosystems at different scales. ",
-      "ratingDescriptions": [
-        "Not meeting expected goals.",
-        "Approaching proficiency.",
-        "Approaching proficiency.",
-        "Exhibiting proficiency."
-      ]
-    },
-    {
-      "id": "C2",
-      "description": "Develop a model to illustrate the role of photosynthesis and cellular respiration in the cycling of carbon among the biosphere, atmosphere, hydrosphere, and geosphere.",
-      "ratingDescriptions": [
-        "Not meeting expected goals.",
-        "Approaching proficiency.",
-        "Approaching proficiency.",
-        "Exhibiting proficiency."
-      ]
-    }
-  ],
-  "ratings": [
-    {
-      "id": "R1",
-      "label": "Beginning",
-      "score": 1
-    },
-    {
-      "id": "R2",
-      "label": "Developing",
-      "score": 2
-    },
-    {
-      "id": "R3",
-      "label": "Proficient",
-      "score": 3
-    },
-    {
-      "id": "R4",
-      "label": "Proficient",
-      "score": 3
-    }
-  ]
-}
-
 export default class RubricBox extends PureComponent {
   constructor(props) {
     super(props)
@@ -62,46 +8,50 @@ export default class RubricBox extends PureComponent {
   }
 
   render() {
-    return  (
-      <div className="rubric-box">
-        <table>
-          <thead>
-            <tr>
-              <th key="xxx"> Aspects of Proficiency</th>
+    const {rubric} = this.props
+    if(!rubric) { return null; }
+    else {
+      return  (
+        <div className="rubric-box">
+          <table>
+            <thead>
+              <tr>
+                <th key="xxx"> Aspects of Proficiency</th>
+                {
+                  rubric.ratings.map((rating) => <th key={rating.id}>{rating.label}</th>)
+                }
+              </tr>
+            </thead>
+            <tbody>
               {
-                sampleData.ratings.map((rating) => <th key={rating.id}>{rating.label}</th>)
-              }
-            </tr>
-          </thead>
-          <tbody>
-            {
-              sampleData.criteria.map((crit) => {
-                return(
-                  <tr key={crit.id}>
-                    <td>{crit.description}</td>
-                     {
-                       sampleData.ratings.map((rating) => {
-                        return(
-                          <td key={rating.id}>
-                            <div className="center">
-                              <input
-                                name={crit.id}
-                                type="radio"
-                                id="rating.id"/>
-                            </div>
-                          </td>
-                        )
-                      })
-                     }
+                rubric.criteria.map((crit) => {
+                  return(
+                    <tr key={crit.id}>
+                      <td>{crit.description}</td>
+                      {
+                        rubric.ratings.map((rating) => {
+                          return(
+                            <td key={rating.id}>
+                              <div className="center">
+                                <input
+                                  name={crit.id}
+                                  type="radio"
+                                  id="rating.id"/>
+                              </div>
+                            </td>
+                          )
+                        })
+                      }
 
-                  </tr>
-                )
-              })
-            }
-          </tbody>
-        </table>
-      </div>
-    )
+                    </tr>
+                  )
+                })
+              }
+            </tbody>
+          </table>
+        </div>
+      )
+    }
   }
 }
 

--- a/js/components/rubric-box.js
+++ b/js/components/rubric-box.js
@@ -1,0 +1,107 @@
+import React, { PureComponent } from 'react'
+import '../../css/rubric-box.less'
+
+const sampleData =
+{
+  "id": "RBK1",
+  "version": "12",
+  "updatedMsUTC": 1519424087822,
+  "originUrl": "http://concord.org/rubrics/RBK1.json",
+  "scoreUsingPoints": false,
+  "showRatingDescriptions": false,
+  "criteria": [
+    {
+      "id": "C1",
+      "description": "Use mathematical and/or computational representations to support explanations of factors that affect carrying capacity of ecosystems at different scales. ",
+      "ratingDescriptions": [
+        "Not meeting expected goals.",
+        "Approaching proficiency.",
+        "Approaching proficiency.",
+        "Exhibiting proficiency."
+      ]
+    },
+    {
+      "id": "C2",
+      "description": "Develop a model to illustrate the role of photosynthesis and cellular respiration in the cycling of carbon among the biosphere, atmosphere, hydrosphere, and geosphere.",
+      "ratingDescriptions": [
+        "Not meeting expected goals.",
+        "Approaching proficiency.",
+        "Approaching proficiency.",
+        "Exhibiting proficiency."
+      ]
+    }
+  ],
+  "ratings": [
+    {
+      "id": "R1",
+      "label": "Beginning",
+      "score": 1
+    },
+    {
+      "id": "R2",
+      "label": "Developing",
+      "score": 2
+    },
+    {
+      "id": "R3",
+      "label": "Proficient",
+      "score": 3
+    },
+    {
+      "id": "R4",
+      "label": "Proficient",
+      "score": 3
+    }
+  ]
+}
+
+export default class RubricBox extends PureComponent {
+  constructor(props) {
+    super(props)
+    this.state = {}
+  }
+
+  render() {
+    return  (
+      <div className="rubric-box">
+        <table>
+          <thead>
+            <tr>
+              <th key="xxx"> Aspects of Proficiency</th>
+              {
+                sampleData.ratings.map((rating) => <th key={rating.id}>{rating.label}</th>)
+              }
+            </tr>
+          </thead>
+          <tbody>
+            {
+              sampleData.criteria.map((crit) => {
+                return(
+                  <tr key={crit.id}>
+                    <td>{crit.description}</td>
+                     {
+                       sampleData.ratings.map((rating) => {
+                        return(
+                          <td key={rating.id}>
+                            <div className="center">
+                              <input
+                                name={crit.id}
+                                type="radio"
+                                id="rating.id"/>
+                            </div>
+                          </td>
+                        )
+                      })
+                     }
+
+                  </tr>
+                )
+              })
+            }
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+

--- a/js/containers/activity-feedback-panel.js
+++ b/js/containers/activity-feedback-panel.js
@@ -14,7 +14,8 @@ import {
   getFeedbacksNotAnswered,
   getComputedMaxScore,
   getQuestions,
-  calculateStudentScores
+  calculateStudentScores,
+  getActivityRubric
 } from '../core/activity-feedback-data'
 import '../../css/feedback-panel.less'
 import '../../css/tooltip.less'
@@ -94,7 +95,8 @@ class ActivityFeedbackPanel extends PureComponent {
       numFeedbacksNeedingReview,
       notAnswerd,
       autoScores,
-      computedMaxScore
+      computedMaxScore,
+      rubric
     }  = this.props;
     const numNotAnswered = notAnswerd.size
     const prompt = activity.get("name")
@@ -168,6 +170,7 @@ class ActivityFeedbackPanel extends PureComponent {
                       autoScore={autoScores.get(studentId)}
                       feedbackEnabled={showText}
                       useRubric={useRubric}
+                      rubric={rubric}
                       maxScore={maxScore}
                       updateFeedback={this.props.updateActivityFeedback}
                       showOnlyNeedReview={this.state.showOnlyNeedReview}
@@ -199,8 +202,8 @@ function mapStateToProps(state, ownProps) {
   const questions = getQuestions(state, actId)
   const computedMaxScore = getComputedMaxScore(questions)
   const autoScores = calculateStudentScores(state, questions)
-
-  return { feedbacks, feedbacksNeedingReview, numFeedbacksNeedingReview, numFeedbacksGivenReview, notAnswerd, computedMaxScore, autoScores}
+  const rubric = getActivityRubric(state, actId);
+  return { rubric, feedbacks, feedbacksNeedingReview, numFeedbacksNeedingReview, numFeedbacksGivenReview, notAnswerd, computedMaxScore, autoScores}
 }
 
 const mapDispatchToProps = (dispatch) => {

--- a/js/containers/activity-feedback-panel.js
+++ b/js/containers/activity-feedback-panel.js
@@ -167,6 +167,7 @@ class ActivityFeedbackPanel extends PureComponent {
                       scoreType={scoreType}
                       autoScore={autoScores.get(studentId)}
                       feedbackEnabled={showText}
+                      useRubric={useRubric}
                       maxScore={maxScore}
                       updateFeedback={this.props.updateActivityFeedback}
                       showOnlyNeedReview={this.state.showOnlyNeedReview}

--- a/js/containers/feedback-panel.js
+++ b/js/containers/feedback-panel.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { PureComponent } from 'react' // eslint-disable-line
 import ReactDom from 'react-dom'
 
 import Button from '../components/button'
@@ -69,17 +69,17 @@ class FeedbackPanel extends PureComponent {
   }
 
   setMaxScore(event) {
-    const value = parseInt(event.target.value) || null
+    const value = parseInt(event.target.value, 10) || null
     this.props.enableFeedback(this.props.question.get('key'), {maxScore: value})
   }
 
-  studentRowRef(index){
+  studentRowRef(index) {
     return `student-row-${index}`
   }
 
   scrollStudentIntoView(eventProxy) {
     const index = eventProxy.target.value
-    const ref = this.studentRowRef(index-1)
+    const ref = this.studentRowRef(index - 1)
     const itemComponent = this.refs[ref]
     if (itemComponent) {
       const domNode = ReactDom.findDOMNode(itemComponent)
@@ -99,14 +99,13 @@ class FeedbackPanel extends PureComponent {
   }
 
   render() {
-    const question      = this.props.question
+    const { question, answers } = this.props
     const showing       = this.state.showFeedbackPanel
     const prompt        = question.get('prompt')
     const number        = question.get('questionNumber')
-    const answers       = this.props.answers
 
     const realAnswers     = answers.filter(a => a.get('type') != 'NoAnswer')
-    const needingFeedback = realAnswers.filter( a => ! this.answerIsMarkedComplete(a) )
+    const needingFeedback = realAnswers.filter(a => !this.answerIsMarkedComplete(a))
 
     const filteredAnswers = this.state.showOnlyNeedReview ? needingFeedback : answers
     const numAnswers       = realAnswers.count()
@@ -118,30 +117,31 @@ class FeedbackPanel extends PureComponent {
     const feedbackEnabled = question.get('feedbackEnabled') || false
     const maxScore = question.get('maxScore') || 0
 
-    const showGettingStarted = (!scoreEnabled) && (!feedbackEnabled)
-    const studentsPulldown = filteredAnswers.map( (a) => {
+    const showGettingStarted = !scoreEnabled && !feedbackEnabled
+    const studentsPulldown = filteredAnswers.map((a) => {
       return {
         realName: a.getIn(['student', 'realName']),
-        id: a.getIn(['student','id']),
+        id: a.getIn(['student', 'id']),
         answer: a,
       }
     })
 
-    if((!scoreEnabled) && (!feedbackEnabled)) {
+    if(!scoreEnabled && !feedbackEnabled) {
       numNeedsFeedback = 0
       numFeedbackGiven = 0
     }
 
 
-    if (!showing) { return (
-      <div className="feedback-container">
-        <FeedbackButton
-          feedbackEnabled={feedbackEnabled || scoreEnabled}
-          needsReviewCount={numNeedsFeedback}
-          disabled={numAnswers < 1}
-          showFeedback={this.showFeedback}/>
-      </div>
-    )}
+    if (!showing) {
+      return (
+        <div className="feedback-container">
+          <FeedbackButton
+            feedbackEnabled={feedbackEnabled || scoreEnabled}
+            needsReviewCount={numNeedsFeedback}
+            disabled={numAnswers < 1}
+            showFeedback={this.showFeedback}/>
+        </div>)
+    }
     return (
       <div className="feedback-container">
         <div className="lightbox-background" />
@@ -167,11 +167,13 @@ class FeedbackPanel extends PureComponent {
               <input id="scoreEnabled" checked={scoreEnabled} type="checkbox" onChange={this.enableScore}/>
               <label htmlFor="scoreEnabled">Give Score</label>
               <br/>
-              { scoreEnabled ?
-                <div>
-                  <label className="max-score">Max. Score</label>
-                  <input className="max-score-input" value={maxScore} onChange={this.setMaxScore}/>
-                </div> : ""
+              { scoreEnabled
+                ?
+                  <div>
+                    <label className="max-score">Max. Score</label>
+                    <input className="max-score-input" value={maxScore} onChange={this.setMaxScore}/>
+                  </div>
+                : ""
               }
             </div>
           </div>
@@ -222,7 +224,7 @@ function mapStateToProps(state) {
   return { feedbacks: state.get('feedbacks')}
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = (dispatch) => {
   return {
     updateFeedback: (answerKey, feedback) => dispatch(updateFeedback(answerKey, feedback)),
     enableFeedback: (embeddableKey, feedbackFlags)  => dispatch(enableFeedback(embeddableKey, feedbackFlags)),

--- a/js/core/activity-feedback-data.js
+++ b/js/core/activity-feedback-data.js
@@ -110,3 +110,10 @@ export function getActivityFeedbacks(state, activityId) {
   const result = students.map( s => activityFeedbackFor(state, activity, s))
   return students.map( s => activityFeedbackFor(state, activity, addRealName(s))).toList()
 }
+
+export function getActivityRubric(state, activityId) {
+  const activity = state.getIn(['report','activities', activityId.toString()])
+  const rubricUrl = activity.get('rubricUrl');
+  const rubric =  state.getIn(['rubrics', rubricUrl]);
+  return rubric;
+}

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -13,6 +13,8 @@
         "name": "Test Activity 1 (sequence part)",
         "enable_text_feedback": false,
         "score_type": "none",
+        "use_rubric": false,
+        "rubric_url": "http://foo.bar",
         "max_score": 10,
         "activity_feedback":[
           {

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -14,7 +14,7 @@
         "enable_text_feedback": false,
         "score_type": "none",
         "use_rubric": false,
-        "rubric_url": "http://foo.bar",
+        "rubric_url": "https://jsonblob.com/api/jsonBlob/04ef35c9-2186-11e8-8521-3152b2a8394e",
         "max_score": 10,
         "activity_feedback":[
           {

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -5,6 +5,7 @@ import {
   SET_ANSWER_SELECTED_FOR_COMPARE, SHOW_COMPARE_VIEW, HIDE_COMPARE_VIEW, ENABLE_FEEDBACK, ENABLE_ACTIVITY_FEEDBACK} from '../actions'
 
 import feedbackReducer from './feedback-reducer'
+import { rubricReducer } from './rubric-reducer'
 import { activityFeedbackReducer } from './activity-feedback-reducer'
 import transformJSONResponse from '../core/transform-json-response'
 import { noSelection } from '../calculations'
@@ -129,6 +130,7 @@ export default function reducer(state = Map(), action) {
     data: data(state.get('data'), action),
     report: report(state.get('report'), action),
     feedbacks: feedbackReducer(state.get('feedbacks'), action),
+    rubrics: rubricReducer(state.get('rubrics'), action),
     activityFeedbacks: activityFeedbackReducer(state.get('activityFeedbacks'), action)
   })
 }

--- a/js/reducers/rubric-reducer.js
+++ b/js/reducers/rubric-reducer.js
@@ -1,0 +1,18 @@
+import { Map } from 'immutable'
+import { LOAD_RUBRIC, REQUEST_RUBRIC} from '../actions/load-rubric'
+
+const INITIAL_RUBRIC_STATE = Map({})
+
+export function rubricReducer(state = INITIAL_RUBRIC_STATE, action) {
+  switch (action.type) {
+    case REQUEST_RUBRIC:
+      // NOOP for now.
+      return state;
+    case LOAD_RUBRIC:
+      const {url, rubric} = action;
+      return state.set(url, rubric)
+
+    default:
+      return state
+  }
+}

--- a/js/store/configure-store.js
+++ b/js/store/configure-store.js
@@ -8,6 +8,7 @@ export default function configureStore(initialState) {
   return createStore(
     rootReducer,
     initialState,
-    applyMiddleware(thunkMiddleware, apiMiddleware /*, createLogger() */)
+    // apiMiddleware can now use thunk when calling `next()`
+    applyMiddleware(apiMiddleware, thunkMiddleware) //, createLogger())
   )
 }

--- a/js/util/scoring-constants.js
+++ b/js/util/scoring-constants.js
@@ -1,0 +1,6 @@
+export const NO_SCORE_L        = "No scoring"
+export const NO_SCORE          = "none"
+export const MANUAL_SCORE_L    = "Manual Scoring"
+export const MANUAL_SCORE      = "manual"
+export const AUTOMATIC_SCORE_L = "Automatic Scoring"
+export const AUTOMATIC_SCORE   = "auto"

--- a/js/util/student-report-url.js
+++ b/js/util/student-report-url.js
@@ -6,7 +6,7 @@ export default function studentReportUrl(student_ids) {
   const url = window.location
   const params = queryString.parse(url.search)
   params[studentIdParam] = student_ids
-  params.reportFor='student'
+  params.reportFor = 'student'
   const baseUrl = `${window.location.origin}${window.location.pathname}`
   const newSearch = queryString.stringify(params)
   return `${baseUrl}?${newSearch}`


### PR DESCRIPTION
## PR to start epic about adding Rubric scores to student feedbacks.

The summary of this feature is that activity authors can create criteria for evaluating students work at  the activity level. The rubric is a matrix of grading categories and proficiency levels. 
 
There are several rubric related stories tagged with `feedback` and PT.  This PR handles these two stories:

https://www.pivotaltracker.com/story/show/155404185 
https://www.pivotaltracker.com/story/show/155404153

> A teacher can select "use rubric" as one of the activity level feedback options, and they will see the rubric for this activity appear in activity-level feedback.

> An author can define a rubric using JSON. This structure of the rubric would be any number of grading categories, which could be scored using any number of proficiency levels. There could be a numerical value associated with a proficiency level.  … (more in story)

Before I started working on these features, I extracted `FeedbackOptions` from `FeedbackOverview` in e65dca3

Most of the view related changes happened in deb893d

Actions and reducers were added in 1d19b73

## Notes:

The rubric is loaded asynchronously from URLs.  We imagine that rubric will eventually be hosted in the portal, but for MVP purposes we might host rubric elsewhere.  

This was my first attempt to work with asynchronously updating the state tree, and I tried to follow the patterns set out in the ApiMiddleware, but eventually had to learn about dispatching actions from within actions using Thunk.

I feel good about the implementation, but it was new to me.  

I found that in order to use thunk within the ApiMiddleware I had to change the middleware load order.

Thanks for looking at this long PR @pjanik 



