### PR TITLE
Use offering URL as fallback when reportUrl is not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language:
   - node_js
   - ruby
 node_js:
-  - 6
+  - node
 install:
   - travis_retry gem install s3_website -v 3.4.0
   - travis_retry yarn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1531,6 +1531,12 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "cheerio": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
@@ -4364,6 +4370,12 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -6688,6 +6700,63 @@
         }
       }
     },
+    "nock": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.3.tgz",
+      "integrity": "sha512-FBgnx25er2ly7KBr0Est5F0z5g+lnyr6a72vZI1KMi7nTL4ojU6XpFhlrfw6CXRdnT2FA5i8exHiT1uVNUM1qA==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "chai": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+          "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+          "dev": true,
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "check-error": "^1.0.1",
+            "deep-eql": "^3.0.0",
+            "get-func-name": "^2.0.0",
+            "pathval": "^1.0.0",
+            "type-detect": "^4.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+          "dev": true,
+          "requires": {
+            "type-detect": "^4.0.0"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -7216,6 +7285,12 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.16",
@@ -8039,6 +8114,12 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "mocha": "^3.2.0",
+    "nock": "^9.3.3",
     "postcss-loader": "^1.2.1",
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.6.2",

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai'
+import { beforeEach, afterEach, describe, it } from 'mocha'
+import { dom } from './test_helper'
+import nock from 'nock'
+import { fetchReportData } from '../js/api'
+
+describe('api helper', () => {
+  afterEach(() => {
+    dom.reconfigure({ url: 'https://example.com/' })
+    nock.cleanAll()
+  })
+
+  describe('fetchReportData', () => {
+    const okResponse = { message: 'OK' }
+
+    beforeEach(() => {
+      nock('https://portal.com/')
+        .get('/offerings/123').reply(200, { weDontWantToReceiveThisOne: 123 })
+        .get('/reports/123').reply(200, okResponse)
+    })
+
+    describe('when reportUrl URL param is present', () => {
+      beforeEach(() => {
+        dom.reconfigure({ url: 'https://example.com/?reportUrl=https://portal.com/reports/123&offering=https://portal.com/offerings/123' })
+      })
+      it('should use it to download report data', async () => {
+        const resp = await fetchReportData()
+        expect(resp).to.eql(okResponse)
+      })
+    })
+
+    describe('when reportUrl URL param is not available, but there is offering URL', () => {
+      beforeEach(() => {
+        dom.reconfigure({ url: 'https://example.com/?offering=https://portal.com/offerings/123' })
+      })
+      it('should use offering URL to generate report API URL and use it to download report data', async () => {
+        const resp = await fetchReportData()
+        expect(resp).to.eql(okResponse)
+      })
+    })
+  })
+})


### PR DESCRIPTION
[#158501911]

@scytacki, I've implemented it here, as that's what you seemed to prefer.
Note that we'll need to change Portal soon anyway to support highlighted questions, so we could consider adding `reportUrl` to external reports too. I think we don't do it only for "historical" reasons. It won't have any performance consequences until report actually uses this URL (that it can generate anyway, as that's what we do here). 

Also, when I add `http://localhost:8080/?dashboard=true` as an external report, the final URL is `http://localhost:8080/?dashboard=true?offering=...`. There are two question marks. I think you pointed out this issue recently. That's another reason to modify this Portal code. However, it does not break anything, the browser seems to handle it correctly anyway.

Anyway, this PR ensures that we can start using Dashboard right away.