### PR TITLE
Improvements to student feedback

### DIFF
--- a/css/activity-feedback-for-student.less
+++ b/css/activity-feedback-for-student.less
@@ -1,0 +1,45 @@
+.activity-feedback {
+  display: flex;
+  justify-content: flex-end;
+  .actFeedbackPanel {
+    padding: 0.5em;
+    border-radius: 0.5em;
+    background-color: hsl(0,0%, 95%);
+    max-width: 500px;
+    box-shadow: 1px 1px 3px hsla(0,0%, 50%, 0.5); 
+    font-weight: lighter;
+    .heading {
+      color: hsl(0,0%,50%);
+      font-weight: bold;
+    }
+    div {
+      font-family: helvetica, arial, sans-serif;
+      margin-bottom: 0.8em;
+    }
+    .score {
+      text-align: right;
+      margin-bottom: 0px;
+      .scoreLabel {
+        color: hsl(0,0%,50%);
+        font-weight: bold;
+      }
+    }
+    .rating { font-weight: normal;}
+  }
+
+}
+
+.active {
+  .actFeedbackPanel {
+    display: none;
+  }
+}
+
+@media print {
+  .report .activity-feedback .feedback-section  h1 {
+    display: inline;
+    margin-right: 0.5em;
+    font-size: 1em;
+    font-weight: normal;
+  }
+}

--- a/css/feedback-panel-for-student.less
+++ b/css/feedback-panel-for-student.less
@@ -6,8 +6,16 @@
     border-radius: 0.5em;
     background-color: hsl(0,0%, 95%);
     max-width: 500px;
-    box-shadow: 1px 1px 3px hsla(0,0%, 50%, 0.5); 
+    width: 50vw;
+    box-shadow: 1px 1px 3px hsla(0,0%, 50%, 0.5);
     font-weight: lighter;
+    font-size: 10pt;
+    @media print {
+      font-size: 9pt;
+      background-color: white;
+      border-radius: 0px;
+      box-shadow: none;
+    }
     .heading {
       color: hsl(0,0%,50%);
       font-weight: bold;

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -235,7 +235,7 @@ export function updateActivityFeedback (activityFeedbackKey, feedback) {
   }
 }
 
-export function enableActivityFeedback (activityId, feedbackFlags) {
+export function enableActivityFeedback (activityId, feedbackFlags, invalidatePreviousFeedback = true) {
   const mappings = {
     enableTextFeedback: 'enable_text_feedback',
     scoreType: 'score_type',
@@ -247,6 +247,7 @@ export function enableActivityFeedback (activityId, feedbackFlags) {
   return {
     type: ENABLE_ACTIVITY_FEEDBACK,
     activityId,
+    invalidatePreviousFeedback,
     feedbackFlags,
     callAPI: {
       type: 'updateReportSettings',

--- a/js/actions/rubric.js
+++ b/js/actions/rubric.js
@@ -50,7 +50,8 @@ const addRubric = (data) => {
         rubricUrl: url
       }
       // Event will trigger API call that will update the rubric in the portal.
-      dispatch(enableActivityFeedback(activityId, feedbackFlags))
+      // Doesn't require that we invalidate student answers though.
+      dispatch(enableActivityFeedback(activityId, feedbackFlags, false))
     })
   }
 }

--- a/js/components/activity-feedback-for-student.js
+++ b/js/components/activity-feedback-for-student.js
@@ -1,75 +1,21 @@
 import React, { PureComponent } from 'react'
-import '../../css/activity-feedback.less'
-import '../../css/activity-feedback-for-student.less'
+import FeedbackPanelForStudent from '../components/feedback-panel-for-student'
 
 export default class ActivityFeedbackForStudent extends PureComponent {
-  renderRubricSection (feedback) {
-    const { useRubric } = this.props
-    const rubricFeedbacks = feedback.rubricFeedbacks || [
-      {
-        description: `Evaluate the explaination based on data on the transfer
-                      of energy and matter to and from producers about the claim
-                      evidence and reasining in the explaination`,
-        rating: '– Proficient' },
-      {
-        description: `Identifty specific evidence from data on the transfer
-                      energy and or mater to and from the producers.`,
-        rating: '– Begining'
-      }
-    ]
-
-    if (useRubric && rubricFeedbacks && rubricFeedbacks.length > 0) {
-      return (
-        <div className='rubricFeedback'>
-          {
-            rubricFeedbacks.map((r) => {
-              return (
-                <div className='criterion' key={r.label}>
-                  <span className='description'>{r.description}</span>
-                  <span className='rating'>{r.rating}</span>
-                </div>
-              )
-            })
-          }
-        </div>
-      )
-    }
-    return null
-  }
-
-  renderTextSection (feedback) {
-    const { showText } = this.props
-    if (showText) {
-      return (
-        <div className='feedback-section written-feedback'>
-          <span>{feedback.feedback}</span>
-        </div>
-      )
-    }
-    return null
-  }
-
-  renderScoreSection (feedback) {
-    const { showScore, maxScore, autoScore } = this.props
-    const score = autoScore || feedback.score
-    if (showScore) {
-      return (
-        <div className='feedback-section score'>
-          <span className='scoreLabel'>Overall Score:</span>
-          <span className='studentScore'> {score} </span>
-          of
-          <span className='maxScore'> {maxScore} </span>
-        </div>
-      )
-    }
-    return null
-  }
-
   render () {
-    const {student, feedbacks, feedbackEnabled} = this.props
+    const {
+      student,
+      feedbacks,
+      feedbackEnabled,
+      useRubric,
+      rubric,
+      showScore,
+      maxScore,
+      showText,
+      autoScore
+    } = this.props
     let feedback = null
-
-    if (!feedbackEnabled) { return <div /> }
+    if (!feedbackEnabled) { return null }
     const _feedbacks = feedbacks
       .find((f) => f.get('studentId') === student.get('id'))
 
@@ -79,27 +25,28 @@ export default class ActivityFeedbackForStudent extends PureComponent {
         feedback = fblist.first().toJS()
       }
     }
-
     const showFeedback = (feedback && feedback.hasBeenReviewed)
-    // const showFeedback = true
-    const feedbackDiv =
-      <div className='actFeedbackPanel'>
-        <div className='heading'>Teacher Feedback:</div>
-        { this.renderRubricSection(feedback) }
-        { this.renderTextSection(feedback) }
-        { this.renderScoreSection(feedback) }
-      </div>
-
-    const noFeedbackDiv =
-      <div className='heading'>
-        No overall feedback yet.
-      </div>
-
-    const displayDiv = showFeedback ? feedbackDiv : noFeedbackDiv
+    const score = autoScore == null
+      ? feedback && feedback.score
+      : autoScore
+    const textFeedback = feedback && feedback.feedback
+    const hasBeenReviewed = feedback && feedback.hasBeenReviewed
+    const rubricFeedback = feedback && feedback.rubricFeedback
     return (
-      <div className='activity-feedback'>
-        { displayDiv }
-      </div>
-    )
+      <FeedbackPanelForStudent
+        student={student}
+        showScore={showScore}
+        maxScore={maxScore}
+        feedbackEnabled={showFeedback}
+        showText={showText}
+        textFeedback={textFeedback}
+        score={score}
+        hasBeenReviewed={hasBeenReviewed}
+        useRubric={useRubric}
+        rubric={rubric}
+        rubricFeedback={rubricFeedback}
+        autoScore={autoScore}
+        isOverall
+      />)
   }
 }

--- a/js/components/activity-feedback-for-student.js
+++ b/js/components/activity-feedback-for-student.js
@@ -1,19 +1,52 @@
 import React, { PureComponent } from 'react'
-
 import '../../css/activity-feedback.less'
+import '../../css/activity-feedback-for-student.less'
 
 export default class ActivityFeedbackForStudent extends PureComponent {
+  renderRubricSection (feedback) {
+    const { useRubric } = this.props
+    const rubricFeedbacks = feedback.rubricFeedbacks || [
+      {
+        description: `Evaluate the explaination based on data on the transfer
+                      of energy and matter to and from producers about the claim
+                      evidence and reasining in the explaination`,
+        rating: '– Proficient' },
+      {
+        description: `Identifty specific evidence from data on the transfer
+                      energy and or mater to and from the producers.`,
+        rating: '– Begining'
+      }
+    ]
+
+    if (useRubric && rubricFeedbacks && rubricFeedbacks.length > 0) {
+      return (
+        <div className='rubricFeedback'>
+          {
+            rubricFeedbacks.map((r) => {
+              return (
+                <div className='criterion' key={r.label}>
+                  <span className='description'>{r.description}</span>
+                  <span className='rating'>{r.rating}</span>
+                </div>
+              )
+            })
+          }
+        </div>
+      )
+    }
+    return null
+  }
+
   renderTextSection (feedback) {
     const { showText } = this.props
     if (showText) {
       return (
         <div className='feedback-section written-feedback'>
-          <h1>Overall Feedback:</h1>
           <span>{feedback.feedback}</span>
         </div>
       )
     }
-    return <div />
+    return null
   }
 
   renderScoreSection (feedback) {
@@ -22,23 +55,21 @@ export default class ActivityFeedbackForStudent extends PureComponent {
     if (showScore) {
       return (
         <div className='feedback-section score'>
-          <h1>Overall Score:</h1>
-          <span className='score'>{score} / {maxScore} </span>
+          <span className='scoreLabel'>Overall Score:</span>
+          <span className='studentScore'> {score} </span>
+          of
+          <span className='maxScore'> {maxScore} </span>
         </div>
       )
     }
-    return <div />
+    return null
   }
 
   render () {
     const {student, feedbacks, feedbackEnabled} = this.props
-    if (!feedbackEnabled) { return <div /> }
+    let feedback = null
 
-    let feedback = {
-      hasBeenReviewed: false,
-      score: 0,
-      feedback: ''
-    }
+    if (!feedbackEnabled) { return <div /> }
     const _feedbacks = feedbacks
       .find((f) => f.get('studentId') === student.get('id'))
 
@@ -50,15 +81,17 @@ export default class ActivityFeedbackForStudent extends PureComponent {
     }
 
     const showFeedback = (feedback && feedback.hasBeenReviewed)
-
+    // const showFeedback = true
     const feedbackDiv =
-      <div className='feedback'>
+      <div className='actFeedbackPanel'>
+        <div className='heading'>Teacher Feedback:</div>
+        { this.renderRubricSection(feedback) }
         { this.renderTextSection(feedback) }
         { this.renderScoreSection(feedback) }
       </div>
 
     const noFeedbackDiv =
-      <div className='feedback noFeedback'>
+      <div className='heading'>
         No overall feedback yet.
       </div>
 

--- a/js/components/feedback-panel-for-student.js
+++ b/js/components/feedback-panel-for-student.js
@@ -1,0 +1,90 @@
+import React, { PureComponent } from 'react'
+import '../../css/activity-feedback.less'
+import '../../css/feedback-panel-for-student.less'
+
+export default class FeedbackPanelForStudent extends PureComponent {
+  renderRubricSection (_rubricFeedback) {
+    const { useRubric, rubric } = this.props
+    const rubricFeedback = _rubricFeedback || {}
+    if (!(rubric && useRubric && rubric.criteria)) {
+      return null
+    }
+    const rFeedbacks = Object.keys(rubricFeedback).map((key) => {
+      const criteria = rubric.criteria.find((c) => c.id === key)
+      const rFeedback = rubricFeedback[key]
+      if (criteria && rFeedback) {
+        return (
+          <div className='criterion' key={key}>
+            <span className='description'>{criteria.description}</span>
+            <span className='rating'> – {rFeedback.label}</span>
+          </div>
+        )
+      }
+      return null
+    }).filter((f) => f)
+    if (useRubric && rFeedbacks.length > 0) {
+      return (
+        <div className='rubricFeedback'>
+          {rFeedbacks}
+        </div>
+      )
+    }
+    return null
+  }
+
+  renderTextSection (feedback) {
+    const { showText } = this.props
+    if (showText && feedback) {
+      return (
+        <div className='feedback-section written-feedback'>
+          <span>{feedback}</span>
+        </div>
+      )
+    }
+    return null
+  }
+
+  renderScoreSection (score) {
+    const { maxScore, showScore, isOverall } = this.props
+    const scoreLabel = isOverall ? 'Overall Score' : 'Score'
+    const ofLabel = 'of'
+    if (score != null && showScore) {
+      return (
+        <div className='feedback-section score'>
+          <span className='scoreLabel'>{scoreLabel}</span>
+          <span className='studentScore'> {score} </span>
+          {ofLabel}
+          <span className='maxScore'> {maxScore} </span>
+        </div>
+      )
+    }
+    return null
+  }
+
+  render () {
+    const {textFeedback, score, rubricFeedback, hasBeenReviewed} = this.props
+    const hasFeedback = textFeedback || score || rubricFeedback
+    const showFeedback = (hasFeedback && hasBeenReviewed)
+
+    let feedbackDiv =
+      <div className='heading'>
+        No overall feedback yet.
+      </div>
+
+    if (showFeedback) {
+      feedbackDiv =
+        <div className='actFeedbackPanel'>
+          <div className='heading'>Teacher Feedback:</div>
+          { this.renderRubricSection(rubricFeedback) }
+          { this.renderTextSection(textFeedback) }
+          { this.renderScoreSection(score) }
+        </div>
+    }
+
+    return (
+      <div className='activity-feedback'>
+        { feedbackDiv }
+      </div>
+    )
+  }
+}

--- a/js/components/question-for-student.js
+++ b/js/components/question-for-student.js
@@ -20,7 +20,7 @@ export default class QuestionForStudent extends PureComponent {
         </div>
         <Prompt question={question} />
         <Answer answer={answer} />
-        <Feedback answer={answer} question={question} htmlFor='student' />
+        <Feedback answer={answer} student={student} question={question} htmlFor='student' />
       </div>
     )
   }

--- a/js/containers/activity-feedback-panel.js
+++ b/js/containers/activity-feedback-panel.js
@@ -4,7 +4,7 @@ import Button from '../components/button'
 import FeedbackFilter from '../components/feedback-filter'
 import FeedbackOverview from '../components/feedback-overview'
 import FeedbackOptions from '../components/feedback-options'
-import FeedbackRow from '../components/activity-feedback-row'
+import ActivityFeedbackRow from '../components/activity-feedback-row'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import { connect } from 'react-redux'
 import { updateActivityFeedback, enableActivityFeedback } from '../actions'
@@ -161,7 +161,7 @@ class ActivityFeedbackPanel extends PureComponent {
                 <ReactCSSTransitionGroup transitionName='answer' transitionEnterTimeout={400} transitionLeaveTimeout={300}>
                   { filteredFeedbacks.map((studentActivityFeedback, i) => {
                     const studentId = studentActivityFeedback.get('studentId')
-                    return <FeedbackRow
+                    return <ActivityFeedbackRow
                       studentActivityFeedback={studentActivityFeedback}
                       activityFeedbackId={activityFeedbackId}
                       key={`${activityFeedbackId}-${studentId}`}

--- a/js/containers/activity.js
+++ b/js/containers/activity.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react'
 import { connect } from 'react-redux'
 import Sticky from 'react-stickynode'
-
 import Section from '../components/section'
 import FeedbackButton from '../components/feedback-button'
 import ActivityFeedbackForStudent from '../components/activity-feedback-for-student'
@@ -11,7 +10,8 @@ import {
   getQuestions,
   getFeedbacksNeedingReview,
   getComputedMaxScore,
-  calculateStudentScores
+  calculateStudentScores,
+  getActivityRubric
 } from '../core/activity-feedback-data'
 
 import '../../css/activity.less'
@@ -45,7 +45,8 @@ class Activity extends PureComponent {
       needsReviewCount,
       feedbacks,
       computedMaxScore,
-      autoScores
+      autoScores,
+      rubric
     } = this.props
     const activityName = activity.get('name')
     const showText = activity.get('enableTextFeedback')
@@ -65,8 +66,8 @@ class Activity extends PureComponent {
       />
       : ''
 
-    const feedbackButton = reportFor === 'class'
-      ? <span className='feedback'>
+    let feedbackButton =
+      <span className='feedback'>
         <FeedbackButton
           text='Provide overall feedback'
           needsReviewCount={needsReviewCount}
@@ -74,16 +75,25 @@ class Activity extends PureComponent {
           showFeedback={showFeedback}
         />
       </span>
-      : <ActivityFeedbackForStudent
-        student={reportFor}
-        feedbacks={feedbacks}
-        showScore={showScore}
-        maxScore={maxScore}
-        showText={showText}
-        useRubric={useRubric}
-        autoScore={scoreType === 'auto' ? autoScores.get(reportFor.get('id')) : null}
-        feedbackEnabled={feedbackEnabled}
-      />
+
+    if (reportFor !== 'class') {
+      const autoScore = scoreType === 'auto'
+        ? autoScores.get(reportFor.get('id'))
+        : null
+
+      feedbackButton =
+        <ActivityFeedbackForStudent
+          student={reportFor}
+          feedbacks={feedbacks}
+          showScore={showScore}
+          maxScore={maxScore}
+          showText={showText}
+          useRubric={useRubric}
+          rubric={rubric}
+          autoScore={autoScore}
+          feedbackEnabled={feedbackEnabled}
+        />
+    }
 
     return (
       <div className={`activity ${activity.get('visible') ? '' : 'hidden'}`}>
@@ -110,7 +120,8 @@ function mapStateToProps (state, ownProps) {
   const autoScores = calculateStudentScores(state, questions)
   const feedbacksNeedingReview = getFeedbacksNeedingReview(feedbacks)
   const needsReviewCount = feedbacksNeedingReview.size
-  return { feedbacks, feedbacksNeedingReview, needsReviewCount, autoScores, computedMaxScore }
+  const rubric = getActivityRubric(state, actId)
+  return { feedbacks, feedbacksNeedingReview, rubric, needsReviewCount, autoScores, computedMaxScore }
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => { return {} }

--- a/js/containers/activity.js
+++ b/js/containers/activity.js
@@ -53,6 +53,7 @@ class Activity extends PureComponent {
     const _maxScore = activity.get('maxScore')
     const maxScore = scoreType === 'auto' ? computedMaxScore : _maxScore
     const showScore = (scoreType !== 'none')
+    const useRubric = activity.get('useRubric')
     const showFeedback = this.showFeedback
     const hideFeedback = this.hideFeedback
     const feedbackEnabled = showScore || showText
@@ -79,6 +80,7 @@ class Activity extends PureComponent {
         showScore={showScore}
         maxScore={maxScore}
         showText={showText}
+        useRubric={useRubric}
         autoScore={scoreType === 'auto' ? autoScores.get(reportFor.get('id')) : null}
         feedbackEnabled={feedbackEnabled}
       />

--- a/js/containers/feedback.js
+++ b/js/containers/feedback.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import { connect } from 'react-redux'
-
+import FeedbackPanelForStudent from '../components/feedback-panel-for-student'
 import '../../css/answer-feedback.less'
 
 class Feedback extends PureComponent {
@@ -56,26 +56,31 @@ class Feedback extends PureComponent {
   }
 
   render () {
-    const forWho = this.props.for || '' // student or teacher
-    const className = `answer-feedback ${forWho}`
+    const {student} = this.props
+    const showScore = this.scoreEnabled()
+    const showText = this.feedbackEnabled()
+    const feedbackEnabled = showText || showScore
+    const maxScore = this.props.question.get('maxScore')
     const feedback = this.getLatestFeedback()
-    const feedbackDisabled = !(this.feedbackEnabled() || this.scoreEnabled())
+    const score = feedback && feedback.get('score')
+    const textFeedback = feedback && feedback.get('feedback')
     const hasBeenReviewed = feedback && feedback.get('hasBeenReviewed')
-    const noFeedbackMessage = this.props.answer.get('answered')
-      ? 'No Feedback yet.'
-      : 'Not answered yet.'
-    if (feedbackDisabled) {
-      return (<div className={`${className} disabled`}>No feedback yet.</div>)
-    } else if (hasBeenReviewed) {
-      return (
-        <div className={className}>
-          {this.renderFeedback(feedback)}
-          {this.renderScore(feedback)}
-        </div>
-      )
-    } else {
-      return (<div className={className}>{noFeedbackMessage}</div>)
-    }
+    return (
+      <FeedbackPanelForStudent
+        student={student}
+        showScore={showScore}
+        maxScore={maxScore}
+        feedbackEnabled={feedbackEnabled}
+        showText={showText}
+        textFeedback={textFeedback}
+        score={score}
+        hasBeenReviewed={hasBeenReviewed}
+        useRubric={false}
+        rubric={null}
+        autoScore={false}
+        isOverall={false}
+      />
+    )
   }
 }
 

--- a/js/core/activity-feedback-data.js
+++ b/js/core/activity-feedback-data.js
@@ -109,6 +109,9 @@ export function getActivityFeedbacks (state, activityId) {
 export function getActivityRubric (state, activityId) {
   const activity = state.getIn(['report', 'activities', activityId.toString()])
   const rubricUrl = activity.get('rubricUrl')
-  const rubric = state.getIn(['rubrics', rubricUrl]).toJS()
-  return rubric
+  const rubric = state.getIn(['rubrics', rubricUrl])
+  if (rubric) {
+    return rubric.toJS ? rubric.toJS() : rubric
+  }
+  return null
 }

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -11,8 +11,8 @@
         "activity_feedback_id": 29,
         "type": "Activity",
         "name": "Test Activity 1 (sequence part)",
-        "enable_text_feedback": false,
-        "score_type": "none",
+        "enable_text_feedback": true,
+        "score_type": "manual",
         "use_rubric": true,
         "rubric_url": "sample-rubric.json",
         "max_score": 10,
@@ -22,9 +22,9 @@
             "learner_id": 215,
             "feedbacks": [
               {
-                "score": 10,
+                "score": 9,
                 "feedback": "good",
-                "has_been_reviewed": false,
+                "has_been_reviewed": true,
                 "rubric_feedback": {
                   "C1": {
                     "id": "R1",

--- a/js/reducers/activity-feedback-reducer.js
+++ b/js/reducers/activity-feedback-reducer.js
@@ -33,7 +33,10 @@ export function activityFeedbackReducer (state = INITIAL_ACTIVITY_FEEDBACK_STATE
     case UPDATE_ACTIVITY_FEEDBACK:
       return updateActivityFeedback(state, action)
     case ENABLE_ACTIVITY_FEEDBACK:
-      return markAnswersNeedReview(state, action)
+      if (action.invalidatePreviousFeedback) {
+        return markAnswersNeedReview(state, action)
+      }
+      return state
     default:
       return state
   }


### PR DESCRIPTION
This pull request improves the student views (and the teacher's print view) in two key ways:

1. It adds feedback from the rubric to the activity level view.
2. It unifies all feedback areas with a consistent look. It also aligns feedback scores so they always appear on the right hand side, allowing teachers and students to easily check scores.

This PR is mainly component / container changes.  I also changed the dummy report JSON in minor ways to excise the new views.


PT: Story

[#153265633]
The student can see activity level feedback at the top of the report on their work.

When teacher does not have a text feedback, the score appears on the left side. When there is a text feedback, the scores are on the right side.

It would be easier to glance down one side to see scores if they were all on the same side. See images

https://www.pivotaltracker.com/story/show/153265633