### PR TITLE
Fix:  Overlay panel for 'getting started' could not be dismissed.

### DIFF
--- a/css/feedback-filters.less
+++ b/css/feedback-filters.less
@@ -1,4 +1,5 @@
 .feedback-filters {
+  position: relative;
   flex-shrink: 0;
   flex-grow: 0;
   .filters {


### PR DESCRIPTION
Because of a positioning stylesheet regression, the 'getting started' box could not be dismissed.

Story:
[#157362447]
https://www.pivotaltracker.com/story/show/157362447