### PR TITLE
Fix negative value bug in maxScore.

### DIFF
--- a/js/components/report/feedback-options-view.js
+++ b/js/components/report/feedback-options-view.js
@@ -24,6 +24,7 @@ export default class FeedbackOptionsView extends PureComponent {
           <NumericTextField
             className='max-score-input'
             value={maxScore}
+            min={0}
             default={MAX_SCORE_DEFAULT}
             onChange={setMaxScore}
             disabled={!scoreEnabled}

--- a/js/components/report/feedback-options-view.js
+++ b/js/components/report/feedback-options-view.js
@@ -24,7 +24,7 @@ export default class FeedbackOptionsView extends PureComponent {
           <NumericTextField
             className='max-score-input'
             value={maxScore}
-            min={0}
+            min={1}
             default={MAX_SCORE_DEFAULT}
             onChange={setMaxScore}
             disabled={!scoreEnabled}

--- a/js/components/report/numeric-text-field.js
+++ b/js/components/report/numeric-text-field.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react' // eslint-disable-line
 // Numeric text fields DEFAULT value is not
 // the same thing as MAX_SCORE_DEFAULT.
 const DEFAULT_NUMERIC_INPUT_VALUE = 0
+const DEFAULT_NUMERIC_MIN_VALUE = 0
 
 class NumericTextField extends PureComponent {
   constructor (props) {
@@ -26,10 +27,26 @@ class NumericTextField extends PureComponent {
   }
 
   setValue (event) {
-    const defaultValue = this.props.default || DEFAULT_NUMERIC_INPUT_VALUE
-    const newValue = parseInt(this.state.value, 10) || defaultValue
-    const onChange = this.props.onChange
+    const {min, onChange} = this.props
+    const numericValue = parseInt(this.state.value, 10)
     const lastValue = this.props.value
+
+    const defaultValue = typeof this.props.default === 'undefined'
+      ? DEFAULT_NUMERIC_INPUT_VALUE
+      : this.props.default
+
+    const minValue = typeof min === 'undefined'
+      ? DEFAULT_NUMERIC_MIN_VALUE
+      : min
+
+    let newValue = isNaN(numericValue)
+      ? defaultValue
+      : numericValue
+
+    newValue = newValue >= minValue
+      ? newValue
+      : defaultValue
+
     this.setState({value: newValue})
     if ((newValue !== lastValue) && onChange) {
       onChange(newValue)

--- a/test/components/report/numeric-text-field_spec.js
+++ b/test/components/report/numeric-text-field_spec.js
@@ -47,4 +47,10 @@ describe('<NumericTextField /> minValue prop', () => {
     wrapper.find('input').simulate('blur', {})
     expect(wrapper.state('value')).to.equal(-3)
   })
+  it('wont allow zero value when minimum is 1; with default 10', () => {
+    const wrapper = shallow(<NumericTextField default={10} min={1} />)
+    wrapper.find('input').simulate('change', { target: { value: '0' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(10)
+  })
 })

--- a/test/components/report/numeric-text-field_spec.js
+++ b/test/components/report/numeric-text-field_spec.js
@@ -5,52 +5,73 @@ import { shallow } from 'enzyme'
 import NumericTextField from '../../../js/components/report/numeric-text-field'
 
 describe('<NumericTextField /> minValue prop', () => {
-  it('should not allow non-numeric values, and default to 0', () => {
-    const wrapper = shallow(<NumericTextField />)
-    wrapper.find('input').simulate('change', { target: { value: 'x' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(0)
+
+  describe('default behavior with no configuration', () => {
+    it('should not allow non-numeric values, and default to 0', () => {
+      const wrapper = shallow(<NumericTextField />)
+      wrapper.find('input').simulate('change', { target: { value: 'x' } })
+      wrapper.find('input').simulate('blur', {})
+      expect(wrapper.state('value')).to.equal(0)
+    })
+    it('will allow values greater than 0', () => {
+      const wrapper = shallow(<NumericTextField />)
+      wrapper.find('input').simulate('change', { target: { value: '5' } })
+      wrapper.find('input').simulate('blur', {})
+      expect(wrapper.state('value')).to.equal(5)
+    })
+    it('will allow an in-range decimal value. Truncates to integer', () => {
+      const wrapper = shallow(<NumericTextField />)
+      wrapper.find('input').simulate('change', { target: { value: '2.6' } })
+      wrapper.find('input').simulate('blur', {})
+      expect(wrapper.state('value')).to.equal(2)
+    })
   })
-  it('not allow non-numeric values; default to 10 as we specify', () => {
-    const wrapper = shallow(<NumericTextField default={10} />)
-    wrapper.find('input').simulate('change', { target: { value: 'x' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(10)
-  })
-  it('will not allow negative numbers; default to default value', () => {
-    const wrapper = shallow(<NumericTextField default={10} />)
-    wrapper.find('input').simulate('change', { target: { value: '-1' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(10)
-  })
-  it('will not allow numbers less than default (10) as we specify', () => {
-    const wrapper = shallow(<NumericTextField default={10} />)
-    wrapper.find('input').simulate('change', { target: { value: '5' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(5)
-  })
-  it('will not allow negative numbers; with default 10, and min as 0', () => {
-    const wrapper = shallow(<NumericTextField default={10} min={0} />)
-    wrapper.find('input').simulate('change', { target: { value: '-1' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(10)
-  })
-  it('will allow Zero; with default 10, and min as 0', () => {
-    const wrapper = shallow(<NumericTextField default={10} min={0} />)
-    wrapper.find('input').simulate('change', { target: { value: '0' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(0)
-  })
-  it('will allow negative values; with default 10, and min as -10', () => {
-    const wrapper = shallow(<NumericTextField default={10} min={-10} />)
-    wrapper.find('input').simulate('change', { target: { value: '-3' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(-3)
-  })
-  it('wont allow zero value when minimum is 1; with default 10', () => {
-    const wrapper = shallow(<NumericTextField default={10} min={1} />)
-    wrapper.find('input').simulate('change', { target: { value: '0' } })
-    wrapper.find('input').simulate('blur', {})
-    expect(wrapper.state('value')).to.equal(10)
+
+  describe('When default value is set to 10', () => {
+    it('wont allow non-numeric values. Revert to 10', () => {
+      const wrapper = shallow(<NumericTextField default={10} />)
+      wrapper.find('input').simulate('change', { target: { value: 'x' } })
+      wrapper.find('input').simulate('blur', {})
+      expect(wrapper.state('value')).to.equal(10)
+    })
+    it('wont allow negative numbers. Revert to 10', () => {
+      const wrapper = shallow(<NumericTextField default={10} />)
+      wrapper.find('input').simulate('change', { target: { value: '-1' } })
+      wrapper.find('input').simulate('blur', {})
+      expect(wrapper.state('value')).to.equal(10)
+    })
+
+    describe('When min value is set to 0', () => {
+      it('will allow 0.', () => {
+        const wrapper = shallow(<NumericTextField default={10} min={0} />)
+        wrapper.find('input').simulate('change', { target: { value: '0' } })
+        wrapper.find('input').simulate('blur', {})
+        expect(wrapper.state('value')).to.equal(0)
+      })
+      it('wont allow negative numbers; will revert to 10', () => {
+        const wrapper = shallow(<NumericTextField default={10} min={0} />)
+        wrapper.find('input').simulate('change', { target: { value: '-1' } })
+        wrapper.find('input').simulate('blur', {})
+        expect(wrapper.state('value')).to.equal(10)
+      })
+    })
+
+    describe('When min value is set to -10', () => {
+      it('will allow negative values > -10', () => {
+        const wrapper = shallow(<NumericTextField default={10} min={-10} />)
+        wrapper.find('input').simulate('change', { target: { value: '-3' } })
+        wrapper.find('input').simulate('blur', {})
+        expect(wrapper.state('value')).to.equal(-3)
+      })
+    })
+
+    describe('When min value is set to 1', () => {
+      it('wont allow 0. Will revert to 10', () => {
+        const wrapper = shallow(<NumericTextField default={10} min={1} />)
+        wrapper.find('input').simulate('change', { target: { value: '0' } })
+        wrapper.find('input').simulate('blur', {})
+        expect(wrapper.state('value')).to.equal(10)
+      })
+    })
   })
 })

--- a/test/components/report/numeric-text-field_spec.js
+++ b/test/components/report/numeric-text-field_spec.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { shallow } from 'enzyme'
+import NumericTextField from '../../../js/components/report/numeric-text-field'
+
+describe('<NumericTextField /> minValue prop', () => {
+  it('should not allow non-numeric values, and default to 0', () => {
+    const wrapper = shallow(<NumericTextField />)
+    wrapper.find('input').simulate('change', { target: { value: 'x' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(0)
+  })
+  it('not allow non-numeric values; default to 10 as we specify', () => {
+    const wrapper = shallow(<NumericTextField default={10} />)
+    wrapper.find('input').simulate('change', { target: { value: 'x' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(10)
+  })
+  it('will not allow negative numbers; default to default value', () => {
+    const wrapper = shallow(<NumericTextField default={10} />)
+    wrapper.find('input').simulate('change', { target: { value: '-1' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(10)
+  })
+  it('will not allow numbers less than default (10) as we specify', () => {
+    const wrapper = shallow(<NumericTextField default={10} />)
+    wrapper.find('input').simulate('change', { target: { value: '5' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(5)
+  })
+  it('will not allow negative numbers; with default 10, and min as 0', () => {
+    const wrapper = shallow(<NumericTextField default={10} min={0} />)
+    wrapper.find('input').simulate('change', { target: { value: '-1' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(10)
+  })
+  it('will allow Zero; with default 10, and min as 0', () => {
+    const wrapper = shallow(<NumericTextField default={10} min={0} />)
+    wrapper.find('input').simulate('change', { target: { value: '0' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(0)
+  })
+  it('will allow negative values; with default 10, and min as -10', () => {
+    const wrapper = shallow(<NumericTextField default={10} min={-10} />)
+    wrapper.find('input').simulate('change', { target: { value: '-3' } })
+    wrapper.find('input').simulate('blur', {})
+    expect(wrapper.state('value')).to.equal(-3)
+  })
+})


### PR DESCRIPTION
+ add test for NumericTextField

Part of  this PT Story:

'Make default max score 10 instead of 0.'
[#130389079]
https://www.pivotaltracker.com/story/show/130389079