### PR TITLE
Fixes crashing when displaying answer-table without selected question.

### DIFF
--- a/js/containers/report/answers-table.js
+++ b/js/containers/report/answers-table.js
@@ -13,11 +13,10 @@ class AnswersTable extends PureComponent {
   }
 
   render () {
-    const {question, answers, hidden, showCompare} = this.props
+    const {question, answers, hidden, showCompare, anonymous} = this.props
     const getLatestFeedback = this.getLatestFeedback.bind(this)
-    const anonymous = this.props.anonymous
-    const scoreEnabled = (!anonymous) && question.get('scoreEnabled')
-    const feedbackEnabled = (!anonymous) && question.get('feedbackEnabled')
+    const scoreEnabled = (!anonymous) && question && question.get('scoreEnabled')
+    const feedbackEnabled = (!anonymous) && question && question.get('feedbackEnabled')
     const feedbackTH = feedbackEnabled ? <th>Feedback</th> : null
     const scoreTH = scoreEnabled ? <th>Score</th> : null
     const selectTH = showCompare ? <th className='select-header'>Select</th> : null

--- a/test/components/dashboard/answer-table_spec.js
+++ b/test/components/dashboard/answer-table_spec.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { fromJS } from 'immutable'
+import { Provider } from 'react-redux'
+import { renderIntoDocument, findRenderedDOMComponentWithClass } from 'react-addons-test-utils'
+import AnswersTable from '../../../js/containers/report/answers-table'
+
+describe('<AnswersTable />', () => {
+  const question = fromJS({
+    scoreEnabled: true,
+    feedbackEnabled: true
+  })
+  const hidden = false
+  const showCompare = false
+  const anonymous = false
+  const answers = fromJS([])
+  const state = {}
+  const store = { getState: () => fromJS(state), subscribe: () => {} }
+  const params = { hidden, showCompare, anonymous, question, answers }
+
+  describe('with a question', () => {
+    it('should render <AnswersTable> with Score and Feedback text', () => {
+      const component = renderIntoDocument(
+        <Provider store={store} >
+          <AnswersTable {...params} />
+        </Provider>
+      )
+      const found = findRenderedDOMComponentWithClass(component, 'answers-table')
+      expect(found.textContent).to.match(/Student/)
+      expect(found.textContent).to.match(/Response/)
+      expect(found.textContent).to.match(/Score/)
+      expect(found.textContent).to.match(/Feedback/)
+    })
+  })
+
+  describe('With out a question', () => {
+    const question = null
+    const params = { hidden, showCompare, anonymous, question, answers }
+
+    it('should render <AnswersTable> without Score or Feedback text', () => {
+      const component = renderIntoDocument(
+        <Provider store={store} >
+          <AnswersTable {...params} />
+        </Provider>
+      )
+      const found = findRenderedDOMComponentWithClass(component, 'answers-table')
+      expect(found.textContent).to.match(/Student/)
+      expect(found.textContent).to.match(/Response/)
+      expect(found.textContent).not.to.match(/Score/)
+      expect(found.textContent).not.to.match(/Feedback/)
+    })
+  })
+})


### PR DESCRIPTION
The app was crashing when the question detail box is being closed while showing student work.

It seems the question prop becomes null somewhere in the viewheirarchy when the close button is pressed.

A simple null check on in the  answer-table rendering stops the bug.

I added tests for the container that fail without the null check.

[#164583438]

https://www.pivotaltracker.com/story/show/164583438