### PR TITLE
Simple fix to ensure expanded content fits within the window viewport

### DIFF
--- a/css/dashboard/dashboard.less
+++ b/css/dashboard/dashboard.less
@@ -4,6 +4,8 @@
 .dashboard {
   width: 100%;
   padding: @content-padding;
+  box-sizing: border-box;
+  overflow: auto;
 
   .headers {
     display: flex;
@@ -20,7 +22,7 @@
     width: calc(~"100% -" @student-name-width + 2 * @content-padding);
     white-space: nowrap;
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto;
 
     .questionPromptsRow {
       display: flex;
@@ -53,7 +55,7 @@
     vertical-align: top;
     white-space: nowrap;
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto;
   }
 
   .verticalScrollContainer {
@@ -61,6 +63,7 @@
     display: inline-block;
     vertical-align: top;
     overflow-y: auto;
-    overflow-x: hidden;
+    overflow-x: auto;
+    margin-bottom: 10px;
   }
 }

--- a/js/components/dashboard/dashboard.js
+++ b/js/components/dashboard/dashboard.js
@@ -38,6 +38,7 @@ export default class Dashboard extends PureComponent {
   }
   componentDidUpdate(prevProps) {
     if (!_timeout && prevProps.expandedStudents !== this.props.expandedStudents) {
+      // timer used for fixing vertical container resizing after expanded data is displayed
       _timeout = window.setTimeout(this.onResize, 2000);
     }
   }
@@ -55,10 +56,10 @@ export default class Dashboard extends PureComponent {
 
   onResize () {
     // Make sure that the verticalScrollContainer fits the window height.
-    console.log("resize");
-    _timeout = null;
     const bb = this.verticalScrollingContainer.getBoundingClientRect()
     this.verticalScrollingContainer.style.height = (window.innerHeight - bb.y - BOTTOM_MARGIN) + 'px'
+    // clear timer
+    _timeout = null;
   }
 
   onHorizontalContainerScroll () {

--- a/js/components/dashboard/dashboard.js
+++ b/js/components/dashboard/dashboard.js
@@ -17,6 +17,8 @@ import {
   MC_SUMMARY_APPROX_WIDTH
 } from './const-metrics'
 
+let _timeout = null;
+
 export default class Dashboard extends PureComponent {
   constructor (props) {
     super(props)
@@ -34,6 +36,11 @@ export default class Dashboard extends PureComponent {
     this.activityHeaders.addEventListener('scroll', this.onHeadersScroll)
     this.onResize()
   }
+  componentDidUpdate(prevProps) {
+    if (!_timeout && prevProps.expandedStudents !== this.props.expandedStudents) {
+      _timeout = window.setTimeout(this.onResize, 2000);
+    }
+  }
 
   componentWillUnmount () {
     window.removeEventListener('resize', this.onResize)
@@ -48,6 +55,8 @@ export default class Dashboard extends PureComponent {
 
   onResize () {
     // Make sure that the verticalScrollContainer fits the window height.
+    console.log("resize");
+    _timeout = null;
     const bb = this.verticalScrollingContainer.getBoundingClientRect()
     this.verticalScrollingContainer.style.height = (window.innerHeight - bb.y - BOTTOM_MARGIN) + 'px'
   }


### PR DESCRIPTION
There's a lot going on in the code to handle scrolling in different places so I've taken a light approach here to ensure that the content should all be visible and scrollbars should always appear in line with request from Trudi.

The addition of a timeout is undesirable - but without it, the bottom of the vertical scroll panel will be flush with the bottom of the page until the page is resized, then it jumps up a small amount when resized. I think @pjanik you worked on some of the scrolling and calc logic in the past, would be great to know if you can see a more elegant solution!