### PR TITLE
Add S3 upload to rubric authoring

### DIFF
--- a/css/authoring/s3-upload.less
+++ b/css/authoring/s3-upload.less
@@ -1,0 +1,23 @@
+.s3Details {
+  input {
+    width: 500px;
+    margin: 5px;
+  }
+  button {
+    margin: 10px;
+    font-size: 1.2em;
+  }
+  .s3-status {
+    font-weight: bold;
+    font-size: 0.85em;
+  }
+  .url {
+    margin-top: 20px;
+    font-size: 1.1em;
+  }
+  .help {
+    margin-top: 30px;
+    font-size: 0.8em;
+  }
+}
+

--- a/js/components/authoring/rubric-form.js
+++ b/js/components/authoring/rubric-form.js
@@ -233,12 +233,13 @@ class RubricForm extends PureComponent {
       this.form.executeSubmit()
     }
   }
-  
+
   renderRubricForm () {
     const { rubric, updateRubric } = this.props
     return (
       <div>
         <Formik
+          enableReinitialize // so update of initialValues reinitializes the form
           initialValues={rubric}
           onSubmit={updateRubric}
           ref={node => (this.form = node)}
@@ -249,10 +250,10 @@ class RubricForm extends PureComponent {
                 <h3> General options </h3>
                 <label> ID: </label>
                 <Field name='id' />
-  
+
                 <label> Reference URL: </label>
                 <Field name='referenceURL' />
-  
+
                 <label> Show rating descriptions: </label>
                 <Field
                   name='showRatingDescriptions'
@@ -264,16 +265,16 @@ class RubricForm extends PureComponent {
                   name='scoreUsingPoints'
                   component='input'
                   type='checkbox' checked={values.scoreUsingPoints} />
-  
+
                 <label> Criteria label:</label>
                 <Field name='criteriaLabel' />
-  
+
                 <label> Criteria Label for student: </label>
                 <Field name='criteriaLabelForStudent' />
-  
+
                 <label> Fiedback label for students: </label>
                 <Field name='feedbackLabelForStudent' />
-  
+
               </div>
 
               <div className='rating-section'>
@@ -324,7 +325,6 @@ class RubricForm extends PureComponent {
                   </div>
                 )}
               />
-              <button className='big' type='submit'>Update</button>
             </Form>
           )}
         />

--- a/js/components/authoring/s3-upload.js
+++ b/js/components/authoring/s3-upload.js
@@ -1,0 +1,227 @@
+import React, { PureComponent } from 'react'
+import config from '../../config'
+import { s3Url, s3Upload } from '../../util/s3-helpers'
+
+import '../../../css/authoring/s3-upload.less'
+
+// Keys used to obtain dat from URL or local storage.
+const RESOURCE_NAME = 'rubric'
+const USERNAME = 'username'
+const S3_ACCESS = 's3AccessKey'
+const S3_SECRET = 's3SecretKey'
+
+const getStatusTxt = (msg) => `[${(new Date()).toLocaleTimeString()}] ${msg}`
+
+class S3Upload extends PureComponent {
+  constructor (props) {
+    super(props)
+    this.state = {
+      resourceName: config(RESOURCE_NAME) || '',
+      username: config(USERNAME) || window.localStorage.getItem(USERNAME) || '',
+      s3AccessKey: config(S3_ACCESS) || window.localStorage.getItem(S3_ACCESS) || '',
+      // Don't let users set S3 Secret Key using URL, so they don't share it by accident.
+      s3SecretKey: window.localStorage.getItem(S3_SECRET) || '',
+      s3ActionInProgress: false,
+      s3Status: ''
+    }
+
+    this.handleInputChange = this.handleInputChange.bind(this)
+    this.uploadJSONToS3 = this.uploadJSONToS3.bind(this)
+    this.loadJSONFromS3 = this.loadJSONFromS3.bind(this)
+  }
+
+  get s3FeaturesAvailable () {
+    const { s3ActionInProgress, resourceName, username, s3AccessKey, s3SecretKey } = this.state
+    return !s3ActionInProgress && resourceName && username && s3AccessKey && s3SecretKey
+  }
+
+  get resourceFileName () {
+    const { resourceName } = this.state
+    if (!resourceName) {
+      return null
+    }
+    return resourceName.endsWith('.json') ? resourceName : `${resourceName}.json`
+  }
+
+  get resourceUrl () {
+    const { username } = this.state
+    if (!username || !this.resourceFileName) {
+      return null
+    }
+    return s3Url({dir: username, filename: this.resourceFileName})
+  }
+
+  componentDidMount () {
+    if (this.resourceUrl) {
+      this.loadJSONFromS3()
+    }
+  }
+
+  async loadJSONFromS3 () {
+    const { onLoad } = this.props
+
+    this.setState({
+      s3ActionInProgress: true,
+      s3Status: getStatusTxt('Loading JSON...')
+    })
+    try {
+      const response = await window.fetch(this.resourceUrl)
+      if (response.status !== 200) {
+        this.setState({
+          s3ActionInProgress: false,
+          s3Status: getStatusTxt('Loading JSON failed')
+        })
+        return
+      }
+      try {
+        const textResponse = await response.text()
+        onLoad(textResponse)
+        JSON.parse(textResponse) // parse just to check for errors and potentially display error msg
+        this.setState({
+          s3ActionInProgress: false,
+          s3Status: getStatusTxt('Loading JSON: success!')
+        })
+      } catch (parseError) {
+        this.setState({
+          s3ActionInProgress: false,
+          s3Status: getStatusTxt('Loading JSON failed: unexpected/malformed content')
+        })
+      }
+    } catch (fetchError) {
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt('Loading JSON failed: fetch error')
+      })
+    }
+  }
+
+  uploadJSONToS3 () {
+    const {username} = this.state
+    const {resourceJSON} = this.props
+
+    this.setState({
+      s3ActionInProgress: true,
+      s3Status: getStatusTxt('Uploading JSON to S3...')
+    })
+    const {s3AccessKey, s3SecretKey} = this.state
+    s3Upload({
+      dir: username,
+      filename: this.resourceFileName,
+      accessKey: s3AccessKey,
+      secretKey: s3SecretKey,
+      body: resourceJSON,
+      contentType: 'application/json',
+      cacheControl: 'no-cache'
+    }).then((url) => {
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt('Uploading JSON to S3: success!'),
+        resourceUrl: url
+      })
+    }).catch(err => {
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt(err)
+      })
+    })
+  }
+
+  handleInputChange (event) {
+    const value = event.target.value
+    const name = event.target.name
+    switch (name) {
+      case 'resourceName':
+        this.setState({resourceName: value})
+        window.localStorage.setItem(RESOURCE_NAME, value)
+        break
+      case 'username':
+        this.setState({username: value})
+        window.localStorage.setItem(USERNAME, value)
+        break
+      case 's3AccessKey':
+        this.setState({s3AccessKey: value})
+        window.localStorage.setItem(S3_ACCESS, value)
+        break
+      case 's3SecretKey':
+        this.setState({s3SecretKey: value})
+        window.localStorage.setItem(S3_SECRET, value)
+        break
+    }
+  }
+
+  render () {
+    const { resourceName, username, s3AccessKey, s3SecretKey, s3Status } = this.state
+    const resource = RESOURCE_NAME.charAt(0).toUpperCase() + RESOURCE_NAME.slice(1)
+    const resourceUrl = this.resourceUrl
+    const exampleLink = window.location.href + '?rubric=test&username=joe&s3AccessKey=ABCXYZ'
+    return (
+      <div>
+        <div className='s3Details'>
+          <table>
+            <tbody>
+              <tr className='name'>
+                <td>{ resource } Name</td>
+                <td>
+                  <input
+                    value={resourceName}
+                    type='text'
+                    name='resourceName'
+                    onChange={this.handleInputChange}
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>Username</td>
+                <td><input value={username} type='text' name='username' onChange={this.handleInputChange} /></td>
+              </tr>
+              <tr>
+                <td>S3 Access Key</td>
+                <td><input value={s3AccessKey} type='text' name='s3AccessKey' onChange={this.handleInputChange} /></td>
+              </tr>
+              <tr>
+                <td>S3 Secret Key</td>
+                <td><input value={s3SecretKey} type='text' name='s3SecretKey' onChange={this.handleInputChange} /></td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <button disabled={!this.s3FeaturesAvailable} data-cy='save' onClick={this.uploadJSONToS3}>
+              Save
+            </button>
+            <button disabled={!username || !resourceName} data-cy='load' onClick={this.loadJSONFromS3}>
+              Load
+            </button>
+          </p>
+          <div className='s3Status'>
+            {s3Status}
+          </div>
+          {
+            resourceUrl &&
+            <div className='url'>
+              { resource } URL: <a href={resourceUrl} target='_blank'>{ resourceUrl }</a>
+            </div>
+          }
+          <div className='help'>
+            <p>This authoring page supports following URL parameters:</p>
+            <ul>
+              <li>rubric</li>
+              <li>username</li>
+              <li>s3AccessKey</li>
+            </ul>
+            <p>They can be used to set the initial value of text inputs above. E.g.:</p>
+
+            <p><a href={exampleLink} target='_blank'>{exampleLink}</a></p>
+
+            <p>Authors should use IAM account that belongs this group:</p>
+
+            <a href='https://console.aws.amazon.com/iam/home#/groups/Rubric-S3-Access' target='_blank'>https://console.aws.amazon.com/iam/home#/groups/Rubric-S3-Access</a>
+
+            <p>It limits access to their own directory based on the username (IAM username and username on the authoring page have to match).</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default S3Upload

--- a/js/rubric-test.js
+++ b/js/rubric-test.js
@@ -1,7 +1,7 @@
 import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
-import RubricTest from './containers/authoring/rubric-test'
+import RubricTest from './components/authoring/rubric-test'
 
 render(
   <RubricTest />,

--- a/js/util/s3-helpers.js
+++ b/js/util/s3-helpers.js
@@ -1,0 +1,34 @@
+import * as AWS from 'aws-sdk/index'
+
+export const S3_BUCKET = 'models-resources'
+export const S3_DIR_PREFIX = 'rubric-resources'
+export const S3_REGION = 'us-east-1'
+export const CLOUDFRONT_URL = 'https://models-resources.concord.org'
+
+export function s3Upload ({dir, filename, accessKey, secretKey, body, contentType = '', cacheControl = ''}) {
+  const s3 = new AWS.S3({
+    region: S3_REGION,
+    accessKeyId: accessKey,
+    secretAccessKey: secretKey,
+  })
+  const key = `${S3_DIR_PREFIX}/${dir}/${filename}`
+  return s3.upload({
+    Bucket: S3_BUCKET,
+    Key: key,
+    Body: body,
+    ACL: 'public-read',
+    ContentType: contentType,
+    CacheControl: cacheControl
+  }).promise()
+    .then(data => {
+      return `${CLOUDFRONT_URL}/${data.Key}`
+    })
+    .catch(error => {
+      throw(error.message)
+    })
+}
+
+// In fact it returns Cloudfront URL pointing to a given object in S3 bucket.
+export function s3Url ({filename, dir}) {
+  return `${CLOUDFRONT_URL}/${S3_DIR_PREFIX}/${dir}/${filename}`
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -668,6 +668,53 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "aws-sdk": {
+      "version": "2.451.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.451.0.tgz",
+      "integrity": "sha512-ruVK/fnUFHumSgcqVkJTHLS9eWXc8lf14ZW2G6RVR0baj2MMNDS5gxInuy8GM24Exe0GfnDFk6PnPiSuQs4AVQ==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -1439,8 +1486,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "batch": {
       "version": "0.6.1",
@@ -1683,7 +1729,6 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -3985,8 +4030,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "eventsource": {
       "version": "0.1.6",
@@ -5641,8 +5685,7 @@
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-      "dev": true
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -6174,8 +6217,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
       "version": "2.2.1",
@@ -6212,6 +6254,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
       "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "joi": {
       "version": "9.2.0",
@@ -6614,7 +6661,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -6805,7 +6852,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -7854,7 +7901,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -8542,8 +8589,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -9504,8 +9550,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
       "version": "0.13.6",
@@ -12242,6 +12287,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "webpack-dev-server": "^2.11.5"
   },
   "dependencies": {
+    "aws-sdk": "^2.451.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "babel-polyfill": "^6.6.1",

--- a/test/util/s3-helpers_spec.js
+++ b/test/util/s3-helpers_spec.js
@@ -1,0 +1,48 @@
+import { s3Upload, s3Url, CLOUDFRONT_URL, S3_BUCKET, S3_DIR_PREFIX } from '../../js/util/s3-helpers'
+import * as AWS from 'aws-sdk'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { describe, it, beforeEach } from 'mocha'
+
+describe('S3 helpers', () => {
+  describe('s3Upload', () => {
+    beforeEach(() => {
+      AWS.S3.prototype.upload = sinon.spy((params) => {
+        return {
+          promise: () => new Promise(resolve => {
+            resolve({Key: `${params.Key}`})
+          })
+        }
+      })
+    })
+
+    it('should call AWS.S3.upload with correct arguments and return Cloudfront URL', async () => {
+      const params = {
+        dir: 'test',
+        filename: 'test.txt',
+        accessKey: '123',
+        secretKey: 'abc',
+        body: 'test',
+        cacheControl: 'max-age=123',
+        contentType: 'application/test'
+      }
+      const url = await s3Upload(params)
+      const expectedKey = `${S3_DIR_PREFIX}/${params.dir}/${params.filename}`
+      expect(AWS.S3.prototype.upload.calledOnceWithExactly({
+        Bucket: S3_BUCKET,
+        Key: expectedKey,
+        Body: params.body,
+        ACL: 'public-read',
+        ContentType: params.contentType,
+        CacheControl: params.cacheControl
+      })).to.equal(true)
+      expect(url).to.equal(`${CLOUDFRONT_URL}/${expectedKey}`)
+    })
+  })
+
+  describe('s3Url', () => {
+    describe('it should return Cloudfront URL for a given file and directory', () => {
+      expect(s3Url({filename: 'test.abc', dir: 'dir'})).to.equal(`${CLOUDFRONT_URL}/${S3_DIR_PREFIX}/dir/test.abc`)
+    })
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
         ]
       },
       {
-        test: /css\/(common|report)\/.*\.less$/,
+        test: /css\/(common|report|authoring)\/.*\.less$/,
         loader: 'style-loader!css-loader!less-loader'
       },
       {


### PR DESCRIPTION
[#165795459]

Note that this PR is against `editing-form` branch. 

It adds a new tab to Rubric authoring with a simple form that lets you save or load rubric from S3 bucket. I've followed the same patterns that we used in Glossary authoring. Some inputs are stored in local storage or can be provided via URL. If we have enough data to generate rubric URL using URL params, it will be loaded on the page load.

I tried to make this component independent from glossary or rubric, and pretty standalone, so it can be reused in the future if needed. That's why there's `resource` word everywhere there.

I had to make two pretty significant changes in your form @knowuh.
I had to add `forceRenderTabPanel`, so tab views don't get constantly mounted and unmounted, each time we change a tab. It doesn't work too well if tab component has its own state obviously (as it gets lost).

That broke synchronization between forms and JSON editor, so there are a few other changes that fix that. 

I've also removed the "Update" button from the form, as it wasn't visible to me at all. There was auto-save on unmount anyway, so this button was a bit redundant. Unmount used to equal to tab change, but not anymore because of the `forceRenderTabPanel`. That's why I've reimplemented auto-save in a different way.