### PR TITLE
Fix:  Scroll Student into view.

### DIFF
--- a/js/containers/activity-feedback-panel.js
+++ b/js/containers/activity-feedback-panel.js
@@ -31,6 +31,7 @@ class ActivityFeedbackPanel extends PureComponent {
     this.state = {
       showOnlyNeedReview: true
     }
+    this.studentRowRefs = {}
     this.makeOnlyNeedReview = this.makeOnlyNeedReview.bind(this)
     this.makeShowAll = this.makeShowAll.bind(this)
     this.changeScoreType = this.changeScoreType.bind(this)
@@ -69,7 +70,7 @@ class ActivityFeedbackPanel extends PureComponent {
   scrollStudentIntoView (eventProxy) {
     const index = eventProxy.target.value
     const ref = this.studentRowRef(index - 1)
-    const itemComponent = this.refs[ref]
+    const itemComponent = this.studentRowRefs[ref]
     if (itemComponent) {
       const domNode = ReactDom.findDOMNode(itemComponent)
       domNode.scrollIntoView()
@@ -162,7 +163,7 @@ class ActivityFeedbackPanel extends PureComponent {
                       studentActivityFeedback={studentActivityFeedback}
                       activityFeedbackId={activityFeedbackId}
                       key={`${activityFeedbackId}-${studentId}`}
-                      ref={() => this.studentRowRef(i)}
+                      ref={(row) => { this.studentRowRefs[this.studentRowRef(i)] = row }}
                       scoreType={scoreType}
                       autoScore={autoScores.get(studentId)}
                       feedbackEnabled={showText}

--- a/js/containers/feedback-panel.js
+++ b/js/containers/feedback-panel.js
@@ -20,7 +20,7 @@ class FeedbackPanel extends PureComponent {
       showOnlyNeedReview: true,
       showFeedbackPanel: false
     }
-
+    this.studentRowRefs = {}
     this.makeOnlyNeedReview = this.makeOnlyNeedReview.bind(this)
     this.makeShowAll = this.makeShowAll.bind(this)
     this.showFeedback = this.showFeedback.bind(this)
@@ -79,7 +79,7 @@ class FeedbackPanel extends PureComponent {
   scrollStudentIntoView (eventProxy) {
     const index = eventProxy.target.value
     const ref = this.studentRowRef(index - 1)
-    const itemComponent = this.refs[ref]
+    const itemComponent = this.studentRowRefs[ref]
     if (itemComponent) {
       const domNode = ReactDom.findDOMNode(itemComponent)
       domNode.scrollIntoView()
@@ -188,7 +188,7 @@ class FeedbackPanel extends PureComponent {
                   {filteredAnswers.map((answer, i) =>
                     <FeedbackRow
                       answer={answer}
-                      ref={() => this.studentRowRef(i)}
+                      ref={(row) => { this.studentRowRefs[this.studentRowRef(i)] = row }}
                       key={answer.get('key')}
                       scoreEnabled={scoreEnabled}
                       feedbackEnabled={feedbackEnabled}


### PR DESCRIPTION
Wait for #44 

This stopped working a while back. The `refs` API had changed and I implemented the new method incorrectly.

Here is a longer discussion:
https://reactjs.org/docs/refs-and-the-dom.html#the-ref-callback-attribute