### PR TITLE
Hot-fix: CSS (boostrap modal) regression in CompareView

### DIFF
--- a/css/report/bootstrap-components.less
+++ b/css/report/bootstrap-components.less
@@ -10,7 +10,6 @@
 .modal-content {
   color: @color;
   font: @font;
-
   a {
     color: #479492;
     text-decoration: none;
@@ -48,5 +47,9 @@
 .modal {
   &.fade {
     opacity: 1;
+    .modal-dialog {
+      -webkit-transform: translate(0, 0);
+      transform: translate(0, 0);
+    }
   }
 }

--- a/css/report/bootstrap-components.less
+++ b/css/report/bootstrap-components.less
@@ -38,3 +38,15 @@
 .modal-footer {
   text-align: left;
 }
+
+.modal-backdrop {
+  &.fade {
+    opacity: 0.5;
+  }
+}
+
+.modal {
+  &.fade {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
bootstrap and react-bootstrap were updated along with React 16.
Animation interfaces must have broken, because faded components never
un-fade.

This fix is a little bit of a hack because it doesn't restore animation, it just makes
sets faded bootstrap components to opaque instead of transparent.

https://www.pivotaltracker.com/story/show/166907544
[#166907544] fix-compare-view

Compare view no longer works.

This is a regression from v1.9.0 to v1.10.0, probably a result of updating React to 16.