### PR TITLE
Added minimal markdown to JSX transform for selected rubric descriptions

### DIFF
--- a/css/report/rubric-box.less
+++ b/css/report/rubric-box.less
@@ -19,6 +19,9 @@
         align-items: center;
         justify-content: center;
       }
+      li {
+        margin-left: 2.25em;
+      }
       .summary-cell-value {
         background-color: hsla(0,0%,100%,0.8);
         padding: 0.25em;

--- a/js/components/report/rubric-box-for-student.js
+++ b/js/components/report/rubric-box-for-student.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import Markdown from 'markdown-to-jsx'
 import { RubricHelper } from '../../util/rubric-helper'
 import '../../../css/report/rubric-box-for-student.less'
 
@@ -9,10 +10,12 @@ export default class RubricBoxForStudent extends PureComponent {
 
     const feedbacks = helper.allFeedback('student').filter(f => !!f).map(f =>
       <tr className='criterion' key={f.key}>
-        <td className='description'>{f.description}</td>
+        <td className='description'><Markdown>{f.description}</Markdown></td>
         <td className='rating'>
           <span className='rating-label'>{f.label}</span>
-          { rubric.showRatingDescriptions && ` - ${f.ratingDescription}` }
+          <Markdown>
+            { rubric.showRatingDescriptions && ` - ${f.ratingDescription}` }
+          </Markdown>
         </td>
       </tr>
     )

--- a/js/components/report/rubric-box.js
+++ b/js/components/report/rubric-box.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import Markdown from 'markdown-to-jsx'
 import colorScale from '../../util/colors'
 
 import '../../../css/report/rubric-box.less'
@@ -113,7 +114,7 @@ export default class RubricBox extends PureComponent {
               criteria.map((crit, critIndex) => {
                 return (
                   <tr key={crit.id}>
-                    <td>{crit.description}</td>
+                    <td><Markdown>{crit.description}</Markdown></td>
                     { isSummaryView
                       ? ratings.map((rating, ratingIndex) => this.renderSummaryRating(crit, critIndex, rating, ratingIndex, ratings.length))
                       : ratings.map(rating => this.renderLearnerRating(crit, rating, learnerId, rubricFeedback))

--- a/package-lock.json
+++ b/package-lock.json
@@ -6824,6 +6824,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-to-jsx": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.7.3.tgz",
+      "integrity": "sha512-P2v286Frc387vQutzD3OX4gUUweeo/BUEfQQybMHywl0F5EaBJf4i/1WHyV4PqpEEartiy8W9tRSJK12JRd2Eg==",
+      "requires": {
+        "prop-types": "^15.5.10",
+        "unquote": "^1.1.0"
+      }
+    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -10570,6 +10579,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "iframe-phone": "^1.1.3",
     "immutable": "^3.7.6",
     "isomorphic-fetch": "^2.2.1",
+    "markdown-to-jsx": "^6.7.3",
     "normalizr": "^3.2.3",
     "query-string": "^5.0.0",
     "react": "^15.3.0",

--- a/public/sample-rubric.json
+++ b/public/sample-rubric.json
@@ -13,17 +13,17 @@
     "criteria": [
         {
             "id": "C1",
+            "description": "Make a claim, _**supported by evidence**_ that indicates that when the population of one organism changes, the pattern of impact on other organisms is based on the types of interactions between the organisms.",
             "nonApplicableRatings" : [ "R2" ],
-            "description": "Make a claim supported by evidence that indicates that when the population of one organism changes, the pattern of impact on other organisms is based on the types of interactions between the organisms.",
             "ratingDescriptions": {
-                "R1": "Student makes a claim supported by evidence that indicates the pattern of impact on both ladybugs and aphids when the population of fire ants changes.",
-                "R2": "Student makes a claim supported by evidence that indicates the pattern of impact on either ladybugs or aphids when the population of fire ants changes.",
-                "R3": "Student makes a claim not supported by evidence or does not make a claim that indicates the pattern of  impact on EITHER ladybugs or aphids when the population of fire ants changes."
+                "R1": "Student makes a claim _supported_ by evidence that indicates the pattern of impact on both ladybugs and aphids when the population of fire ants changes.",
+                "R2": "Student makes a claim **supported** by evidence that indicates the pattern of impact on either ladybugs or aphids when the population of fire ants changes.",
+                "R3": "Student makes a claim _**not supported**_ by evidence or does not make a claim that indicates the pattern of  impact on EITHER ladybugs or aphids when the population of fire ants changes."
             }
         },
         {
             "id": "C2",
-            "description": "Provide reasoning by stating that interactions between organisms (i.e., competitive and predator-prey) are distinguished by patterns in data.",
+            "description": "Provide reasoning:\n\n* by stating that interactions between organisms (i.e., competitive and predator-prey)\n\n* and how they are distinguished by patterns in data.",
             "descriptionForStudent": "Student specific C2 criteria description",
             "ratingDescriptions": {
                 "R1": "Student provides reasoning that describes  predator-prey AND mutually beneficial interactions between fire ants/ladybugs and fire ants/aphids, respectively.",

--- a/test/util/rubric-helper_spec.js
+++ b/test/util/rubric-helper_spec.js
@@ -29,7 +29,7 @@ describe('the rubric helper class', () => {
     describe('when there is no student description', () => {
       it('should always return the default description', () => {
         const criteria = fromJS(rubric.criteria[0])
-        const expected = 'Student makes a claim supported by evidence that indicates the pattern of impact on both ladybugs and aphids when the population of fire ants changes.'
+        const expected = 'Student makes a claim _supported_ by evidence that indicates the pattern of impact on both ladybugs and aphids when the population of fire ants changes.'
 
         const defaultDesc = helper.feedbackDescriptionForCriteria(criteria)
         expect(defaultDesc).to.equal(expected)


### PR DESCRIPTION
[NP/DL]: "Rubric content can use simple markdown formatting."

* Added a React library, `markdown-to-jsx`. Used to convert descriptions in the rubric definition into styled HTML. Uses the markdown syntax.

* Updated the sample rubric with example markdown -- demonstrating text styes (bold, italic) and bullet items following new-line (\n) characters.

PT User Story: https://www.pivotaltracker.com/story/show/160794757
