### PR TITLE
Add mocha test for rubric Markdown Support.

### DIFF
--- a/js/components/report/rubric-box.js
+++ b/js/components/report/rubric-box.js
@@ -113,8 +113,8 @@ export default class RubricBox extends PureComponent {
             {
               criteria.map((crit, critIndex) => {
                 return (
-                  <tr key={crit.id}>
-                    <td><Markdown>{crit.description}</Markdown></td>
+                  <tr key={crit.id} id={crit.id}>
+                    <td className='description'><Markdown>{crit.description}</Markdown></td>
                     { isSummaryView
                       ? ratings.map((rating, ratingIndex) => this.renderSummaryRating(crit, critIndex, rating, ratingIndex, ratings.length))
                       : ratings.map(rating => this.renderLearnerRating(crit, rating, learnerId, rubricFeedback))

--- a/test/components/report/rubric-box_spec.js
+++ b/test/components/report/rubric-box_spec.js
@@ -25,4 +25,27 @@ describe('<RubricBox /> disabling non-applicable ratings', () => {
     expect(rubricBox.find("#C1-R2")[0].attribs.disabled).equals('')
     expect(rubricBox.find("#C1-R3")[0].attribs.disabled).undefined
   })
-}) 
+})
+
+describe('<RubricBox /> converting markdown in description fields', () => {
+  it('should convert to HTML', () => {
+    const rubric = sampleRubric
+    const rubricFeedback = {}
+    const updateFeedback = () => null
+    const learnerId = 'id3'
+    const rubricBox = render(<RubricBox
+      rubric={rubric}
+      rubricFeedback={rubricFeedback}
+      rubricChange={updateFeedback}
+      learnerId={learnerId}
+    />)
+
+    // Verify the input rubric includes expected markdown:
+    expect(rubric.criteria[0].description)
+      .to.include('_**supported by evidence**_')
+
+    // Verify the Markdown in our description gets converted to HTML tags:
+    expect(rubricBox.find('tr#C1 td.description').html())
+      .to.include('<em><strong>supported by evidence</strong></em>')
+  })
+})


### PR DESCRIPTION
Add a simple Mocha test to verify rubric definitions can include Markdown, which will be rendered using the correct HTML tags in the report.

PT Story:
[#161133513]
https://www.pivotaltracker.com/story/show/161133513