### PR TITLE
155404659 don't display 'Rubric summary' when its innapropriate

### DIFF
--- a/js/components/feedback-panel-for-student.js
+++ b/js/components/feedback-panel-for-student.js
@@ -74,8 +74,8 @@ export default class FeedbackPanelForStudent extends PureComponent {
     const showFeedback = (hasFeedback && hasBeenReviewed)
 
     let feedbackDiv =
-      <div className='heading'>
-        No overall feedback yet.
+      <div>
+        No feedback yet.
       </div>
 
     if (showFeedback) {

--- a/js/containers/activity.js
+++ b/js/containers/activity.js
@@ -72,7 +72,7 @@ class Activity extends PureComponent {
         activity={activity}
       />
       : ''
-
+    let summaryIndicator = null
     let feedbackButton =
       <div className='feedback'>
         <FeedbackButton
@@ -83,7 +83,16 @@ class Activity extends PureComponent {
         />
       </div>
 
-    if (reportFor !== 'class') {
+    if (reportFor === 'class') {
+      summaryIndicator = <SummaryIndicator
+        scores={summaryScores}
+        maxScore={maxScore}
+        useRubric={useRubric}
+        showScore={showScore}
+        rubricFeedbacks={rubricFeedbacks}
+        rubric={rubric}
+      />
+    } else {
       const studentId = reportFor.get('id')
       const autoScore = isAutoScoring(scoreType)
         ? autoScores.get(`${studentId}`)
@@ -111,14 +120,7 @@ class Activity extends PureComponent {
             { feedbackButton }
           </div>
         </Sticky>
-        <SummaryIndicator
-          scores={summaryScores}
-          maxScore={maxScore}
-          useRubric={useRubric}
-          showScore={showScore}
-          rubricFeedbacks={rubricFeedbacks}
-          rubric={rubric}
-        />
+        { summaryIndicator }
         <div>
           {feedbackPanel}
           {activity.get('children').map(s => <Section key={s.get('id')} section={s} reportFor={reportFor} />)}
@@ -144,7 +146,7 @@ function makeMapStateToProps () {
       scores,
       rubricFeedbacks } = getFeedbacks(state, ownProps)
     const needsReviewCount = feedbacksNeedingReview.size
-    
+
     return { scores, rubricFeedbacks, feedbacks, feedbacksNeedingReview, rubric, needsReviewCount, autoScores, computedMaxScore }
   }
 }


### PR DESCRIPTION
To be reviewed after #49 

Rubric summary should not be displayed when there is no rubric being used.  These summary items were also being displayed on the student reports.  This PR fixes both of these problems.



