### PR TITLE
Always assume HTTPS protocol for CC activity URLs while querying Firestore

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -49,7 +49,13 @@ function receivePortalData(rawPortalData: IPortalRawData) {
       type: RECEIVE_PORTAL_DATA,
       response: rawPortalData
     });
-    const resourceUrl = rawPortalData.offering.activity_url;
+    let resourceUrl = rawPortalData.offering.activity_url.toLowerCase();
+    if (resourceUrl.match(/http:\/\/.*\.concord\.org/)) {
+      // Ensure that CC LARA URLs always start with HTTPS. Teacher could have assigned HTTP version to a class long
+      // time ago, but all the resources stored in Firestore assume that they're available under HTTPS now.
+      // We can't replace all the HTTP protocols to HTTPS not to break dev environments.
+      resourceUrl = resourceUrl.replace("http", "https");
+    }
     const source = parseUrl(resourceUrl).hostname.replace(/\./g, "_");
     if (source === "fake_authoring_system") { // defined in data/offering-data.json
       // Use fake data.


### PR DESCRIPTION
@scytacki, what do you think about this fix?
Firestore doesn't let us query using substrings or regex.
I couldn't replace all HTTP with HTTPS not to break local dev env which is usually using HTTP. Also, if we think about it, this problem is specific to LARA only and its history. Other systems could use HTTP or HTTPS, and perhaps we shouldn't do assumptions about it.

Another solution would be to try a different protocol if the first one fails.


