### PR TITLE
Feature: Link to referenceURL if specified in JSON

### DIFF
--- a/css/rubric-box.less
+++ b/css/rubric-box.less
@@ -1,5 +1,9 @@
 .rubric-box {
   padding-bottom: 1em;
+  .reference-link {
+    font-size: 10pt;
+    margin-bottom: 0.5em;
+  }
   table {
     border-collapse: collapse;
     th {

--- a/js/components/rubric-box.js
+++ b/js/components/rubric-box.js
@@ -27,9 +27,16 @@ export default class RubricBox extends PureComponent {
 
   render () {
     const { rubric, rubricFeedback, learnerId } = this.props
+    const linkLabel = 'Scoring Guide'
+    const referenceLink = rubric.referenceURL
+      ? <div className='reference-link'>
+        <a href={rubric.referenceURL} target='_blank'> {linkLabel}
+        </a></div>
+      : null
     if (!rubric) { return null } else {
       return (
         <div className='rubric-box'>
+          {referenceLink}
           <table>
             <thead>
               <tr>

--- a/public/sample-rubric.json
+++ b/public/sample-rubric.json
@@ -4,6 +4,7 @@
     "version": "12",
     "updatedMsUTC": 1519424087822,
     "originUrl": "http://concord.org/rubrics/RBK1.json",
+    "referenceURL": "https://www.nap.edu/read/13165/chapter/10#143",
     "scoreUsingPoints": false,
     "showRatingDescriptions": false,
     "criteria": [


### PR DESCRIPTION
Story:

[#156316554]
Add referenceURL to Rubric JSON specification

This URL will be used to generate links in the teacher report that open a new tab containing a page that explains the rubric in detail.

If the field is blank, there is no link.

https://www.pivotaltracker.com/story/show/156316554