### PR TITLE
Replacing dummy answer cell with a generic answer icon

### DIFF
--- a/css/dashboard/generic-answer.less
+++ b/css/dashboard/generic-answer.less
@@ -1,0 +1,8 @@
+@import "./helpers";
+
+.genericAnswer {
+  .cell();
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/css/dashboard/helpers.less
+++ b/css/dashboard/helpers.less
@@ -24,6 +24,7 @@
   line-height: @row-height;
   padding: @row-padding;
   border: @cell-border;
+  flex-grow: 1;
 }
 
 .nowrap {

--- a/css/dashboard/short-answer.less
+++ b/css/dashboard/short-answer.less
@@ -1,6 +1,6 @@
 @import "./helpers";
 
-.answerCell {
+.shortAnswer {
   .cell();
   flex: 1;
   white-space: normal;

--- a/js/components/dashboard/activity-answers.js
+++ b/js/components/dashboard/activity-answers.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import ProgressBar from './progress-bar'
-import AnswerCell from './answer-cell'
+import GenericAnswer from './generic-answer'
 
 import css from '../../../css/dashboard/activity-answers.less'
 
@@ -17,7 +17,7 @@ export default class ActivityAnswers extends PureComponent {
         }
         {
           expanded && studentAnswers.map((a, idx) =>
-            <AnswerCell key={idx} answer={a} showFullAnswer={showFullAnswers} />
+            <GenericAnswer key={idx} answer={a} />
           )
         }
       </div>

--- a/js/components/dashboard/generic-answer.js
+++ b/js/components/dashboard/generic-answer.js
@@ -1,0 +1,17 @@
+import React, { PureComponent } from 'react'
+
+import css from '../../../css/dashboard/generic-answer.less'
+
+export default class GenericAnswerCell extends PureComponent {
+  render () {
+    const { answer } = this.props
+    return (
+      <div className={css.genericAnswer}>
+        {
+          answer &&
+          <i className='icomoon-radio-unchecked' />
+        }
+      </div>
+    )
+  }
+}

--- a/js/components/dashboard/short-answer.js
+++ b/js/components/dashboard/short-answer.js
@@ -1,18 +1,19 @@
 import React, { PureComponent } from 'react'
 
-import css from '../../../css/dashboard/answer-cell.less'
+import css from '../../../css/dashboard/short-answer.less'
 
-export default class AnswerCell extends PureComponent {
+export default class ShortAnswer extends PureComponent {
   render () {
     const { answer, showFullAnswer } = this.props
     let answerText = ''
     if (answer) {
+      // TODO: Show an actual icon and answer text
       answerText = showFullAnswer ? 'randomized answer '.repeat(Math.random() * 50) : '[ans icon]'
     } else {
       answerText = showFullAnswer ? 'No Answer' : ''
     }
     return (
-      <div className={css.answerCell + ' ' + (showFullAnswer ? css.fullAnswer : '')}>
+      <div className={css.shortAnswer + ' ' + (showFullAnswer ? css.fullAnswer : '')}>
         {
           answerText
         }


### PR DESCRIPTION
A very simple component that shows an icon when there's any answer. This is the default cell now, but I renamed the existing `AnswerCell` to `ShortAnswer`, since it should be a useful basis for that in the future.

http://portal-report.concord.org/branch/generic-icons/index.html?dashboard=true