### PR TITLE
155798025 preview rubric layout

### DIFF
--- a/js/components/feedback-panel-for-student.js
+++ b/js/components/feedback-panel-for-student.js
@@ -12,11 +12,18 @@ export default class FeedbackPanelForStudent extends PureComponent {
     const rFeedbacks = Object.keys(rubricFeedback).map((key) => {
       const criteria = rubric.criteria.find((c) => c.id === key)
       const rFeedback = rubricFeedback[key]
+      const ratingDescription = (
+        rubric.showRatingDescriptions &&
+        criteria.ratingDescriptions &&
+        criteria.ratingDescriptions[rFeedback.id]
+      )
+        ? ` (${criteria.ratingDescriptions[rFeedback.id]})`
+        : ''
       if (criteria && rFeedback) {
         return (
           <div className='criterion' key={key}>
             <span className='description'>{criteria.description}</span>
-            <span className='rating'> – {rFeedback.label}</span>
+            <span className='rating'> – {rFeedback.label}{ratingDescription}</span>
           </div>
         )
       }

--- a/js/components/rubric-box.js
+++ b/js/components/rubric-box.js
@@ -53,7 +53,11 @@ export default class RubricBox extends PureComponent {
                           const checked = rubricFeedback &&
                             rubricFeedback[critId] &&
                             rubricFeedback[critId].id === ratingId
-
+                          const ratingDescription = (
+                            rubric.showRatingDescriptions &&
+                            crit.ratingDescriptions &&
+                            crit.ratingDescriptions[ratingId]
+                          ) || null
                           return (
                             <td key={radioButtonKey}>
                               <div className='center'>
@@ -62,6 +66,7 @@ export default class RubricBox extends PureComponent {
                                   type='radio'
                                   checked={checked}
                                   value={ratingId}
+                                  title={ratingDescription}
                                   onChange={(e) => this.updateSelection(e, critId, ratingId)}
                                   id={radioButtonKey} />
                               </div>

--- a/js/containers/rubric-test.js
+++ b/js/containers/rubric-test.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import RubricBox from '../components/rubric-box'
-import FeedbackPanelFroStudent from '../components/feedback-panel-for-student'
+import FeedbackPanelForStudent from '../components/feedback-panel-for-student'
 
 const sampleRubric = {
   'id': 'RBK1',
@@ -101,7 +101,7 @@ class RubricTest extends PureComponent {
             rubricFeedback={rubricFeedback}
             rubricChange={updateFeedback}
             learnerId={learnerId} />
-          <FeedbackPanelFroStudent
+          <FeedbackPanelForStudent
             textFeedback='Great work!'
             score={10}
             maxScore={10}

--- a/js/containers/rubric-test.js
+++ b/js/containers/rubric-test.js
@@ -1,0 +1,121 @@
+import React, { PureComponent } from 'react'
+import RubricBox from '../components/rubric-box'
+import FeedbackPanelFroStudent from '../components/feedback-panel-for-student'
+
+const sampleRubric = {
+  'id': 'RBK1',
+  'formatVersion': '1.0.0',
+  'version': '12',
+  'updatedMsUTC': 1519424087822,
+  'originUrl': 'http://concord.org/rubrics/RBK1.json',
+  'scoreUsingPoints': false,
+  'showRatingDescriptions': false,
+  'criteria': [
+    {
+      'id': 'C1',
+      'description': 'Use mathematical and/or computational representations to support explanations of factors that affect carrying capacity of ecosystems at different scales. ',
+      'ratingDescriptions': {
+        'R1': 'Not meeting expected goals.',
+        'R2': 'Approaching proficiency.',
+        'R3': 'Exhibiting proficiency.'
+      }
+    },
+    {
+      'id': 'C2',
+      'description': 'Develop a model to illustrate the role of photosynthesis and cellular respiration in the cycling of carbon among the biosphere, atmosphere, hydrosphere, and geosphere.',
+      'ratingDescriptions': {
+        'R1': 'Not meeting expected goals.',
+        'R2': 'Approaching proficiency.',
+        'R3': 'Exhibiting proficiency.'
+      }
+    }
+  ],
+  'ratings': [
+    {
+      'id': 'R1',
+      'label': 'Beginning',
+      'score': 1
+    },
+    {
+      'id': 'R2',
+      'label': 'Developing',
+      'score': 2
+    },
+    {
+      'id': 'R3',
+      'label': 'Proficient',
+      'score': 3
+    }
+  ]
+}
+
+class RubricTest extends PureComponent {
+  constructor (props) {
+    super(props)
+    this.state = {
+      rubric: sampleRubric,
+      rubricText: JSON.stringify(sampleRubric, null, '  '),
+      learnerId: 'noah123',
+      rubricFeedback: {},
+      hasBug: false
+    }
+  }
+  render () {
+    const { learnerId, rubric, rubricFeedback, hasBug, rubricText } = this.state
+    const updateFeedback = (rf) => {
+      console.dir(rf)
+      this.setState({rubricFeedback: rf})
+    }
+    const updateRubric = (e) => {
+      const value = e.target.value
+      console.dir(value)
+      this.setState({rubricText: value})
+      try {
+        const newRubric = JSON.parse(value)
+        if (newRubric) {
+          this.setState({rubric: newRubric, hasBug: false})
+        }
+      } catch (e) {
+        console.error(e)
+        this.setState({hasBug: true})
+      }
+    }
+    const style = {
+      display: 'flex',
+      flexDirection: 'row'
+    }
+    return (
+      <div style={style}>
+        <div style={{
+          backgroundColor: hasBug ? 'hsl(0,30%,50%)' : 'white',
+          padding: '1em'
+        }}>
+          <textarea
+            style={{ width: '50vw', height: '50vh', fontSize: '12pt', fontFamily: 'monospace' }}
+            onChange={updateRubric}
+            value={rubricText} />
+        </div>
+        <div>
+          <RubricBox
+            rubric={rubric}
+            rubricFeedback={rubricFeedback}
+            rubricChange={updateFeedback}
+            learnerId={learnerId} />
+          <FeedbackPanelFroStudent
+            textFeedback='Great work!'
+            score={10}
+            maxScore={10}
+            rubricFeedback={rubricFeedback}
+            rubric={rubric}
+            hasBeenReviewed
+            showScore
+            useRubric
+            showText
+          />
+        </div>
+      </div>
+    )
+  }
+}
+
+export default RubricTest

--- a/js/rubric-test.js
+++ b/js/rubric-test.js
@@ -1,0 +1,9 @@
+import 'babel-polyfill'
+import React from 'react'
+import { render } from 'react-dom'
+import RubricTest from './containers/rubric-test'
+
+render(
+  <RubricTest />,
+  document.getElementById('app')
+)

--- a/public/rubric-test.html
+++ b/public/rubric-test.html
@@ -25,8 +25,7 @@
   </style>
 </head>
 <body>
-  <div
-    id="app"></div>
+  <div id="app" />
   <script src="rubric-test.js"></script>
 </body>
 </html>

--- a/public/rubric-test.html
+++ b/public/rubric-test.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Report</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html { height: auto; min-height: 100%; }
+    body {
+      margin: 2em;
+      padding: 0;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      background-color: hsl(0,0%,90%);
+    }
+    #app {
+      font-family: Arial, Helvetica, sans-serif;
+      background-color: white;
+      padding: 10px;
+      border-radius: 0.5em;
+    }
+  </style>
+</head>
+<body>
+  <div
+    id="app"></div>
+  <script src="rubric-test.js"></script>
+</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,13 @@ var path = require('path');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
-  entry: [
-    './js/index.js'
-  ],
+  entry: {
+    'app': ['./js/index.js'],
+    'rubric-test': ['./js/rubric-test.js']
+  },
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'app.js'
+    filename: '[name].js'
   },
   module: {
     loaders: [


### PR DESCRIPTION
This PR creates a new html page called `rubric-test.html` which can be used by authors to try out rubric JSON.  This is a **quick and dirty hack** to use until a graphical tool can be built.

The original story was to use an URL input field, but it was understood that a text area for writing complete JSON would also be acceptable.

PT Story:

An author writing a rubric can go to a URL to preview the rubric if they provide a parameter that is the URL to the rubric data.

[#155798025]

https://www.pivotaltracker.com/story/show/155798025