### PR TITLE
Move refresh button to the sticky header

### DIFF
--- a/css/report/report.less
+++ b/css/report/report.less
@@ -56,6 +56,12 @@
         display: inline-block;
         width: auto;
       }
+
+      .last-updated {
+        font-size: 0.6em;
+        text-align: right;
+        margin: 3px 3px 0 0;
+      }
     }
   }
 

--- a/js/components/report/report.js
+++ b/js/components/report/report.js
@@ -80,14 +80,14 @@ export default class Report extends PureComponent {
   }
 
   onShowHideNamesClick = (isAnonymous) => {
-    const { reportTree, setAnonymous, trackEvent } = this.props
+    const { setAnonymous, trackEvent } = this.props
     const trackAction = isAnonymous ? 'Show Student Names' : 'Hide Student Names'
     trackEvent('Report', trackAction, '')
     return setAnonymous(!isAnonymous)
   }
 
   renderControls () {
-    const { report, reportTree, hideUnselectedQuestions, showUnselectedQuestions, setAnonymous, trackEvent } = this.props
+    const { report, lastUpdated, isFetching, onRefreshClick } = this.props
     const isAnonymous = report.get('anonymous')
     const nowShowing = report.get('nowShowing')
     const buttonText = (nowShowing === 'class') ? 'Print student reports' : 'Print'
@@ -100,6 +100,8 @@ export default class Report extends PureComponent {
           <Button onClick={this.onShowUnselectedClick}>Show all</Button>
           <Button onClick={() => this.onShowHideNamesClick(isAnonymous)}>{isAnonymous ? 'Show names' : 'Hide names'}</Button>
           <Button onClick={this.printStudentReports}>{buttonText}</Button>
+          {onRefreshClick && <Button onClick={onRefreshClick} disabled={isFetching}>Refresh</Button>}
+          {lastUpdated && <div className='last-updated'>Last updated at {new Date(lastUpdated).toLocaleTimeString()} </div>}
         </div>
       )
     } else {

--- a/js/containers/report/report-app.js
+++ b/js/containers/report/report-app.js
@@ -35,7 +35,8 @@ class ReportApp extends PureComponent {
   }
 
   renderReport () {
-    const { report, reportTree, hideUnselectedQuestions, showUnselectedQuestions, setNowShowing, setAnonymous, trackEvent } = this.props
+    const { report, reportTree, hideUnselectedQuestions, showUnselectedQuestions, setNowShowing, setAnonymous,
+      trackEvent, lastUpdated, isFetching } = this.props
     return <Report
       report={report}
       reportTree={reportTree}
@@ -44,6 +45,9 @@ class ReportApp extends PureComponent {
       setNowShowing={setNowShowing}
       setAnonymous={setAnonymous}
       trackEvent={trackEvent}
+      lastUpdated={lastUpdated}
+      isFetching={isFetching}
+      onRefreshClick={this.handleRefreshClick}
     />
   }
 
@@ -62,7 +66,7 @@ class ReportApp extends PureComponent {
     const { report, error, isFetching, lastUpdated } = this.props
     return (
       <div className='report-app'>
-        <Header lastUpdated={lastUpdated} isFetching={isFetching} onRefreshClick={this.handleRefreshClick} />
+        <Header />
         <div className='report' style={{ opacity: isFetching ? 0.3 : 1 }}>
           {report && this.renderReport()}
           {error && <DataFetchError error={error} />}


### PR DESCRIPTION
[#164604410]

This PR moves location of the refresh button.

Old header:
<img width="555" alt="Screenshot 2019-05-14 at 13 58 16" src="https://user-images.githubusercontent.com/767857/57696140-5eb6a480-7650-11e9-9461-d27e153b69d1.png">
New header:
<img width="618" alt="Screenshot 2019-05-14 at 13 58 24" src="https://user-images.githubusercontent.com/767857/57696144-5fe7d180-7650-11e9-8127-2219b16e52eb.png">
