### PR TITLE
157206977 Hide activity level feedback options for question level feedback.

### DIFF
--- a/js/components/activity-feedback-options.js
+++ b/js/components/activity-feedback-options.js
@@ -7,7 +7,7 @@ import {
   isAutoScoring
 } from '../util/scoring-constants'
 
-export default class FeedbackOptions extends PureComponent {
+export default class ActivityFeedbackOptions extends PureComponent {
   constructor (props) {
     super(props)
     this.state = { lastScoreType: null }
@@ -91,6 +91,7 @@ export default class FeedbackOptions extends PureComponent {
         showText={showText}
         changeScoreType={this.changeScoreType}
         setMaxScore={this.setMaxScore}
+        allowAutoScoring
       />
     )
   }

--- a/js/components/feedback-options-view.js
+++ b/js/components/feedback-options-view.js
@@ -16,7 +16,7 @@ import {
 
 export default class FeedbackOptionsView extends PureComponent {
   renderMaxScore () {
-    const {scoreType, maxScore, setMaxScore} = this.props
+    const {scoreType, maxScore, setMaxScore, scoreEnabled} = this.props
     if (scoreType === MANUAL_SCORE) {
       return (
         <span>
@@ -26,6 +26,7 @@ export default class FeedbackOptionsView extends PureComponent {
             value={maxScore}
             default={MAX_SCORE_DEFAULT}
             onChange={setMaxScore}
+            disabled={!scoreEnabled}
           />
         </span>
       )
@@ -38,48 +39,119 @@ export default class FeedbackOptionsView extends PureComponent {
     )
   }
 
-  render () {
+  renderToolTip (id, text) {
+    return <ReactTooltip id={id} place='top' type='dark'delayShow={500}> {text} </ReactTooltip>
+  }
+
+  renderRubricSelectBox () {
     const {
-      useRubric,
       rubricAvailable,
-      scoreEnabled,
-      scoreType,
+      allowAutoScoring,
       enableRubric,
-      enableText,
-      toggleScoreEnabled,
+      useRubric
+    } = this.props
+    const showRubricScoreOptions = rubricAvailable && allowAutoScoring
+    if (!showRubricScoreOptions) { return null }
+    return (
+      <div>
+        <input id='rubricEnabled'
+          type='checkbox'
+          checked={useRubric}
+          disabled={!rubricAvailable}
+          onChange={enableRubric}
+        />
+        <label
+          disabled={!rubricAvailable}
+          className={!rubricAvailable
+            ? 'disabled'
+            : ''}
+          htmlFor='rubricEnabled'>
+          Use rubric</label>
+        <br />
+      </div>
+    )
+  }
+
+  renderAutoScoreGroups () {
+    const {
       changeScoreType,
-      showText
+      scoreType,
+      useRubric,
+      rubricAvailable
+    } = this.props
+
+    return (
+      <RadioGroup
+        name='scoreType'
+        selectedValue={scoreType}
+        onChange={changeScoreType}
+      >
+        <div>
+          <Radio value={MANUAL_SCORE} />
+          <span className='tooltip' data-tip data-for='MANUAL_SCORE'>
+            {MANUAL_SCORE_L}
+          </span>
+          { this.renderMaxScore() }
+        </div>
+
+        <div>
+          <Radio value={AUTOMATIC_SCORE} />
+          <span className='tooltip' data-tip data-for='AUTOMATIC_SCORE'>
+            {AUTOMATIC_SCORE_L}
+          </span>
+        </div>
+        { rubricAvailable
+          ? <div className={useRubric ? '' : 'disabled'}>
+            <Radio value={RUBRIC_SCORE} disabled={!useRubric} />
+            <span className='tooltip' data-tip data-for='RUBRIC_SCORE'>
+              {RUBRIC_SCORE_L}
+            </span>
+          </div>
+          : null
+        }
+
+        { this.renderToolTip('NO_SCORE', 'Provide your own activity level score.') }
+        { this.renderToolTip('MANUAL_SCORE', 'No activity level score.') }
+        { this.renderToolTip('RUBRIC_SCORE', 'Scores come from the rubric.') }
+        { this.renderToolTip('AUTOMATIC_SCORE', 'Sum scores from individual questions.') }
+      </RadioGroup>
+    )
+  }
+
+  renderScoreOptions () {
+    const {
+      scoreEnabled,
+      allowAutoScoring
     } = this.props
 
     const scoreClassName = scoreEnabled
       ? 'enabled'
       : 'disabled'
 
+    return (
+      <div className='score-options'>
+        <div className={scoreClassName} style={{marginLeft: '1em'}}>
+          { allowAutoScoring ? this.renderAutoScoreGroups() : this.renderMaxScore() }
+        </div>
+      </div>
+    )
+  }
+
+  render () {
+    const {
+      scoreEnabled,
+      enableText,
+      toggleScoreEnabled,
+      showText
+    } = this.props
+
     const writtenFeedbackLabel = 'Provide written feedback'
     const giveScoreLabel = 'Give Score'
-    const renderToolTip = (id, text) => {
-      return <ReactTooltip id={id} place='top' type='dark'delayShow={500}> {text} </ReactTooltip>
-    }
 
     return (
       <div className='feedback-options'>
         <div className='main-options'>
-          <input id='rubricEnabled'
-            type='checkbox'
-            checked={useRubric}
-            disabled={!rubricAvailable}
-            onChange={enableRubric}
-          />
-
-          <label
-            disabled={!rubricAvailable}
-            className={!rubricAvailable
-              ? 'disabled'
-              : ''}
-            htmlFor='rubricEnabled'>
-            Use rubric</label>
-          <br />
-
+          {this.renderRubricSelectBox() }
           <input
             id='feedbackEnabled'
             type='checkbox'
@@ -88,7 +160,6 @@ export default class FeedbackOptionsView extends PureComponent {
           />
           <label htmlFor='feedbackEnabled'>{writtenFeedbackLabel}</label>
           <br />
-
           <input
             id='giveScore'
             name='giveScore'
@@ -98,45 +169,9 @@ export default class FeedbackOptionsView extends PureComponent {
           />
           <label htmlFor='giveScore'>{giveScoreLabel}</label>
           <br />
+          { this.renderScoreOptions() }
         </div>
-        <div className='score-options'>
-          <div className={scoreClassName} style={{marginLeft: '1em'}}>
-            <RadioGroup
-              name='scoreType'
-              selectedValue={scoreType}
-              onChange={changeScoreType}
-            >
-              <div>
-                <Radio value={MANUAL_SCORE} />
-                <span className='tooltip' data-tip data-for='MANUAL_SCORE'>
-                  {MANUAL_SCORE_L}
-                </span>
-                {this.renderMaxScore()}
-              </div>
 
-              <div>
-                <Radio value={AUTOMATIC_SCORE} />
-                <span className='tooltip' data-tip data-for='AUTOMATIC_SCORE'>
-                  {AUTOMATIC_SCORE_L}
-                </span>
-              </div>
-              { useRubric
-                ? <div>
-                  <Radio value={RUBRIC_SCORE} />
-                  <span className='tooltip' data-tip data-for='RUBRIC_SCORE'>
-                    {RUBRIC_SCORE_L}
-                  </span>
-                </div>
-                : null
-              }
-
-              { renderToolTip('NO_SCORE', 'Provide your own activity level score.') }
-              { renderToolTip('MANUAL_SCORE', 'No activity level score.') }
-              { renderToolTip('RUBRIC_SCORE', 'Scores come from the rubric.') }
-              { renderToolTip('AUTOMATIC_SCORE', 'Sum scores from individual questions.') }
-            </RadioGroup>
-          </div>
-        </div>
       </div>
     )
   }

--- a/js/components/feedback-panel-for-student.js
+++ b/js/components/feedback-panel-for-student.js
@@ -74,8 +74,8 @@ export default class FeedbackPanelForStudent extends PureComponent {
     const showFeedback = (hasFeedback && hasBeenReviewed)
 
     let feedbackDiv =
-      <div className='heading'>
-        No overall feedback yet.
+      <div>
+        No feedback yet.
       </div>
 
     if (showFeedback) {

--- a/js/components/numeric-text-field.js
+++ b/js/components/numeric-text-field.js
@@ -35,7 +35,7 @@ class NumericTextField extends PureComponent {
   }
 
   render () {
-    const { className } = this.props
+    const { className,disabled } = this.props
     const { value } = this.state
     return (
       <input
@@ -43,6 +43,7 @@ class NumericTextField extends PureComponent {
         value={value}
         onChange={this.updateValue}
         onBlur={this.setValue}
+        disabled={disabled}
       />
     )
   }

--- a/js/containers/activity-feedback-panel.js
+++ b/js/containers/activity-feedback-panel.js
@@ -3,7 +3,7 @@ import ReactDom from 'react-dom'
 import Button from '../components/button'
 import FeedbackFilter from '../components/feedback-filter'
 import FeedbackOverview from '../components/feedback-overview'
-import FeedbackOptions from '../components/feedback-options'
+import ActivityFeedbackOptions from '../components/activity-feedback-options'
 import ActivityFeedbackRow from '../components/activity-feedback-row'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import { connect } from 'react-redux'
@@ -146,7 +146,7 @@ class ActivityFeedbackPanel extends PureComponent {
               numFeedbackGiven={numFeedbacksGivenReview}
               numNeedsFeedback={numFeedbacksNeedingReview}
             />
-            <FeedbackOptions
+            <ActivityFeedbackOptions
               activity={this.props.activity}
               scoreEnabled={this.state.scoreEnabled}
               toggleScoreEnabled={this.toggleScoreEnabled}

--- a/js/containers/activity.js
+++ b/js/containers/activity.js
@@ -72,7 +72,7 @@ class Activity extends PureComponent {
         activity={activity}
       />
       : ''
-
+    let summaryIndicator = null
     let feedbackButton =
       <div className='feedback'>
         <FeedbackButton
@@ -83,7 +83,16 @@ class Activity extends PureComponent {
         />
       </div>
 
-    if (reportFor !== 'class') {
+    if (reportFor === 'class') {
+      summaryIndicator = <SummaryIndicator
+        scores={summaryScores}
+        maxScore={maxScore}
+        useRubric={useRubric}
+        showScore={showScore}
+        rubricFeedbacks={rubricFeedbacks}
+        rubric={rubric}
+      />
+    } else {
       const studentId = reportFor.get('id')
       const autoScore = isAutoScoring(scoreType)
         ? autoScores.get(`${studentId}`)
@@ -111,14 +120,7 @@ class Activity extends PureComponent {
             { feedbackButton }
           </div>
         </Sticky>
-        <SummaryIndicator
-          scores={summaryScores}
-          maxScore={maxScore}
-          useRubric={useRubric}
-          showScore={showScore}
-          rubricFeedbacks={rubricFeedbacks}
-          rubric={rubric}
-        />
+        { summaryIndicator }
         <div>
           {feedbackPanel}
           {activity.get('children').map(s => <Section key={s.get('id')} section={s} reportFor={reportFor} />)}
@@ -144,7 +146,7 @@ function makeMapStateToProps () {
       scores,
       rubricFeedbacks } = getFeedbacks(state, ownProps)
     const needsReviewCount = feedbacksNeedingReview.size
-    
+
     return { scores, rubricFeedbacks, feedbacks, feedbacksNeedingReview, rubric, needsReviewCount, autoScores, computedMaxScore }
   }
 }

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -2,8 +2,9 @@ import Immutable, { Map, Set} from 'immutable'
 import {
   REQUEST_DATA, RECEIVE_DATA, RECEIVE_ERROR, INVALIDATE_DATA, SET_NOW_SHOWING, SET_ANONYMOUS,
   SET_QUESTION_SELECTED, SHOW_SELECTED_QUESTIONS, SHOW_ALL_QUESTIONS,
-  SET_ANSWER_SELECTED_FOR_COMPARE, SHOW_COMPARE_VIEW, HIDE_COMPARE_VIEW, ENABLE_FEEDBACK, ENABLE_ACTIVITY_FEEDBACK} from '../actions'
-
+  SET_ANSWER_SELECTED_FOR_COMPARE, SHOW_COMPARE_VIEW, HIDE_COMPARE_VIEW, ENABLE_FEEDBACK, ENABLE_ACTIVITY_FEEDBACK
+} from '../actions'
+import { MANUAL_SCORE, RUBRIC_SCORE } from '../util/scoring-constants'
 import feedbackReducer from './feedback-reducer'
 import { rubricReducer } from './rubric-reducer'
 import { activityFeedbackReducer } from './activity-feedback-reducer'
@@ -56,8 +57,18 @@ function enableFeedback (state, action) {
 }
 
 function enableActivityFeedback (state, action) {
+
   const {activityId, feedbackFlags} = action
-  const nextState = state.mergeIn(['activities', activityId.toString()], feedbackFlags)
+  const statePath = ['activities', activityId.toString()]
+  // We have to unset 'RUBRIC_SCORE' scoretypes when
+  // we are no longer using rubric...
+  if (feedbackFlags.useRubric === false) {
+    const scoreType = state.getIn(statePath).get('scoreType')
+    if (scoreType === RUBRIC_SCORE) {
+      feedbackFlags.scoreType = MANUAL_SCORE
+    }
+  }
+  const nextState = state.mergeIn(statePath, feedbackFlags)
   return nextState
 }
 

--- a/js/selectors/activity-feedback-selectors.js
+++ b/js/selectors/activity-feedback-selectors.js
@@ -177,7 +177,7 @@ export const makeGetQuestionAutoScores = () => {
       const getFeedbackScore = (feedbackId) => {
         const score = questionFeedbacks.getIn([feedbackId, 'score'])
         const reviewed = questionFeedbacks.getIn([feedbackId, 'hasBeenReviewed'])
-        const computedScore = reviewed ? (score || 0) : 0
+        const computedScore = reviewed ? (score || 0) : false
         return computedScore
       }
       const scores = questions
@@ -190,6 +190,7 @@ export const makeGetQuestionAutoScores = () => {
           .filter(ans => ans.get('feedbacks'))
           .map(ans => ans.get('feedbacks').last())
           .map(feedbackId => getFeedbackScore(feedbackId))
+          .filter(a => isNumeric(a))
         )
       const sums = scores.map(s => s.reduce((sum, v) => sum + v, 0))
       return sums
@@ -255,7 +256,9 @@ const makeGetAutoMaxScore = () => {
     (questions) => {
       return questions
         .filter(question => question.get('scoreEnabled'))
-        .map(question => question.get('maxScore') || MAX_SCORE_DEFAULT)
+        .map(question => isNumeric(question.get('maxScore'))
+          ? question.get('maxScore')
+          : MAX_SCORE_DEFAULT)
         .reduce((total, score) => total + score, 0)
     }
   )


### PR DESCRIPTION
Questions were showing options for 'use rubric for scoring' and other things which weren't possible.

This bug was a result of a partially completed factor-out of a common `feedbackOptionsView.` component.

This PR finishes the refactoring.

NOTE: Should be reviewed after #51

This PR if for this [PT story](https://www.pivotaltracker.com/story/show/157206977)

