### PR TITLE
1: Feature: Add summary indicators to activity section.

### DIFF
--- a/css/question.less
+++ b/css/question.less
@@ -51,6 +51,9 @@
   .prompt {
     font-weight: bold;
     margin-bottom: 0.5em;
+    max-width: 65vw;
+    height: 8em;
+    overflow: auto;
   }
 
   .answers-toggle {

--- a/css/rubric-box.less
+++ b/css/rubric-box.less
@@ -1,5 +1,9 @@
 .rubric-box {
   padding-bottom: 1em;
+  .reference-link {
+    font-size: 10pt;
+    margin-bottom: 0.5em;
+  }
   table {
     border-collapse: collapse;
     th {

--- a/css/summary-indicator.less
+++ b/css/summary-indicator.less
@@ -1,0 +1,26 @@
+.summary-indicator {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  margin: 0.2em;
+  box-sizing: border-box;
+  border-collapse: collapse;
+  .avg-score {
+    font-size: 10pt;
+    padding: 1em;
+  }
+  .rubric-row {
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
+    border: 0.3px solid white;
+  }
+  .rubric-summary {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    flex-direction: column;
+    background-color: black;
+  }
+}

--- a/js/components/rubric-box.js
+++ b/js/components/rubric-box.js
@@ -27,9 +27,16 @@ export default class RubricBox extends PureComponent {
 
   render () {
     const { rubric, rubricFeedback, learnerId } = this.props
+    const linkLabel = 'Scoring Guide'
+    const referenceLink = rubric.referenceURL
+      ? <div className='reference-link'>
+        <a href={rubric.referenceURL} target='_blank'> {linkLabel}
+        </a></div>
+      : null
     if (!rubric) { return null } else {
       return (
         <div className='rubric-box'>
+          {referenceLink}
           <table>
             <thead>
               <tr>

--- a/js/components/summary-indicator.js
+++ b/js/components/summary-indicator.js
@@ -1,0 +1,79 @@
+import React, { PureComponent } from 'react'
+import chroma from 'chroma-js'
+import '../../css/summary-indicator.less'
+
+export default class SummaryIndicator extends PureComponent {
+  renderLabel (label) {
+    return <span className='label'> {label} : </span>
+  }
+
+  renderAvgScore (label) {
+    const {scores, maxScore} = this.props
+    const avgScore = scores.reduce((p, c) => p + c, 0) / scores.length
+    const roundedAvg = Math.round(avgScore * 10) / 10
+    return avgScore
+      ? <span className='value'> {roundedAvg} / {maxScore}</span>
+      : null
+  }
+
+  renderRubricRow (rowNumbers) {
+    const width = 40
+    const total = rowNumbers.reduce((p, c) => p + c, 0)
+    const colors = chroma.scale(['hsl(198, 0%, 95%)', 'hsl(198, 100%, 25%)']).colors(rowNumbers.length)
+    const scale = (x) => x / total * width
+    const style = (value, index) => {
+      return {
+        height: '20px',
+        width: `${scale(value)}px`,
+        backgroundColor: colors[index]
+      }
+    }
+    return (
+      <div className='rubric-row'>
+        {rowNumbers.map((value, index) => <div style={style(value, index)} />)}
+      </div>
+    )
+  }
+
+  renderRubricSummary () {
+    const {rubricFeedbacks, rubric} = this.props
+    if (!rubric || !rubricFeedbacks || rubricFeedbacks.length < 1) { return }
+    const rows = rubric.criteria.map((criteria) => {
+      const cid = criteria.id
+      const rowMap = rubric.ratings.map((r, i) => {
+        const rid = r.id
+        return rubricFeedbacks.reduce((p, c) => {
+          if (c[cid] && c[cid].id === rid) {
+            return p + 1
+          }
+          return p
+        }, 0)
+      })
+      return rowMap
+    })
+    return (
+      <div className='rubric-summary'>
+        {rows.map((r) => this.renderRubricRow(r))}
+      </div>
+    )
+  }
+
+  render () {
+    const {scores, useRubric, showScore, rubricFeedbacks} = this.props
+    const _showScore = showScore && scores && scores.length > 0
+    const showRubric = useRubric && rubricFeedbacks && rubricFeedbacks.length > 0
+    const showLabel = showRubric || showScore
+    const label = _showScore
+      ? 'Avg. Score'
+      : 'Rubric Summary'
+    return (
+      <div className='summary-indicator'>
+        <div className='avg-score'>
+          { showLabel ? this.renderLabel(label) : null }
+          { _showScore ? this.renderAvgScore() : null}
+        </div>
+        { showRubric ? this.renderRubricSummary() : null}
+      </div>
+    )
+  }
+}

--- a/js/containers/activity.js
+++ b/js/containers/activity.js
@@ -5,6 +5,8 @@ import Section from '../components/section'
 import FeedbackButton from '../components/feedback-button'
 import ActivityFeedbackForStudent from '../components/activity-feedback-for-student'
 import ActivityFeedbackPanel from './activity-feedback-panel'
+import SummaryIndicator from '../components/summary-indicator'
+
 import {
   getActivityFeedbacks,
   getQuestions,
@@ -46,7 +48,9 @@ class Activity extends PureComponent {
       feedbacks,
       computedMaxScore,
       autoScores,
-      rubric
+      rubric,
+      rubricFeedbacks,
+      scores
     } = this.props
     const activityName = activity.get('name')
     const showText = activity.get('enableTextFeedback')
@@ -73,6 +77,14 @@ class Activity extends PureComponent {
           needsReviewCount={needsReviewCount}
           feedbackEnabled={feedbackEnabled}
           showFeedback={showFeedback}
+        />
+        <SummaryIndicator
+          scores={scores}
+          maxScore={maxScore}
+          useRubric={useRubric}
+          showScore={showScore}
+          rubricFeedbacks={rubricFeedbacks}
+          rubric={rubric}
         />
       </span>
 
@@ -121,7 +133,19 @@ function mapStateToProps (state, ownProps) {
   const feedbacksNeedingReview = getFeedbacksNeedingReview(feedbacks)
   const needsReviewCount = feedbacksNeedingReview.size
   const rubric = getActivityRubric(state, actId)
-  return { feedbacks, feedbacksNeedingReview, rubric, needsReviewCount, autoScores, computedMaxScore }
+  const scores = feedbacks
+    .flatMap(f => f.get('feedbacks')
+      .filter(f => f.get('hasBeenReviewed'))
+      .map(f2 => f2.get('score')))
+    .filter(x => x)
+    .toJS()
+  const rubricFeedbacks = feedbacks
+    .flatMap(f => f.get('feedbacks')
+      .filter(f => f.get('hasBeenReviewed'))
+      .map(f2 => f2.get('rubricFeedback')))
+    .filter(x => x)
+    .toJS()
+  return { scores, rubricFeedbacks, feedbacks, feedbacksNeedingReview, rubric, needsReviewCount, autoScores, computedMaxScore }
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => { return {} }

--- a/js/containers/feedback-panel.js
+++ b/js/containers/feedback-panel.js
@@ -6,6 +6,7 @@ import FeedbackFilter from '../components/feedback-filter'
 import FeedbackOverview from '../components/feedback-overview'
 import FeedbackRow from '../components/feedback-row'
 import FeedbackButton from '../components/feedback-button'
+import SummaryIndicator from '../components/summary-indicator'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import { truncate } from '../util/misc'
 import { connect } from 'react-redux'
@@ -100,12 +101,17 @@ class FeedbackPanel extends PureComponent {
   render () {
     const { question, answers } = this.props
     const showing = this.state.showFeedbackPanel
-    const prompt = truncate(question.get('prompt') || '', 200)
+    const prompt = question.get('prompt')
     const number = question.get('questionNumber')
     const realAnswers = answers.filter(a => a.get('type') !== 'NoAnswer')
     const needingFeedback = realAnswers.filter(a => !this.answerIsMarkedComplete(a))
 
     const filteredAnswers = this.state.showOnlyNeedReview ? needingFeedback : answers
+    const scores = this.props.feedbacks
+      .map(f => f.get('score'))
+      .filter(f => f != null)
+      .toArray()
+
     const numAnswers = realAnswers.count()
     const numNoAnswers = answers.count() - realAnswers.count()
     let numNeedsFeedback = needingFeedback.count()
@@ -114,7 +120,6 @@ class FeedbackPanel extends PureComponent {
     const scoreEnabled = question.get('scoreEnabled') || false
     const feedbackEnabled = question.get('feedbackEnabled') || false
     const maxScore = question.get('maxScore') || 0
-
     const showGettingStarted = !scoreEnabled && !feedbackEnabled
     const studentsPulldown = filteredAnswers.map((a) => {
       return {
@@ -137,6 +142,12 @@ class FeedbackPanel extends PureComponent {
             needsReviewCount={numNeedsFeedback}
             disabled={numAnswers < 1}
             showFeedback={this.showFeedback} />
+
+          <SummaryIndicator
+            scores={scores}
+            showScore={numAnswers > 0 && scoreEnabled}
+            maxScore={maxScore}
+          />
         </div>)
     }
     return (

--- a/js/containers/rubric-test.js
+++ b/js/containers/rubric-test.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import RubricBox from '../components/rubric-box'
 import FeedbackPanelForStudent from '../components/feedback-panel-for-student'
-
+import SummaryIndicator from '../components/summary-indicator'
 const sampleRubric = {
   'id': 'RBK1',
   'formatVersion': '1.0.0',
@@ -48,7 +48,23 @@ const sampleRubric = {
     }
   ]
 }
+const genRFeedbacks = (rubric, numAnswers) => {
+  const ratings = rubric.ratings
+  const pickRating = (id) => {
+    return ratings[Math.floor(Math.random() * ratings.length)]
+  }
+  const answers = []
 
+  for (let i = 0; i < numAnswers; i++) {
+    const answer = {}
+    rubric.criteria.forEach(c => {
+      answer[c.id] = pickRating()
+    })
+    answers.push(answer)
+  }
+  console.dir(answers)
+  return answers
+}
 class RubricTest extends PureComponent {
   constructor (props) {
     super(props)
@@ -111,6 +127,13 @@ class RubricTest extends PureComponent {
             showScore
             useRubric
             showText
+          />
+          <SummaryIndicator
+            scores={[1, 4, 3, 4, 0, 2]}
+            maxScore={10}
+            rubricFeedbacks={genRFeedbacks(rubric, 10)}
+            rubric={rubric}
+            useRubric
           />
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-polyfill": "^6.6.1",
     "bootstrap": "^3.3.6",
+    "chroma-js": "^1.3.6",
     "humps": "^2.0.0",
     "iframe-phone": "^1.1.3",
     "immutable": "^3.7.6",

--- a/public/sample-rubric.json
+++ b/public/sample-rubric.json
@@ -4,6 +4,7 @@
     "version": "12",
     "updatedMsUTC": 1519424087822,
     "originUrl": "http://concord.org/rubrics/RBK1.json",
+    "referenceURL": "https://www.nap.edu/read/13165/chapter/10#143",
     "scoreUsingPoints": false,
     "showRatingDescriptions": false,
     "criteria": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,6 +970,10 @@ chokidar@^1.0.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chroma-js@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-1.3.6.tgz#22dd7220ef6b55dcfcb8ef92982baaf55dced45d"
+
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"


### PR DESCRIPTION
This adds summary indicators to the activity feedback section.
Also adds a summary indicator to the rubric-test page.

PT Story:
[#155404659]

Add summary feedback indicators to the summary portal reports.
For numerical feedback, post the mean.
For rubric feedback, generate an icon that uses proportional color bars to represent what percentage of students scored at a particular level for each category.

https://www.pivotaltracker.com/story/show/155404659