### PR TITLE
Fix:  Feedback hyphen causes bullet Markdown

### DIFF
--- a/js/components/report/rubric-box-for-student.js
+++ b/js/components/report/rubric-box-for-student.js
@@ -12,9 +12,11 @@ export default class RubricBoxForStudent extends PureComponent {
       <tr className='criterion' key={f.key}>
         <td className='description'><Markdown>{f.description}</Markdown></td>
         <td className='rating'>
-          <span className='rating-label'>{f.label}</span>
           <Markdown>
-            { rubric.showRatingDescriptions && ` - ${f.ratingDescription}` }
+            { rubric.showRatingDescriptions
+              ? `${f.label.toUpperCase()} – ${f.ratingDescription}`
+              : f.label.toUpperCase()
+            }
           </Markdown>
         </td>
       </tr>


### PR DESCRIPTION
Dan showed a video where the hyphen preceeding freedback is interpreted as
part of markdown.  This code change fixes this by placing the intro
hpyhen outside the markdown block.

[#164439344]

https://www.pivotaltracker.com/story/show/164439344

@DALove1025  -- Please have a look.