### PR TITLE
RubricFeedback for students #155408322

### DIFF
--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -218,7 +218,8 @@ export function updateActivityFeedback (activityFeedbackKey, feedback) {
     hasBeenReviewed: 'has_been_reviewed',
     activityFeedbackId: 'activity_feedback_id',
     learnerId: 'learner_id',
-    feedback: 'text_feedback'
+    feedback: 'text_feedback',
+    rubricFeedback: 'rubric_feedback'
   })
   feedbackData.feedback_key = activityFeedbackKey
   return {
@@ -239,7 +240,8 @@ export function enableActivityFeedback (activityId, feedbackFlags) {
     enableTextFeedback: 'enable_text_feedback',
     scoreType: 'score_type',
     maxScore: 'max_score',
-    activityFeedbackId: 'activity_feedback_id'
+    activityFeedbackId: 'activity_feedback_id',
+    useRubric: 'use_rubric'
   }
   const feedbackSettings = mappedCopy(feedbackFlags, mappings)
   return {

--- a/js/components/rubric-box.js
+++ b/js/components/rubric-box.js
@@ -5,10 +5,28 @@ export default class RubricBox extends PureComponent {
   constructor (props) {
     super(props)
     this.state = {}
+    this.updateSelection = this.updateSelection.bind(this)
+  }
+
+  updateSelection (evt, critId, ratingId) {
+    const { rubric, rubricChange, rubricFeedback } = this.props
+    const change = {}
+    const rating = rubric.ratings.find((r) => r.id === ratingId)
+    const criteria = rubric.criteria.find((c) => c.id === critId)
+    const score = rating.score
+    const label = rating.label
+    change[critId] = {
+      id: ratingId,
+      score: score,
+      label: label,
+      description: criteria.ratingDescriptions[ratingId]
+    }
+    const newFeedback = Object.assign({}, rubricFeedback, change)
+    rubricChange(newFeedback)
   }
 
   render () {
-    const {rubric} = this.props
+    const { rubric, rubricFeedback, learnerId } = this.props
     if (!rubric) { return null } else {
       return (
         <div className='rubric-box'>
@@ -29,13 +47,23 @@ export default class RubricBox extends PureComponent {
                       <td>{crit.description}</td>
                       {
                         rubric.ratings.map((rating) => {
+                          const critId = crit.id
+                          const ratingId = rating.id
+                          const radioButtonKey = `${critId}-${ratingId}`
+                          const checked = rubricFeedback &&
+                            rubricFeedback[critId] &&
+                            rubricFeedback[critId].id === ratingId
+
                           return (
-                            <td key={rating.id}>
+                            <td key={radioButtonKey}>
                               <div className='center'>
                                 <input
-                                  name={crit.id}
+                                  name={`${learnerId}_${critId}`}
                                   type='radio'
-                                  id='rating.id' />
+                                  checked={checked}
+                                  value={ratingId}
+                                  onChange={(e) => this.updateSelection(e, critId, ratingId)}
+                                  id={radioButtonKey} />
                               </div>
                             </td>
                           )

--- a/js/core/transform-json-response.js
+++ b/js/core/transform-json-response.js
@@ -22,7 +22,10 @@ const DEFAULT_REPORT_FOR = 'class'
 // into normalized form where objects are grouped by ID.
 // See: https://github.com/gaearon/normalizr
 export default function transformJSONResponse (json) {
-  const camelizedJson = humps.camelizeKeys(json)
+  const camelizedJson = humps.camelizeKeys(json,
+    // don't convert keys that are only upercase letters and numbers.
+    // This is useful for rubric keys for example "C2" and "R1"
+    (key, convert) => /^[A-Z0-9_]+$/.test(key) ? key : convert(key))
 
   const student = new schema.Entity('students')
   const investigation = new schema.Entity('investigations')

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -13,8 +13,8 @@
         "name": "Test Activity 1 (sequence part)",
         "enable_text_feedback": false,
         "score_type": "none",
-        "use_rubric": false,
-        "rubric_url": "https://jsonblob.com/api/jsonBlob/04ef35c9-2186-11e8-8521-3152b2a8394e",
+        "use_rubric": true,
+        "rubric_url": "sample-rubric.json",
         "max_score": 10,
         "activity_feedback":[
           {
@@ -24,7 +24,21 @@
               {
                 "score": 10,
                 "feedback": "good",
-                "has_been_reviewed": true
+                "has_been_reviewed": false,
+                "rubric_feedback": {
+                  "C1": {
+                    "id": "R1",
+                    "score": 1,
+                    "label": "Beginning",
+                    "description": "Not meeting expected goals."
+                    },
+                    "C2": {
+                    "id": "R2",
+                    "score": 2,
+                    "label": "Developing",
+                    "description": "Approaching proficiency."
+                    }
+                }
               }
             ]
           }
@@ -53,6 +67,7 @@
                     "is_required": false,
                     "feedback_enabled": true,
                     "score_enabled": true,
+                    "max_score": 10,
                     "key": "Embeddable::MultipleChoice|116",
                     "type": "Embeddable::MultipleChoice",
                     "answers": [
@@ -778,7 +793,7 @@
                     ],
                     "feedback_enabled": false,
                     "score_enabled": false,
-                    "max_score": 0
+                    "max_score": 10
                   },
                   {
                     "id": 1022,
@@ -848,7 +863,7 @@
                     ],
                     "feedback_enabled": false,
                     "score_enabled": false,
-                    "max_score": 0
+                    "max_score": 10
                   }
                 ]
               }
@@ -862,7 +877,7 @@
         "type": "Activity",
         "name": "Test activity 3 (sequence part)",
         "enable_text_feedback": true,
-        "score_type": "none",
+        "score_type": "manual",
         "max_score": 10,
         "activity_feedback":[
           {

--- a/public/sample-rubric.json
+++ b/public/sample-rubric.json
@@ -1,0 +1,46 @@
+{
+    "id": "RBK1",
+    "formatVersion": "1.0.0",
+    "version": "12",
+    "updatedMsUTC": 1519424087822,
+    "originUrl": "http://concord.org/rubrics/RBK1.json",
+    "scoreUsingPoints": false,
+    "showRatingDescriptions": false,
+    "criteria": [
+        {
+            "id": "C1",
+            "description": "Use mathematical and/or computational representations to support explanations of factors that affect carrying capacity of ecosystems at different scales. ",
+            "ratingDescriptions": {
+                "R1": "Not meeting expected goals.",
+                "R2": "Approaching proficiency.",
+                "R3": "Exhibiting proficiency."
+            }
+        },
+        {
+            "id": "C2",
+            "description": "Develop a model to illustrate the role of photosynthesis and cellular respiration in the cycling of carbon among the biosphere, atmosphere, hydrosphere, and geosphere.",
+            "ratingDescriptions": {
+                "R1": "Not meeting expected goals.",
+                "R2": "Approaching proficiency.",
+                "R3": "Exhibiting proficiency."
+            }
+        }
+    ],
+    "ratings": [
+        {
+            "id": "R1",
+            "label": "Beginning",
+            "score": 1
+        },
+        {
+            "id": "R2",
+            "label": "Developing",
+            "score": 2
+        },
+        {
+            "id": "R3",
+            "label": "Proficient",
+            "score": 3
+        }
+    ]
+}


### PR DESCRIPTION
For this PT Story:

"A teacher can select levels of proficiency in rubric-based feedback for each criteria and that score will be saved for that student."

https://www.pivotaltracker.com/story/show/155408322

This PR modifies actions that send activity-level feedback to portal report API, to include the students rubric feedback. Changes are in actions/index.js `enableActivityFeedback` and `updateActivityFeedback`

Corresponding view changes, and updates to the sample data. `report.json` and a new file `public/sample-rubric.json`