### PR TITLE
159280307 expand question column

### DIFF
--- a/css/dashboard/activity-answers.less
+++ b/css/dashboard/activity-answers.less
@@ -7,13 +7,19 @@
 
   .answer {
     .cell();
-    flex: 1;
+    transition: @width-transition;
     white-space: normal;
     overflow-y: auto;
     overflow-x: hidden;
+    width: @closed-question-width;
+    &.fullAnswer {
+      width: @expanded-question-width;
+    }
   }
 
   .multChoiceSummary {
     text-align: center;
+    flex-basis: 120px;
+    flex-grow: 1;
   }
 }

--- a/css/dashboard/activity-name.less
+++ b/css/dashboard/activity-name.less
@@ -4,10 +4,10 @@
   transition: @width-transition;
   display: inline-block;
   vertical-align: top;
-  cursor: pointer;
   background: @main-dark;
   color: #fff;
   font-weight: 500;
+  .clickable();
 
   .content {
     .cell();

--- a/css/dashboard/activity-questions.less
+++ b/css/dashboard/activity-questions.less
@@ -9,15 +9,27 @@
     height: 100%;
 
     .questionPrompt {
+      transition: @width-transition;
       .cell();
       .nowrap();
-      flex: 1;
       background: @main-light;
       color: #fff;
-
+      width: @closed-question-width;
+      .clickable();
       &.fullPrompt {
         white-space: normal;
         overflow-y: auto;
+        width: @expanded-question-width;
+      }
+      &.mcSummary {
+        background: @main-light;
+        flex-grow: 1;
+        flex-basis: 120px;
+        font-weight: 100;
+        cursor: default;
+      }
+      &.blankCell {
+        flex-grow: 1;
       }
     }
   }

--- a/css/dashboard/dashboard.less
+++ b/css/dashboard/dashboard.less
@@ -58,7 +58,7 @@
   }
 
   .verticalScrollContainer {
-    width: calc(~"100% -" 2 * @content-padding);
+    width: 100%;
     display: inline-block;
     vertical-align: top;
     overflow-y: auto;

--- a/css/dashboard/expand-students.less
+++ b/css/dashboard/expand-students.less
@@ -13,7 +13,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    height: calc(~"100% -" (@row-outer-height));
+    height: calc(~"100% -" (@row-height));
     border: @cell-border;
     width: @student-name-width;
     box-sizing: border-box;

--- a/css/dashboard/expand-students.less
+++ b/css/dashboard/expand-students.less
@@ -13,9 +13,10 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    height: calc(~"100% -" (@row-outer-height + 2 * @border-width));
+    height: calc(~"100% -" (@row-outer-height));
     border: @cell-border;
-
+    width: @student-name-width;
+    box-sizing: border-box;
     .button {
       width: 120px;
     }

--- a/css/dashboard/helpers.less
+++ b/css/dashboard/helpers.less
@@ -7,11 +7,14 @@
 @student-name-width: 150px;
 @border-width: 1px;
 @cell-border: @border-width solid @main-dark;
-@row-height: 25px;
+@row-height: 40px;
 @row-padding: 8px;
 @row-outer-height: @row-height + 2 * @row-padding + 2 * @border-width;
 @expanded-student-row-height: 200px;
 @expanded-question-prompt-max-height: 100px;
+@expanded-question-width: 350px;
+@closed-question-width: 50px;
+
 
 // Transitions
 @transition-time: 1s;
@@ -21,13 +24,18 @@
 // Mixins
 .cell {
   min-height: @row-height;
-  line-height: @row-height;
   padding: @row-padding;
   border: @cell-border;
+  box-sizing: border-box;
 }
 
 .nowrap {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.clickable {
+  cursor: pointer;
+  font-weight: 500;
 }

--- a/css/dashboard/student-name.less
+++ b/css/dashboard/student-name.less
@@ -2,11 +2,11 @@
 
 .studentName {
   display: flex;
-  cursor: pointer;
   max-width: @student-name-width;
   height: @row-outer-height;
   transition: @height-transition;
-
+  .clickable();
+  
   &:nth-child(even) {
     background: @even-row;
   }

--- a/js/actions/dashboard.js
+++ b/js/actions/dashboard.js
@@ -7,6 +7,8 @@ export const SORT_BY_NAME = 'NAME'
 export const SORT_BY_MOST_PROGRESS = 'MOST_PROGRESS'
 export const SORT_BY_LEAST_PROGRESS = 'LEAST_PROGRESS'
 
+export const SET_QUESTION_EXPANDED = 'SET_QUESTION_EXPANDED'
+
 export function setActivityExpanded (activityId, value) {
   return (dispatch, getState) => {
     dispatch({
@@ -24,6 +26,17 @@ export function setActivityExpanded (activityId, value) {
         )
       }
     }
+  }
+}
+
+export function setQuestionExpanded (questionId, value) {
+  return (dispatch, getState) => {
+    const expanded = getState().getIn(['dashboard', 'expandedQuestions', questionId.toString()])
+    dispatch({
+      type: SET_QUESTION_EXPANDED,
+      questionId,
+      value: !expanded
+    })
   }
 }
 

--- a/js/components/dashboard/activity-answers.js
+++ b/js/components/dashboard/activity-answers.js
@@ -17,22 +17,36 @@ export default class ActivityAnswers extends PureComponent {
   }
 
   render () {
-    const { student, activity, progress, expanded, showFullAnswers, width, multChoiceSummary } = this.props
-    const studentAnswers = activity.get('questions', []).filter(q => q.get('visible')).map(question => ({
-      question,
-      answer: question.get('answers', []).find(answer => answer.get('studentId') === student.get('id'))
-    }))
+    const {
+      student, activity, progress, expanded, showFullAnswers,
+      width, multChoiceSummary, expandedQuestions
+    } = this.props
+    const studentAnswers = activity.get('questions', [])
+      .filter(q => q.get('visible'))
+      .map(question => ({
+        question,
+        answer: question.get('answers', [])
+          .find(answer => answer.get('studentId') === student.get('id'))
+      }))
     return (
       <div className={css.activityAnswers} style={{ minWidth: width, width: width }} data-cy='activityAnswers'>
         {
           !expanded && <ProgressBar progress={progress} />
         }
         {
-          expanded && studentAnswers.map((data, idx) =>
-            <div key={idx} className={css.answer}>
-              <Answer answer={data.answer} showFullAnswer={showFullAnswers} question={data.question} />
-            </div>
-          )
+          expanded && studentAnswers.map((data, idx) => {
+            const question = data.question
+            const questionIsExpanded = expandedQuestions.get(question.get('id').toString())
+            const showFullAnswer = showFullAnswers || questionIsExpanded
+            const anyStudentExpanded = this.props.anyStudentExpanded
+            const showWide = showFullAnswer || anyStudentExpanded
+            const className = css.answer + ' ' + (showWide ? css.fullAnswer : '')
+            return (
+              <div key={idx} className={className}>
+                <Answer answer={data.answer} showFullAnswer={showFullAnswer} question={question} />
+              </div>
+            )
+          })
         }
         {
           expanded && multChoiceSummary &&

--- a/js/components/dashboard/activity-questions.js
+++ b/js/components/dashboard/activity-questions.js
@@ -11,7 +11,7 @@ export default class ActivityQuestions extends PureComponent {
       expandedQuestions
     } = this.props
 
-    const headerSummaryClassName = css.questionPrompt + ' ' + (showFullPrompts ? css.fullPrompt : '')
+    const headerSummaryClassName = css.questionPrompt + ' ' + css.mcSummary + ' ' + (showFullPrompts ? css.fullPrompt : '')
     return (
       <div className={css.activityQuestions} style={{minWidth: width, width}}>
         <div className={css.content}>
@@ -19,26 +19,40 @@ export default class ActivityQuestions extends PureComponent {
             expanded && activity.get('questions').filter(q => q.get('visible')).map(q => {
               const questionIsExpaned = expandedQuestions.get(q.get('id').toString())
               const expanded = showFullPrompts || questionIsExpaned
-              const headerClassName = css.questionPrompt + ' ' + (expanded ? css.fullPrompt : '')
-              return (
-                <div
-                  key={q.get('id')}
-                  className={headerClassName}
-                  onClick={() => {
-                    setQuestionExpanded(q.get('id'), true)
-                  }}>
-                  Q{ q.get('questionNumber') }. { striptags(q.get('prompt')) }
-                </div>
-              )
+              if (expanded) {
+                const headerClassName = `${css.questionPrompt} ${css.fullPrompt}`
+                return (
+                  <div
+                    key={q.get('id')}
+                    className={headerClassName}
+                    onClick={() => {
+                      setQuestionExpanded(q.get('id'), true)
+                    }}>
+                    Q{ q.get('questionNumber') }. { striptags(q.get('prompt')) }
+                  </div>
+                )
+              } else {
+                const headerClassName = css.questionPrompt
+                return (
+                  <div
+                    key={q.get('id')}
+                    className={headerClassName}
+                    onClick={() => {
+                      setQuestionExpanded(q.get('id'), true)
+                    }}>
+                    Q{ q.get('questionNumber') }.
+                  </div>
+                )
+              }
             })
           }
           {
             expanded && multChoiceSummary &&
-            <div className={headerSummaryClassName}>Multiple Choice Correct</div>
+            <div className={headerSummaryClassName}>Correct</div>
           }
           {
             // Fake question prompt, just to add cell with the border.
-            !expanded && <div className={css.questionPrompt} />
+            !expanded && <div className={`${css.questionPrompt} ${css.blankCell}`} />
           }
         </div>
       </div>

--- a/js/components/dashboard/activity-questions.js
+++ b/js/components/dashboard/activity-questions.js
@@ -5,21 +5,36 @@ import css from '../../../css/dashboard/activity-questions.less'
 
 export default class ActivityQuestions extends PureComponent {
   render () {
-    const { activity, expanded, showFullPrompts, width, multChoiceSummary } = this.props
-    const headerClassName = css.questionPrompt + ' ' + (showFullPrompts ? css.fullPrompt : '')
+    const {
+      activity, expanded, showFullPrompts,
+      width, multChoiceSummary, setQuestionExpanded,
+      expandedQuestions
+    } = this.props
+
+    const headerSummaryClassName = css.questionPrompt + ' ' + (showFullPrompts ? css.fullPrompt : '')
     return (
       <div className={css.activityQuestions} style={{minWidth: width, width}}>
         <div className={css.content}>
           {
-            expanded && activity.get('questions').filter(q => q.get('visible')).map(q =>
-              <div key={q.get('id')} className={headerClassName}>
-                Q{ q.get('questionNumber') }. { striptags(q.get('prompt')) }
-              </div>
-            )
+            expanded && activity.get('questions').filter(q => q.get('visible')).map(q => {
+              const questionIsExpaned = expandedQuestions.get(q.get('id').toString())
+              const expanded = showFullPrompts || questionIsExpaned
+              const headerClassName = css.questionPrompt + ' ' + (expanded ? css.fullPrompt : '')
+              return (
+                <div
+                  key={q.get('id')}
+                  className={headerClassName}
+                  onClick={() => {
+                    setQuestionExpanded(q.get('id'), true)
+                  }}>
+                  Q{ q.get('questionNumber') }. { striptags(q.get('prompt')) }
+                </div>
+              )
+            })
           }
           {
             expanded && multChoiceSummary &&
-            <div className={headerClassName}>Multiple Choice Correct</div>
+            <div className={headerSummaryClassName}>Multiple Choice Correct</div>
           }
           {
             // Fake question prompt, just to add cell with the border.

--- a/js/components/dashboard/const-metrics.js
+++ b/js/components/dashboard/const-metrics.js
@@ -1,0 +1,7 @@
+
+export const BOTTOM_MARGIN = 10 // px
+export const COLLAPSED_ACTIVITY_WIDTH = 250 // px
+export const COLLAPSED_ANSWER_WIDTH = 50 // px
+export const FULL_ANSWER_WIDTH = 350 // px
+export const FULL_MC_SUMMARY_WIDTH = 350 // px
+export const COLLAPSED_MC_SUMMARY_WIDTH = 350 // px

--- a/js/components/dashboard/dashboard.js
+++ b/js/components/dashboard/dashboard.js
@@ -88,7 +88,11 @@ export default class Dashboard extends PureComponent {
   }
 
   render () {
-    const { activities, students, studentProgress, expandedStudents, expandedActivities, setActivityExpanded, setStudentExpanded, setStudentsExpanded } = this.props
+    const {
+      activities, students, studentProgress, expandedStudents,
+      expandedActivities, setActivityExpanded, setStudentExpanded,
+      setStudentsExpanded, setQuestionExpanded, expandedQuestions
+    } = this.props
     const anyStudentExpanded = expandedStudents.includes(true)
     const activitiesList = activities.toList().filter(activity => activity.get('visible'))
     return (
@@ -107,9 +111,16 @@ export default class Dashboard extends PureComponent {
             <div className={css.questionPromptsRow + ' ' + (anyStudentExpanded ? css.fullPrompts : '')}>
               {
                 activitiesList.map(a =>
-                  <ActivityQuestions key={a.get('id')} activity={a} width={this.getActivityColumnWidth(a)}
-                    expanded={expandedActivities.get(a.get('id').toString())} showFullPrompts={anyStudentExpanded}
-                    multChoiceSummary={this.shouldShowMultChoiceSummary(a)} />
+                  <ActivityQuestions
+                    key={a.get('id')}
+                    activity={a}
+                    width={this.getActivityColumnWidth(a)}
+                    expanded={expandedActivities.get(a.get('id').toString())}
+                    showFullPrompts={anyStudentExpanded}
+                    multChoiceSummary={this.shouldShowMultChoiceSummary(a)}
+                    setQuestionExpanded={setQuestionExpanded}
+                    expandedQuestions={expandedQuestions}
+                  />
                 )
               }
             </div>

--- a/js/components/dashboard/dashboard.js
+++ b/js/components/dashboard/dashboard.js
@@ -214,5 +214,6 @@ Dashboard.defaultProps = {
   students: List(),
   expandedStudents: Map(),
   expandedActivities: Map(),
+  expandedQuestions: Map(),
   studentProgress: Map()
 }

--- a/js/components/dashboard/dashboard.js
+++ b/js/components/dashboard/dashboard.js
@@ -8,10 +8,14 @@ import { Map, List } from 'immutable'
 
 import css from '../../../css/dashboard/dashboard.less'
 
-const BOTTOM_MARGIN = 10 // px
-const COLLAPSED_ACTIVITY_WIDTH = 250 // px
-const COLLAPSED_ANSWER_WIDTH = 120 // px
-const FULL_ANSWER_WIDTH = 350 // px
+import {
+  BOTTOM_MARGIN,
+  COLLAPSED_ACTIVITY_WIDTH,
+  COLLAPSED_ANSWER_WIDTH,
+  FULL_ANSWER_WIDTH,
+  FULL_MC_SUMMARY_WIDTH,
+  COLLAPSED_MC_SUMMARY_WIDTH
+} from './const-metrics'
 
 export default class Dashboard extends PureComponent {
   constructor (props) {
@@ -77,12 +81,36 @@ export default class Dashboard extends PureComponent {
       (this.shouldShowMultChoiceSummary(activity) ? 1 : 0)
   }
 
+  getNumberOfExpandedQuestions (activity) {
+    const { expandedQuestions, expandedStudents } = this.props
+    const numberOfQuestions = this.getNumberOfActivityColumns(activity)
+    if (expandedStudents.includes(true)) {
+      return numberOfQuestions
+    }
+    return activity.get('questions').filter(q => expandedQuestions.get(q.get('id').toString())).count()
+  }
+
+  getMultChoiceSummaryWidth (activity, collapsed) {
+    if (
+      activity.get('questions') &&
+      activity.get('questions').some(q =>
+        q.get('visible') &&
+        q.get('type') === 'Embeddable::MultipleChoice' &&
+        q.get('scored')
+      )
+    ) {
+      return collapsed ? FULL_MC_SUMMARY_WIDTH : COLLAPSED_MC_SUMMARY_WIDTH
+    }
+    return 0
+  }
+
   getActivityColumnWidth (activity) {
-    const { expandedActivities, expandedStudents } = this.props
+    const { expandedActivities } = this.props
     if (expandedActivities.get(activity.get('id').toString())) {
-      const showFullPrompts = expandedStudents.includes(true)
-      const questionWidth = showFullPrompts ? FULL_ANSWER_WIDTH : COLLAPSED_ANSWER_WIDTH
-      return Math.max(COLLAPSED_ACTIVITY_WIDTH, (this.getNumberOfActivityColumns(activity) * questionWidth)) + 'px'
+      const numberOfExpandedQuestions = this.getNumberOfExpandedQuestions(activity)
+      const numberOfClosedQuestions = this.getNumberOfActivityColumns(activity) - numberOfExpandedQuestions
+      const width = numberOfClosedQuestions * COLLAPSED_ANSWER_WIDTH + numberOfExpandedQuestions * FULL_ANSWER_WIDTH
+      return Math.max(COLLAPSED_ACTIVITY_WIDTH, width) + 'px'
     }
     return COLLAPSED_ACTIVITY_WIDTH + 'px'
   }
@@ -94,6 +122,8 @@ export default class Dashboard extends PureComponent {
       setStudentsExpanded, setQuestionExpanded, expandedQuestions
     } = this.props
     const anyStudentExpanded = expandedStudents.includes(true)
+    const anyQuestionExpanded = expandedQuestions.includes(true)
+    const showTallQuestionHeader = anyStudentExpanded || anyQuestionExpanded
     const activitiesList = activities.toList().filter(activity => activity.get('visible'))
     return (
       <div className={css.dashboard}>
@@ -108,7 +138,7 @@ export default class Dashboard extends PureComponent {
                 )
               }
             </div>
-            <div className={css.questionPromptsRow + ' ' + (anyStudentExpanded ? css.fullPrompts : '')}>
+            <div className={css.questionPromptsRow + ' ' + (showTallQuestionHeader ? css.fullPrompts : '')}>
               {
                 activitiesList.map(a =>
                   <ActivityQuestions
@@ -129,28 +159,48 @@ export default class Dashboard extends PureComponent {
         <div ref={el => { this.verticalScrollingContainer = el }} className={css.verticalScrollContainer}>
           <div className={css.studentNames}>
             {
-              students.map(s =>
-                <StudentName key={s.get('id')} student={s} expanded={expandedStudents.get(s.get('id').toString())} setStudentExpanded={setStudentExpanded} />
-              )
+              students.map(s => {
+                const expandedStudent = expandedStudents.get(s.get('id').toString())
+                const anyQuestionExpanded = expandedQuestions.find(v => v)
+                const expanded = anyQuestionExpanded || expandedStudent
+                return (
+                  <StudentName
+                    key={s.get('id')}
+                    student={s}
+                    expanded={expanded}
+                    setStudentExpanded={setStudentExpanded} />
+                )
+              })
             }
           </div>
           <div ref={el => { this.horizontalScrollingContainer = el }} className={css.horizontalScrollContainer}>
             {
-              students.map(s =>
-                <div key={s.get('id')} className={css.studentAnswersRow + ' ' + (expandedStudents.get(s.get('id').toString()) ? css.fullAnswers : '')} data-cy='studentAnswersRow'>
-                  {
-                    activitiesList.map(a =>
-                      <ActivityAnswers key={a.get('id')} activity={a} student={s}
-                        width={this.getActivityColumnWidth(a)}
-                        expanded={expandedActivities.get(a.get('id').toString())}
-                        showFullAnswers={expandedStudents.get(s.get('id').toString())}
-                        progress={studentProgress.getIn([s.get('id').toString(), a.get('id').toString()])}
-                        multChoiceSummary={this.shouldShowMultChoiceSummary(a)}
-                      />
-                    )
-                  }
-                </div>
-              )
+              students.map(s => {
+                const expandedStudent = expandedStudents.get(s.get('id').toString())
+                const anyQuestionExpanded = expandedQuestions.find(v => v)
+                const expanded = anyQuestionExpanded || expandedStudent
+
+                return (
+                  <div
+                    key={s.get('id')}
+                    className={css.studentAnswersRow + ' ' + (expanded ? css.fullAnswers : '')} data-cy='studentAnswersRow'>
+                    {
+                      activitiesList.map(a =>
+                        <ActivityAnswers key={a.get('id')} activity={a} student={s}
+                          width={this.getActivityColumnWidth(a)}
+                          anyStudentExpanded={anyStudentExpanded}
+                          expanded={expandedActivities.get(a.get('id').toString())}
+                          showFullAnswers={expandedStudents.get(s.get('id').toString())}
+                          progress={studentProgress.getIn([s.get('id').toString(), a.get('id').toString()])}
+                          multChoiceSummary={this.shouldShowMultChoiceSummary(a)}
+                          setQuestionExpanded={setQuestionExpanded}
+                          expandedQuestions={expandedQuestions}
+                        />
+                      )
+                    }
+                  </div>
+                )
+              })
             }
           </div>
         </div>

--- a/js/containers/dashboard/dashboard-app.js
+++ b/js/containers/dashboard/dashboard-app.js
@@ -1,7 +1,13 @@
 import React, { PureComponent } from 'react'
 import { connect } from 'react-redux'
 import { fetchDataIfNeeded, invalidateData } from '../../actions/index'
-import { setActivityExpanded, setStudentExpanded, setStudentsExpanded, setStudentSort } from '../../actions/dashboard'
+import {
+  setActivityExpanded,
+  setStudentExpanded,
+  setStudentsExpanded,
+  setQuestionExpanded,
+  setStudentSort
+} from '../../actions/dashboard'
 import Dashboard from '../../components/dashboard/dashboard'
 import SortByDropdown from '../../components/dashboard/sort-by-dropdown'
 import Header from '../../components/common/header'
@@ -62,7 +68,7 @@ class DashboardApp extends PureComponent {
 
   render () {
     const { initialLoading } = this.state
-    const { error, clazzName, activityTrees, students, lastUpdated, studentProgress, expandedStudents, expandedActivities, setActivityExpanded, setStudentExpanded, setStudentsExpanded, setStudentSort } = this.props
+    const { error, clazzName, activityTrees, students, lastUpdated, studentProgress, expandedStudents, expandedActivities, expandedQuestions, setActivityExpanded, setStudentExpanded, setQuestionExpanded, setStudentsExpanded, setStudentSort } = this.props
     return (
       <div className={css.dashboardApp}>
         <Header lastUpdated={lastUpdated} background='#6fc6da' />
@@ -78,9 +84,11 @@ class DashboardApp extends PureComponent {
               studentProgress={studentProgress}
               expandedActivities={expandedActivities}
               expandedStudents={expandedStudents}
+              expandedQuestions={expandedQuestions}
               setActivityExpanded={setActivityExpanded}
               setStudentExpanded={setStudentExpanded}
               setStudentsExpanded={setStudentsExpanded}
+              setQuestionExpanded={setQuestionExpanded}
               setStudentSort={setStudentSort}
             />
           </div>
@@ -105,7 +113,8 @@ function mapStateToProps (state) {
     activityTrees: dataDownloaded && getActivityTrees(state),
     studentProgress: dataDownloaded && getStudentProgress(state),
     expandedActivities: state.getIn(['dashboard', 'expandedActivities']),
-    expandedStudents: state.getIn(['dashboard', 'expandedStudents'])
+    expandedStudents: state.getIn(['dashboard', 'expandedStudents']),
+    expandedQuestions: state.getIn(['dashboard', 'expandedQuestions'])
   }
 }
 
@@ -116,6 +125,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     setActivityExpanded: (activityId, value) => dispatch(setActivityExpanded(activityId, value)),
     setStudentExpanded: (studentId, value) => dispatch(setStudentExpanded(studentId, value)),
     setStudentsExpanded: (studentIds, value) => dispatch(setStudentsExpanded(studentIds, value)),
+    setQuestionExpanded: (studentId, value) => dispatch(setQuestionExpanded(studentId, value)),
     setStudentSort: (value) => dispatch(setStudentSort(value))
   }
 }

--- a/js/reducers/dashboard-reducer.js
+++ b/js/reducers/dashboard-reducer.js
@@ -1,10 +1,15 @@
 import { Map } from 'immutable'
-import { SET_ACTIVITY_EXPANDED, SET_STUDENT_EXPANDED, SET_STUDENTS_EXPANDED, SET_STUDENT_SORT, SORT_BY_NAME } from '../actions/dashboard'
+import {
+  SET_ACTIVITY_EXPANDED, SET_STUDENT_EXPANDED,
+  SET_STUDENTS_EXPANDED, SET_STUDENT_SORT,
+  SORT_BY_NAME, SET_QUESTION_EXPANDED
+} from '../actions/dashboard'
 
 const INITIAL_DASHBOARD_STATE = Map({
   sortBy: SORT_BY_NAME,
   expandedActivities: Map(),
-  expandedStudents: Map()
+  expandedStudents: Map(),
+  expandedQuestions: Map()
 })
 
 export default function dashboardReducer (state = INITIAL_DASHBOARD_STATE, action) {
@@ -13,6 +18,8 @@ export default function dashboardReducer (state = INITIAL_DASHBOARD_STATE, actio
       return state.setIn(['expandedActivities', action.activityId.toString()], action.value)
     case SET_STUDENT_EXPANDED:
       return state.setIn(['expandedStudents', action.studentId.toString()], action.value)
+    case SET_QUESTION_EXPANDED:
+      return state.setIn(['expandedQuestions', action.questionId.toString()], action.value)
     case SET_STUDENTS_EXPANDED:
       action.studentIds.forEach((studentId) => {
         state = state.setIn(['expandedStudents', studentId.toString()], action.value)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cypress:open": "cypress open",
     "test": "mocha --compilers js:babel-core/register --require ignore-styles --require ./test/test_helper.js 'test/**/*.@(js|jsx)'",
     "test:debug": "mocha --debug-brk --inspect --compilers js:babel-core/register --require ignore-styles --require ./test/test_helper.js 'test/**/*.@(js|jsx)'",
-    "test:watch": "npm run test -- --watch",
+    "test:watch": "npm run test -R spec -- --watch",
     "test:full": "npm run test && npm run cypress:test"
   },
   "devDependencies": {

--- a/test/components/dashboard/activity-questions_spec.js
+++ b/test/components/dashboard/activity-questions_spec.js
@@ -6,17 +6,40 @@ import { fromJS } from 'immutable'
 import ActivityQuestions from '../../../js/components/dashboard/activity-questions'
 
 describe('<ActivityQuestions />', () => {
-  describe('when expanded', () => {
-    it('should render prompts of the visible questions', () => {
-      const prompt1 = '1st question prompt'
-      const prompt2 = '2nd question prompt (not visible)'
-      const activity = fromJS({ questions: [
-        { id: 1, visible: true, prompt: prompt1 },
-        { id: 2, visible: false, prompt: prompt2 }
-      ]})
-      const wrapper = shallow(<ActivityQuestions expanded activity={activity} />)
-      expect(wrapper.contains(prompt1)).to.equal(true)
-      expect(wrapper.contains(prompt2)).to.equal(false)
+  const prompt1 = '1st question prompt'
+  const prompt2 = '2nd question prompt (not visible)'
+  const activity = fromJS({ questions: [
+    { id: 1, visible: true, prompt: prompt1, questionNumber: '1' },
+    { id: 2, visible: false, prompt: prompt2, questionNumber: '2' }
+  ]})
+  const expandedQuestions = fromJS({})
+  describe('when activity is expanded', () => {
+    describe('when questions are not expanded', () => {
+      it('should render prompts of the visible questions', () => {
+        const wrapper = shallow(
+          <ActivityQuestions
+            expanded
+            activity={activity}
+            expandedQuestions={expandedQuestions}
+          />)
+        expect(wrapper.html()).to.contain('Q1.')
+        expect(wrapper.contains('Q2.')).to.equal(false)
+        expect(wrapper.contains(prompt1)).to.equal(false)
+      })
+    })
+    describe('when first question is expanded', () => {
+      it('should render prompts of the visible questions', () => {
+        const expandedQuestions = fromJS({1: true})
+        const wrapper = shallow(
+          <ActivityQuestions
+            expanded
+            activity={activity}
+            expandedQuestions={expandedQuestions}
+          />)
+        expect(wrapper.html()).to.contain('Q1.')
+        expect(wrapper.contains('Q2.')).to.equal(false)
+        expect(wrapper.contains(prompt1)).to.equal(true)
+      })
     })
   })
 })

--- a/test/reducers/dashboard-reducer_spec.js
+++ b/test/reducers/dashboard-reducer_spec.js
@@ -4,13 +4,13 @@ import dashboardReducer from '../../js/reducers/dashboard-reducer'
 import * as types from '../../js/actions/dashboard'
 import { SORT_BY_NAME } from '../../js/actions/dashboard'
 
-
 describe('dashboard reducer', () => {
   it('should return the initial state', () => {
     expect(dashboardReducer(undefined, {}).toJS()).to.eql(
       {
         sortBy: SORT_BY_NAME,
         expandedActivities: {},
+        expandedQuestions: {},
         expandedStudents: {}
       }
     )


### PR DESCRIPTION
This PR allows report viewers to click on question headers (which are now displayed as `Q1.` … `Qn.` when activities are expanded) to open a vertical expansion of that question for all students.

The action and reducer were minimal changes.  Keeping the table cells well aligned involved some changes to CSS and to parent rendering methods. To simplify CSS I switched to `box-sizing: border-box` to eliminate a few computations that to into account padding values.

There will be some discussion about whether this feature makes sense, because as pointed out, all student row heights must be increased to view the question details.

This PR relates to two PT stories:
> Expand a single column on click so that the teacher can see full student answers for all students to that question. [#159280307](https://www.pivotaltracker.com/story/show/159280307)

and 
> Narrow columns to just display Q# and no question starter. [#159280335](https://www.pivotaltracker.com/story/show/159280335)
