### PR TITLE
Fix Rubric reducers and tweak Rubric Box

### DIFF
--- a/css/rubric-box.less
+++ b/css/rubric-box.less
@@ -23,6 +23,10 @@
         background-color: hsla(0,0%,100%,0.8);
         padding: 0.25em;
         border-radius: 0.25em;
+        min-width: 1em;
+        min-height: 1em;
+        text-align: center;
+        line-height: 1em;
       }
     }
   }

--- a/js/components/rubric-box.js
+++ b/js/components/rubric-box.js
@@ -62,12 +62,14 @@ export default class RubricBox extends PureComponent {
     ) || null
     const { rowMaps } = this.props
     const values = rowMaps[critIndex]
-    const maxV = values.reduce((p, c) => p + c, 0)
-    const value = Math.round(values[ratingIndex] / maxV * 1000) / 10
+    const sum = values.reduce((p, c) => p + c, 0)
+    const value = Math.round(values[ratingIndex] / sum * 1000) / 10
+    // Render check mark when there's data for only one student (instead of 100% and 0%).
+    const valueText = sum > 1 ? `${value}%` : (value === 100 ? '✔' : '')
     return (
       <td style={tableStyle} title={ratingDescription}>
         <div className='center'>
-          <div className='summary-cell-value'>{value}%</div>
+          <div className='summary-cell-value'>{ valueText }</div>
         </div>
       </td>
     )

--- a/js/reducers/rubric-reducer.js
+++ b/js/reducers/rubric-reducer.js
@@ -10,7 +10,7 @@ export function rubricReducer (state = INITIAL_RUBRIC_STATE, action) {
       const report = action.response.report
       const activities = report.type === 'Investigation' ? [ report.children ] : [ report ]
       const nextState = activities.reduce((_state, act) => {
-        return _state.set(act.rubric_url, Map(act.rubric))
+        return act.rubric ? _state.set(act.rubric_url, Map(act.rubric)) : _state
       }, state)
       return nextState
     case REQUEST_RUBRIC:

--- a/js/reducers/rubric-reducer.js
+++ b/js/reducers/rubric-reducer.js
@@ -7,11 +7,11 @@ const INITIAL_RUBRIC_STATE = Map({})
 export function rubricReducer (state = INITIAL_RUBRIC_STATE, action) {
   switch (action.type) {
     case RECEIVE_DATA:
-      const activities = action.response.report.children || []
+      const report = action.response.report
+      const activities = report.type === 'Investigation' ? [ report.children ] : [ report ]
       const nextState = activities.reduce((_state, act) => {
-        return _state.set(act.rubric_url, act.rubric)
+        return _state.set(act.rubric_url, Map(act.rubric))
       }, state)
-
       return nextState
     case REQUEST_RUBRIC:
       // NOOP for now.


### PR DESCRIPTION
1. Rubric Box: pretty simple visual tweak - when there's data for only one student, use check mark instead of 100% and 0%. It's useful in Portal view where we display this icon and box for every student separately.

2. Rubric reducers - it seems to me that `RECEIVE_DATA` was totally broken. It didn't work for sequences (as they're not supported), it didn't do anything for activities (as it was going through activity children=sections that had no rubric information). In case of Activity, everything was set in LOAD_RUBRIC action anyway. I'm actually adding support of sequences, so I had to fix it, so the map is correct and error isn't thrown in another place. BTW, @knowuh, what's the purpose of this RECEIVE_DATA handler? Do we need it at all? I feel that we don't, as it was broken before and things were working more or less.