### PR TITLE
Add rubric migrations and test for migrations.

### DIFF
--- a/js/components/authoring/rubric-form.js
+++ b/js/components/authoring/rubric-form.js
@@ -45,16 +45,23 @@ const MarkdownField = ({value, setValue}) => {
   )
 }
 
-
 const NonApplicableRatings = ({name, values, setFieldValue}) => {
   const ratings = values.ratings
-  const nonApplicableRatings = getIn(values, `${name}.nonApplicableRatings`, [])
+  const fieldPath = `${name}.nonApplicableRatings`
+  const nonApplicableRatings = getIn(values, fieldPath)
+  const fieldValues = ratings.map(r => {
+    const id = r.id
+    if (nonApplicableRatings.indexOf(id) < 0) {
+      return ''
+    }
+    return id
+  })
 
   const nonApplicableRatingSelection = ratings.map((rating, index) => {
-    const checked = nonApplicableRatings.indexOf(rating.id) > -1
-    const valuePath = `${name}.nonApplicableRatings.${index}`
+    const checked = fieldValues.indexOf(rating.id) > -1
+    const valuePath = `${fieldPath}.${index}`
     const setValue = e => {
-      const newValue = e.target.checked ? rating.id : ''
+      const newValue = checked ? '' : rating.id
       setFieldValue(valuePath, newValue)
     }
     return (
@@ -166,11 +173,7 @@ const Criteria = ({name, remove, values, setFieldValue}) => {
   const studentDescriptionName = `${name}.descriptionForStudent`
   const setDescription = v => setFieldValue(descriptionName, v)
   const setStudentDescription = v => {
-    // if (v && v.length > 0) {
     setFieldValue(studentDescriptionName, v)
-    // } else {
-    // setFieldValue(studentDescriptionName, null)
-    // }
   }
   const descriptionValue = getIn(values, descriptionName, 'description')
   const studentDescriptionValue = getIn(values, studentDescriptionName, '')

--- a/js/components/authoring/rubric-test.js
+++ b/js/components/authoring/rubric-test.js
@@ -6,6 +6,7 @@ import sampleRubric from '../../../public/sample-rubric'
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 import RubricForm from './rubric-form'
 import S3Upload from './s3-upload'
+import migrate from '../../core/rubric-migrations'
 
 import 'react-tabs/style/react-tabs.css'
 import '../../../css/authoring/tabs.css'
@@ -31,9 +32,10 @@ const genRFeedbacks = (rubric, numAnswers) => {
 class RubricTest extends PureComponent {
   constructor (props) {
     super(props)
+    const rubric = migrate(sampleRubric)
     this.state = {
-      rubric: sampleRubric,
-      rubricText: JSON.stringify(sampleRubric, null, '  '),
+      rubric: rubric,
+      rubricText: JSON.stringify(rubric, null, '  '),
       learnerId: 'noah123',
       rubricFeedback: {},
       hasBug: false
@@ -49,7 +51,7 @@ class RubricTest extends PureComponent {
     try {
       const newRubric = JSON.parse(value)
       if (newRubric) {
-        this.setState({rubric: newRubric, hasBug: false})
+        this.setState({rubric: migrate(newRubric), hasBug: false})
       }
     } catch (e) {
       console.error(e)

--- a/js/core/rubric-migrations.js
+++ b/js/core/rubric-migrations.js
@@ -1,0 +1,65 @@
+import semver from 'semver'
+
+function notify (message) {
+  console && console.log(message)
+}
+
+function setVersionNumber (rubric, versionString) {
+  rubric.version = versionString
+}
+
+function expandNonApplicableRatings (rubric) {
+  const {ratings, criteria} = rubric
+  criteria.forEach(c => {
+    c.nonApplicableRatings = c.nonApplicableRatings
+      ? c.nonApplicableRatings
+      : []
+    const oldNonApplicable = c.nonApplicableRatings.slice()
+    c.nonApplicableRatings = ratings.map(r => {
+      if (oldNonApplicable.indexOf(r.id) > -1) {
+        return r.id
+      }
+      return ''
+    })
+  })
+}
+
+const migrations = [
+  { version: '1.0.0',
+    migrations: []
+  },
+  {
+    version: '1.1.0',
+    migrations: [
+      expandNonApplicableRatings
+    ]
+  }
+]
+
+function runMigration (rubric, migration) {
+  notify(`migrating rubric to ${migration.version}`)
+  setVersionNumber(rubric, migration.version)
+  for (migration of migration.migrations) {
+    migration(rubric)
+  }
+  return rubric
+}
+
+function skipMigration (migration) {
+  notify(`skipping migration: ${migration.version}`)
+}
+
+export const LastVersion = migrations[migrations.length - 1].version
+
+export default function migrate (rubric) {
+  rubric.reportVersion = rubric.reportVersion ? rubric.reportVersion : '0.0.0'
+
+  for (var m of migrations) {
+    if (semver.gte(rubric.reportVersion, m.version)) {
+      skipMigration(m)
+    } else {
+      runMigration(rubric, m)
+    }
+  }
+  return rubric
+}

--- a/public/sample-rubric.json
+++ b/public/sample-rubric.json
@@ -1,7 +1,7 @@
 {
     "id": "RBK1",
-    "formatVersion": "1.0.0",
-    "version": "12",
+    "version": "1.0.0",
+    "versionNumber": "12",
     "updatedMsUTC": 1519424087822,
     "originUrl": "http://concord.org/rubrics/RBK1.json",
     "referenceURL": "https://docs.google.com/document/d/1wkrWtaT8gjDVyttf0nsa90XUhogyiXOJjC36aQGNLMA/edit?usp=sharing",

--- a/test/core/rubric-migration_spec.js
+++ b/test/core/rubric-migration_spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import fs from 'fs'
+import migrate, {LastVersion} from '../../js/core/rubric-migrations'
+const exampleRubricPath = './public/sample-rubric.json'
+
+describe('the migrating rubric', () => {
+  const originalVersion = '1.0.0'
+  const rubric = JSON.parse(fs.readFileSync(exampleRubricPath))
+  const migrated = migrate(JSON.parse(fs.readFileSync(exampleRubricPath)))
+
+  it('Should read the example rubric', () => {
+    expect(rubric).to.have.property('criteria')
+  })
+
+  describe('the version number', () => {
+    expect(rubric.version).to.eql(originalVersion)
+    expect(migrated.version).to.eql(LastVersion)
+  })
+
+  describe('criteria.nonApplicableRatings', () => {
+
+    describe('the original rubric json should be sparse', () => {
+      const na = rubric.criteria[0].nonApplicableRatings
+      expect(na.length).to.eql(1)
+    })
+
+    describe('the current rubric json should include values for all ratings', () => {
+      const na = migrated.criteria[0].nonApplicableRatings
+      const expectedLength = rubric.ratings.length
+      expect(na.length).to.eql(expectedLength)
+    })
+  })
+})


### PR DESCRIPTION
While fixing [#165857915]  "An author can not uncheck non-applicable rating"

https://www.pivotaltracker.com/n/projects/736901/stories/165857915

This migration generates an verbose representation of the `nonApplicableRatings` key of the `criteria` objects. The value is an array of strings which should match the ratings keys. In the past this was a sparse array of key names. Now it is redundantly including a string for every rating, using the rating id as a value if the rating should be skipped.

This is a confusing format, and only temporary while Kiley gets her work done.

I am working on the next migration, but it will not be backwards compatible, and will use the rating ids as boolean properties of the `nonApplicableRatings` values.  It will be in its own branch and PR because I don't want the authors using a schema that isn't available on production reports.