### PR TITLE
Style and and layout changes to handle large question prompts.

### DIFF
--- a/css/activity.less
+++ b/css/activity.less
@@ -2,7 +2,12 @@
   @media print {
     padding-left: 0.7em;
   }
-
+  .act-header {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row;
+    flex-wrap: nowrap;
+  }
   h3 {
     color: #86b355;
     font-size: 1em;

--- a/css/feedback-panel.less
+++ b/css/feedback-panel.less
@@ -8,264 +8,256 @@
   background-color: hsla(0, 0, 0, 0.90);
   z-index: 5000;
 }
-
-.feedback-panel {
-  div {
-    overflow: hidden;
-  }
-
-  position: fixed;
-  z-index: 5001;
-  top: 100px;
-  left: 40px;
-  right: 40px;
-  bottom: 40px;
-  background-color: white;
-  padding: 2rem;
-  opacity: 1;
-  display: flex;
-  flex-direction: column;
-
-  .feedback-header {
-    margin: 0px;
+.feedback-container {
+  .feedback-panel {
+    div {
+      overflow: hidden;
+    }
+    box-sizing: border-box;
+    position: fixed;
+    z-index: 5001;
+    top: 100px;
+    left: 40px;
+    right: 40px;
+    bottom: 40px;
+    background-color: white;
+    padding: 2rem;
+    opacity: 1;
     display: flex;
-    flex-direction: row;
-    width: 100%;
-    flex-grow: 0;
-    flex-shrink: 0;
-    justify-content: space-between;
+    min-height: 400px;
+    flex-direction: column;
+    h1 {
+      font-size: .9em;
+      margin-bottom: 0px;
+    }
 
-    .left {
+    .prompt {
+      color: #da5936;
+      float: left;
+      font-size: 1.15em;
+      font-weight: normal;
+      height: 5em;
+      overflow: auto;
+      margin: 0px;
+    }
+
+    .feedback-header {
+      box-sizing: border-box;
+      padding: 0.5em;
+      background-color: hsl(0, 0%, 95%);
+      margin-top: 0.5em;
+      display: flex;
+      flex-direction: row;
+      width: 100%;
+      min-height: 80px;
+      justify-content: space-between;
+      align-items: flex-start;
+      &.tall {
+        min-height: 120px;
+      }
+    }
+
+    .feedback-options {
+      margin: 0px;
+      font-size: .8em;
+      h3 {
+        color: #3f3f3f;
+        font-size: 1em;
+        margin: 0px;
+        margin-bottom: .25em;
+      }
+    }
+
+    .disabled {
+      opacity: 0.5;
+    }
+    .main-feedback {
+      width: 100%;
+      flex-grow: 1;
+      flex-shrink: 1;
+      align-self: flex-end;
+      position: relative;
+      margin-top: 0px;
       display: flex;
       flex-direction: column;
+    }
 
-      h1 {
-        font-size: .9em;
-        margin-bottom: 0px;
+    .feedback-rows-wrapper {
+      overflow-y: auto;
+      background: linear-gradient(hsla(0, 0%, 80%, 0.3), hsla(0, 0%, 80%, 0.01));
+      flex-grow: 1;
+      flex-shrink: 1;
+    }
+
+    .feedback-for-students {
+      width: 100%;
+      .answer-enter {
+        opacity: 0.01;
+        max-height: 0px;
       }
 
-      h2 {
-        color: #da5936;
-        float: left;
-        font-size: 1.35em;
-        font-weight: normal;
-        margin: 0px;
+      .answer-enter.answer-enter-active {
+        opacity: 1;
+        max-height: 600px;
+        transition: 400ms ease;
+      }
+
+      .answer-leave {
+        opacity: 1;
+        max-height: 600px;
+      }
+
+      .answer-leave.answer-leave-active {
+        opacity: 0.1;
+        max-height: 0px;
+        transition: 400ms ease;
       }
     }
-  }
 
-  .feedback-options {
-    margin: 0px;
-    background: #eee;
-    font-size: .8em;
-    padding: 10px 15px;
-    align-self: flex-end;
-    flex-grow: 0;
-    flex-shrink: 0;
-    h3 {
-      color: #3f3f3f;
-      font-size: 1em;
-      margin: 0px;
-      margin-bottom: .25em;
-    }
-  }
-
-  .disabled {
-    opacity: 0.5;
-  }
-  .main-feedback {
-    width: 100%;
-    flex-grow: 1;
-    flex-shrink: 1;
-    align-self: flex-end;
-    position: relative;
-    margin-top: 1em;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .feedback-rows-wrapper {
-    overflow-y: scroll;
-    max-height: 400px;
-    border: solid 1px #777;
-    border-top: none;
-    flex-grow: 1;
-    flex-shrink: 1;
-  }
-
-  .feedback-for-students {
-    width: 100%;
-    .answer-enter {
-      opacity: 0.01;
-      max-height: 0px;
-    }
-
-    .answer-enter.answer-enter-active {
-      opacity: 1;
-      max-height: 600px;
-      transition: 400ms ease;
-    }
-
-    .answer-leave {
-      opacity: 1;
-      max-height: 600px;
-    }
-
-    .answer-leave.answer-leave-active {
-      opacity: 0.1;
-      max-height: 0px;
-      transition: 400ms ease;
-    }
-  }
-
-  .feedback-row {
-    background: #f6f6f6;
-    font-size: .9em;
-    overflow: hidden;
-    padding: 10px 15px;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    &:nth-child(even) {
-      background: #f0f0f0;
-    }
-  }
-
-  .gettingStarted {
-    position: absolute;
-    z-index: 5001;
-    height: 100%;
-    background-color: #222;
-    color: #fff;
-    padding: 2rem;
-    padding-top: 0px;
-    opacity: 0.9;
-    display: flex;
-    flex-direction: row;
-    .explainer {
-      font-size: 20pt;
-      width: 70%;
-      text-align: center;
-    }
-    .arrow {
-      font-size: 80pt;
-      line-height: 1em;
-    }
-  }
-
-
-
-  .student-answer {
-    width: 48%;
-  }
-
-  .feedback-interface {
-    width: 50%;
-  }
-
-  .feedback-content {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    font-size: 11pt;
-    input, textarea {
-      font-family: inherit;
-      font-size: inherit;
-      &[disabled] {
-        opacity: 0.4;
-      }
-    }
-    input { margin: 0.2em }
-    div {
-      margin-right: 1em;
-      margin-top: 0.5em;
-    }
-    .score {
-      input { width: 3em; text-align: right;}
-    }
-  }
-
-  .max-score-input {
-    width: 35px;
-  }
-
-  .feedback-complete {
-    float: left;
-    font-size: .9em;
-    width: 50%;
-  }
-
-  .feedback .score {
-    float: right;
-    font-size: .9em;
-    text-align: right;
-    width: 50%;
-  }
-
-  .footer {
-    height: 40px;
-    flex-grow: 0;
-    flex-shrink: 0;
-    .cc-button {
-      float: right;
-      margin: .75em 25px .75em 0;
-      border: none;
-      color: #fff !important;
-      cursor: pointer;
-      display: block;
-      font-family: lato, arial, helvetica, sans-serif;
+    .feedback-row {
+      background: #f6f6f6;
       font-size: .9em;
-      font-weight: normal;
-      padding: .3125em .625em;
-      text-align: center;
-      text-decoration: none;
-      border-radius: .1875em;
-      box-shadow: 0 3px 0 #e16a3e;
+      overflow: hidden;
+      padding: 10px 15px;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: flex-start;
+      &:nth-child(even) {
+        background: #f0f0f0;
+      }
+      &:last-of-type {
+        box-shadow: 1px 0px 4px hsla(0,0%,10%,0.2);
+      }
     }
-  }
 
-  a.cc-button {
-    align-self: flex-end;
-    margin-right: 0px;
-  }
-
-
-  h3 {
-    color: #3a878b;
-    font-size: 1rem;
-    font-weight: bold;
-    margin: 1rem 0px;
-    text-transform: capitalize;
-  }
-
-  h4 {
-    color: #777;
-    font-weight: bold;
-    margin: 1rem 0px;
-    padding: 0px;
-  }
-
-  label {
-    display: inline-block;
-    margin-left: 0.5em;
-    max-width: inherit;
-    margin-bottom: inherit;
-    font-weight: inherit;
-    &.max-score {
-      margin-left: 1.5em;
-      margin-right: 0.5em;
+    .gettingStarted {
+      position: absolute;
+      z-index: 5001;
+      height: 100%;
+      background-color: #222;
+      color: #fff;
+      padding: 2rem;
+      padding-top: 0px;
+      opacity: 0.9;
+      display: flex;
+      flex-direction: row;
+      .explainer {
+        font-size: 20pt;
+        width: 70%;
+        text-align: center;
+      }
+      .arrow {
+        font-size: 80pt;
+        line-height: 1em;
+      }
     }
-  }
 
-  textarea {
-    border: solid 1px #ccc;
-    font: .9em verdana, helvetica, sans-serif;
-    margin-bottom: .25em;
-    padding: 1%;
-    width: 95%;
-    height: 5em;
 
+
+    .student-answer {
+      width: 48%;
+    }
+
+    .feedback-interface {
+      width: 70%;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: flex-end;
+
+      .feedback-content {
+        width: 100%;
+        font-size: 11pt;
+        input, textarea {
+          font-family: inherit;
+          font-size: inherit;
+          &[disabled] {
+            opacity: 0.4;
+          }
+        }
+        input { margin: 0.2em; text-align: right; }
+        div {
+          margin-top: 0.5em;
+        }
+        .score {
+          text-align: right;
+          input { width: 3em; }
+        }
+        .feedback-complete {
+          text-align: right;
+        }
+      }
+    }
+    .max-score-input {
+      width: 35px;
+    }
+
+
+
+    .footer {
+      height: 40px;
+      flex-grow: 0;
+      flex-shrink: 0;
+      .cc-button {
+        float: right;
+        margin: .75em 25px .75em 0;
+        border: none;
+        color: #fff !important;
+        cursor: pointer;
+        display: block;
+        font-family: lato, arial, helvetica, sans-serif;
+        font-size: .9em;
+        font-weight: normal;
+        padding: .3125em .625em;
+        text-align: center;
+        text-decoration: none;
+        border-radius: .1875em;
+        box-shadow: 0 3px 0 #e16a3e;
+      }
+    }
+
+    a.cc-button {
+      align-self: flex-end;
+      margin-right: 0px;
+    }
+
+
+    h3 {
+      color: #3a878b;
+      font-size: 1rem;
+      font-weight: bold;
+      margin: 1rem 0px;
+      text-transform: capitalize;
+    }
+
+    h4 {
+      color: #777;
+      font-weight: bold;
+      margin: 1rem 0px;
+      padding: 0px;
+    }
+
+    label {
+      display: inline-block;
+      margin-left: 0.5em;
+      max-width: inherit;
+      margin-bottom: inherit;
+      font-weight: inherit;
+      &.max-score {
+        margin-left: 1.5em;
+        margin-right: 0.5em;
+      }
+    }
+
+    textarea {
+      border: solid 1px #ccc;
+      font: .9em verdana, helvetica, sans-serif;
+      margin-bottom: .25em;
+      padding: 1%;
+      width: 95%;
+      height: 5em;
+
+    }
   }
 }
-

--- a/css/report.less
+++ b/css/report.less
@@ -6,7 +6,6 @@
       position: fixed;
       left: 0px;
       right: 0px !important;
-      width: 100% !important;
       top: 0px;
       z-index: 1000;
       background-color: #fee9aa;

--- a/js/components/activity-feedback-row.js
+++ b/js/components/activity-feedback-row.js
@@ -58,11 +58,11 @@ export default class ActivityFeedbackRow extends PureComponent {
   renderComplete (answerKey, complete) {
     return (
       <div className='feedback-complete'>
+        <span>Feedback Complete</span>
         <input
           checked={complete}
           type='checkbox'
           onChange={(e) => this.completeChange(e, answerKey)} />
-        Feedback Complete
       </div>
     )
   }
@@ -121,12 +121,12 @@ export default class ActivityFeedbackRow extends PureComponent {
           {
             scoreEnabled
               ? this.renderScore(activityFeedbackKey, disableScore, scoreToRender)
-              : ''
+              : null
           }
           {
             feedbackEnabled || scoreEnabled || useRubric
               ? this.renderComplete(activityFeedbackKey, complete)
-              : ''
+              : null
           }
         </div>
       </div>

--- a/js/components/feedback-row.js
+++ b/js/components/feedback-row.js
@@ -50,11 +50,11 @@ export default class FeedbackRow extends PureComponent {
   renderComplete (answerKey, complete) {
     return (
       <div className='feedback-complete'>
+        <span> Feedback Complete </span>
         <input
           checked={complete}
           type='checkbox'
           onChange={(e) => this.completeChange(e, answerKey)} />
-        Feedback Complete
       </div>
     )
   }

--- a/js/containers/activity-feedback-panel.js
+++ b/js/containers/activity-feedback-panel.js
@@ -23,6 +23,7 @@ import {
   NO_SCORE,
   AUTOMATIC_SCORE
 } from '../util/scoring-constants'
+import { truncate } from '../util/misc'
 
 class ActivityFeedbackPanel extends PureComponent {
   constructor (props) {
@@ -99,7 +100,7 @@ class ActivityFeedbackPanel extends PureComponent {
       rubric
     } = this.props
     const numNotAnswered = notAnswerd.size
-    const prompt = activity.get('name')
+    const prompt = truncate(activity.get('name') || '', 200)
     const scoreType = activity.get('scoreType') || NO_SCORE
     const showText = activity.get('enableTextFeedback')
     const useRubric = activity.get('useRubric')
@@ -125,16 +126,13 @@ class ActivityFeedbackPanel extends PureComponent {
       <div className='feedback-container'>
         <div className='lightbox-background' />
         <div className='feedback-panel'>
-          <div className='feedback-header'>
-            <div className='left'>
-              <h2>{prompt} </h2>
-              <FeedbackOverview
-                numNoAnswers={numNotAnswered}
-                numFeedbackGiven={numFeedbacksGivenReview}
-                numNeedsFeedback={numFeedbacksNeedingReview}
-              />
-            </div>
-
+          <div className='prompt' dangerouslySetInnerHTML={{ __html: prompt }} />
+          <div className='feedback-header tall'>
+            <FeedbackOverview
+              numNoAnswers={numNotAnswered}
+              numFeedbackGiven={numFeedbacksGivenReview}
+              numNeedsFeedback={numFeedbacksNeedingReview}
+            />
             <FeedbackOptions
               activity={this.props.activity}
               scoreEnabled={this.state.scoreEnabled}
@@ -142,7 +140,6 @@ class ActivityFeedbackPanel extends PureComponent {
               enableActivityFeedback={this.props.enableActivityFeedback}
               computedMaxScore={this.props.computedMaxScore}
             />
-
           </div>
 
           <div className='main-feedback'>

--- a/js/containers/activity.js
+++ b/js/containers/activity.js
@@ -98,7 +98,7 @@ class Activity extends PureComponent {
     return (
       <div className={`activity ${activity.get('visible') ? '' : 'hidden'}`}>
         <Sticky top={60}>
-          <div>
+          <div className='act-header'>
             <h3>{activityName} </h3>
             { feedbackButton }
           </div>

--- a/js/containers/feedback-panel.js
+++ b/js/containers/feedback-panel.js
@@ -7,7 +7,7 @@ import FeedbackOverview from '../components/feedback-overview'
 import FeedbackRow from '../components/feedback-row'
 import FeedbackButton from '../components/feedback-button'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
-
+import { truncate } from '../util/misc'
 import { connect } from 'react-redux'
 import { updateFeedback, enableFeedback } from '../actions'
 
@@ -34,11 +34,11 @@ class FeedbackPanel extends PureComponent {
   }
 
   makeOnlyNeedReview () {
-    this.setState({showOnlyNeedReview: true})
+    this.setState({ showOnlyNeedReview: true })
   }
 
   makeShowAll () {
-    this.setState({showOnlyNeedReview: false})
+    this.setState({ showOnlyNeedReview: false })
   }
 
   showFeedback () {
@@ -60,16 +60,16 @@ class FeedbackPanel extends PureComponent {
   }
 
   enableText (event) {
-    this.props.enableFeedback(this.props.question.get('key'), {feedbackEnabled: event.target.checked})
+    this.props.enableFeedback(this.props.question.get('key'), { feedbackEnabled: event.target.checked })
   }
 
   enableScore (event) {
-    this.props.enableFeedback(this.props.question.get('key'), {scoreEnabled: event.target.checked})
+    this.props.enableFeedback(this.props.question.get('key'), { scoreEnabled: event.target.checked })
   }
 
   setMaxScore (event) {
     const value = parseInt(event.target.value, 10) || null
-    this.props.enableFeedback(this.props.question.get('key'), {maxScore: value})
+    this.props.enableFeedback(this.props.question.get('key'), { maxScore: value })
   }
 
   studentRowRef (index) {
@@ -100,9 +100,8 @@ class FeedbackPanel extends PureComponent {
   render () {
     const { question, answers } = this.props
     const showing = this.state.showFeedbackPanel
-    const prompt = question.get('prompt')
+    const prompt = truncate(question.get('prompt') || '', 200)
     const number = question.get('questionNumber')
-
     const realAnswers = answers.filter(a => a.get('type') !== 'NoAnswer')
     const needingFeedback = realAnswers.filter(a => !this.answerIsMarkedComplete(a))
 
@@ -144,17 +143,14 @@ class FeedbackPanel extends PureComponent {
       <div className='feedback-container'>
         <div className='lightbox-background' />
         <div className='feedback-panel'>
+          <h1>Feedback: Question {number}</h1>
+          <div className='prompt' dangerouslySetInnerHTML={{ __html: prompt }} />
           <div className='feedback-header'>
-            <div className='left'>
-              <h1>Feedback: Question {number}</h1>
-              <h2 dangerouslySetInnerHTML={{__html: prompt}} />
-              <FeedbackOverview
-                numNoAnswers={numNoAnswers}
-                numFeedbackGiven={numFeedbackGiven}
-                numNeedsFeedback={numNeedsFeedback}
-              />
-            </div>
-
+            <FeedbackOverview
+              numNoAnswers={numNoAnswers}
+              numFeedbackGiven={numFeedbackGiven}
+              numNeedsFeedback={numNeedsFeedback}
+            />
             <div className='feedback-options'>
               <h3>Feedback Type</h3>
               <br />
@@ -165,7 +161,7 @@ class FeedbackPanel extends PureComponent {
               <input id='scoreEnabled' checked={scoreEnabled} type='checkbox' onChange={this.enableScore} />
               <label htmlFor='scoreEnabled'>Give Score</label>
               <br />
-              { scoreEnabled
+              {scoreEnabled
                 ? <div>
                   <label className='max-score'>Max. Score</label>
                   <input className='max-score-input' value={maxScore} onChange={this.setMaxScore} />
@@ -186,10 +182,10 @@ class FeedbackPanel extends PureComponent {
             />
 
             <div className='feedback-rows-wrapper'>
-              { showGettingStarted ? this.renderGettingStarted() : ''}
+              {showGettingStarted ? this.renderGettingStarted() : ''}
               <div className='feedback-for-students'>
                 <ReactCSSTransitionGroup transitionName='answer' transitionEnterTimeout={400} transitionLeaveTimeout={300}>
-                  { filteredAnswers.map((answer, i) =>
+                  {filteredAnswers.map((answer, i) =>
                     <FeedbackRow
                       answer={answer}
                       ref={() => this.studentRowRef(i)}

--- a/js/data/report.json
+++ b/js/data/report.json
@@ -4,13 +4,13 @@
   "report": {
     "id": 18,
     "type": "Investigation",
-    "name": "Test Sequence",
+    "name": "HAS Climate module: What is the future of Earth's climate? 2018 edition.",
     "children": [
       {
         "id": 29,
         "activity_feedback_id": 29,
         "type": "Activity",
-        "name": "Test Activity 1 (sequence part)",
+        "name": "Test Activity 1: Constructing an argument: climate as imported with long title.",
         "enable_text_feedback": true,
         "score_type": "manual",
         "use_rubric": true,
@@ -47,12 +47,12 @@
           {
             "id": 68,
             "type": "Section",
-            "name": "Test Activity 1 (sequence part) Section",
+            "name": "Activity 1: Constructing an argument: climate",
             "children": [
               {
                 "id": 242,
                 "type": "Page",
-                "name": "1",
+                "name": "What will Earth's climates be in the future?\n\n\nWhat will Earth's climates be in the future?\n\nWhat will Earth's climates be in the future?",
                 "url": "http://authoring.concord.org/activities/802/pages/4532/",
                 "children": [
                   {
@@ -60,7 +60,7 @@
                     "name": "Multiple Choice Question element",
                     "question_number": 1,
                     "description": "description ...",
-                    "prompt": "why does the temperature stay at 99&deg;",
+                    "prompt": "There are four sets of lines on the graph: two for temperature change and two for total solar irradiance. \n\nTwo of the lines show the yearly readings, and the other two show the 11 year average of those readings\n\nWhat is the average temperature change  reading (in °C) for the year 2000?\n\n\nThere are four sets of lines on the graph: two for temperature change and two for total solar irradiance. \n\nTwo of the lines show the yearly readings, and the other two show the 11 year average of those readings\n\nWhat is the average temperature change  reading (in °C) for the year 2000?\n\n\nThere are four sets of lines on the graph: two for temperature change and two for total solar irradiance. \n\nTwo of the lines show the yearly readings, and the other two show the 11 year average of those readings\n\nWhat is the average temperature change  reading (in °C) for the year 2000?",
                     "enable_rationale": false,
                     "rationale_prompt": "Explain your choice. Give specific examples.",
                     "allow_multiple_selection": null,

--- a/js/util/misc.js
+++ b/js/util/misc.js
@@ -1,0 +1,4 @@
+
+// Truncate strings eg:
+// truncate("this is a sentence", 5) // → "this i…"
+export const truncate = (_str, _size) => (_str.length > _size) ? `${_str.substr(0, _size - 1)}…` : _str


### PR DESCRIPTION
This PR addresses edge cases where question prompts are long and renders into a layout where its hard to provide feedback, because the scroll containers can't acquire enough screen real estate.

See screen shots and description in the PT story for examples of these cases.

Most of the changes are in stylesheets and some markup.

Specifically this PR:
* Truncates prompts to 200 characters, appending … to indicate its been shortened.
* Stylesheet changes to help maximize feedback area.
* Ensure that we can always scroll the feedback area.
* Line up UI elements in the right hand column.
* Use 70% of horizontal space for feedback.
* Modify `report.json` dummy data to include long prompts, and section names.

PT Story:

Long prompts make the feedback box unusable.

May be able to scroll, but can't tell. Maybe just on tablets.
Maybe truncate the prompt after a certain length.

#155601961

https://www.pivotaltracker.com/story/show/155601961