### PR TITLE
[#166240880] FireStore: Save assignment level report settings

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -51,6 +51,7 @@ function receivePortalData(rawPortalData: IPortalRawData) {
       response: rawPortalData
     });
     let resourceUrl = rawPortalData.offering.activity_url.toLowerCase();
+    const resourceLinkId = rawPortalData.offering.id.toString();
     if (resourceUrl.match(/http:\/\/.*\.concord\.org/)) {
       // Ensure that CC LARA URLs always start with HTTPS. Teacher could have assigned HTTP version to a class long
       // time ago, but all the resources stored in Firestore assume that they're available under HTTPS now.
@@ -114,7 +115,14 @@ function receivePortalData(rawPortalData: IPortalRawData) {
       });
     }
     // Create Firestore document oberserver for settings:
-    db.doc(reportSettingsFireStorePath(rawPortalData))
+    const fireStorePath = reportSettingsFireStorePath(
+      { resourceLinkId,
+        contextId: rawPortalData.contextId,
+        platformId: rawPortalData.platformId,
+        platformUserId: rawPortalData.platformUserId
+      }
+    );
+    db.doc(fireStorePath)
       .onSnapshot(
         (snapshot)   => {
           dispatch({

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -4,12 +4,13 @@ import fakeSequenceStructure from "../data/sequence-structure.json";
 import fakeAnswers from "../data/answers.json";
 import {Dispatch} from "redux";
 import { Map } from "immutable";
-import { IPortalRawData, IResponse } from "../api";
+import { IPortalRawData, IResponse, reportSettingsFireStorePath } from "../api";
 
 export const REQUEST_PORTAL_DATA = "REQUEST_PORTAL_DATA";
 export const RECEIVE_RESOURCE_STRUCTURE = "RECEIVE_RESOURCE_STRUCTURE";
 export const RECEIVE_ANSWERS = "RECEIVE_ANSWERS";
 export const RECEIVE_PORTAL_DATA = "RECEIVE_PORTAL_DATA";
+export const RECEIVE_USER_SETTINGS = "RECEIVE_USER_SETTINGS";
 export const FETCH_ERROR = "FETCH_ERROR";
 export const SET_NOW_SHOWING = "SET_NOW_SHOWING";
 export const SET_ANONYMOUS = "SET_ANONYMOUS";
@@ -112,6 +113,20 @@ function receivePortalData(rawPortalData: IPortalRawData) {
         }));
       });
     }
+    // Create Firestore document oberserver for settings:
+    db.doc(reportSettingsFireStorePath(rawPortalData))
+      .onSnapshot(
+        (snapshot)   => {
+          dispatch({
+            type: RECEIVE_USER_SETTINGS,
+            response: snapshot.data()
+          });
+        },
+        (err: Error) => {
+          // tslint:disable-next-line no-console
+          console.error(err);
+        }
+      );
   };
 }
 

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -1,4 +1,9 @@
-import { fetchPortalDataAndAuthFirestore, updateReportSettings, APIError, fetchRubric } from "./api";
+import {
+  fetchPortalDataAndAuthFirestore,
+  updateReportSettings,
+  APIError,
+  fetchRubric
+} from "./api";
 
 // This middleware is executed only if action includes .callAPI object.
 // It calls API action defined in callAPI.type.
@@ -6,8 +11,9 @@ import { fetchPortalDataAndAuthFirestore, updateReportSettings, APIError, fetchR
 // If action fails and callAPI.errorAction is defined, it will be called with the error response object.
 export default store => next => action => {
   if (action.callAPI) {
-    const { type, data, successAction, errorAction } = action.callAPI;
-    callApi(type, data)
+    const state = store.getState();
+    const { type, data, successAction, errorAction} = action.callAPI;
+    callApi(type, data, state)
       .then(response => successAction && next(successAction(response)))
       .catch(error => {
         if (error instanceof APIError && errorAction) {
@@ -30,12 +36,12 @@ export default store => next => action => {
   return next(action);
 };
 
-function callApi(type, data) {
+function callApi(type, data, state) {
   switch (type) {
     case "fetchPortalDataAndAuthFirestore":
       return fetchPortalDataAndAuthFirestore();
     case "updateReportSettings":
-      return updateReportSettings(data);
+      return updateReportSettings(data, state.get("report").toJS());
     case "fetchRubric":
       return fetchRubric(data);
   }

--- a/js/api.ts
+++ b/js/api.ts
@@ -11,9 +11,10 @@ const FIREBASE_APP = "report-service-dev";
 const FAKE_FIRESTORE_JWT = "fake firestore JWT";
 
 export interface ILTIPartial {
-  platformId: string;
+  platformId: string;      // portal
   platformUserId: string;
-  contextId: string; // class hash
+  contextId: string;       // class hash
+  resourceLinkId?: string;  // offering ID
 }
 
 export interface IPortalRawData extends ILTIPartial{
@@ -167,23 +168,20 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
 }
 
 export function reportSettingsFireStorePath(LTIData: ILTIPartial) {
-  const {platformId, platformUserId, contextId} = LTIData;
+  const {platformId, platformUserId, resourceLinkId} = LTIData;
   const sourceId = platformId.replace(/https?:\/\//, "");
   // NP: 2019-06-28 In the case of fake portal data we will return
   // `/sources/fake.portal/user_settings/1/offering/class123` which has
   // special FireStore Rules to allow universal read and write to that document.
   // Allows us to test limited report settings with fake portal data, sans JWT.
-  return `/sources/${sourceId}/user_settings/${platformUserId}/offering/${contextId}`;
+  return `/sources/${sourceId}/user_settings/${platformUserId}/resource_link/${resourceLinkId}`;
 }
 
 export function updateReportSettings(update: any, state: ILTIPartial) {
   const path = reportSettingsFireStorePath(state);
-  return new Promise( (resolve, reject) => {
-    firebase.firestore()
+  return firebase.firestore()
       .doc(path)
       .set(update, {merge: true});
-    resolve();
-  });
 }
 
 // The api-middleware calls this function when we need to load rubric in from a rubricUrl.

--- a/js/api.ts
+++ b/js/api.ts
@@ -177,6 +177,10 @@ export function reportSettingsFireStorePath(LTIData: ILTIPartial) {
   return `/sources/${sourceId}/user_settings/${platformUserId}/resource_link/${resourceLinkId}`;
 }
 
+// The updateReportSettings API middleware calls out to the FireStore API.
+// `firestore().path().set()` returns a Promise that will resolve immediately.
+// This due to a feature in the FireStore API called "latency compensation."
+// See: https://firebase.google.com/docs/firestore/query-data/listen
 export function updateReportSettings(update: any, state: ILTIPartial) {
   const path = reportSettingsFireStorePath(state);
   return firebase.firestore()

--- a/js/data/report-settings.json
+++ b/js/data/report-settings.json
@@ -1,0 +1,10 @@
+{
+  "anonymous_report": true,
+  "visibility_filter": {
+    "active": true,
+    "questions": [
+      "open_response_60",
+      "multiple_choice_19"
+    ]
+  }
+}

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -198,10 +198,14 @@ function report(state = INITIAL_REPORT_STATE, action) {
     case SET_NOW_SHOWING:
       return state.set("nowShowing", action.value);
 
-    // The following actions only trigger API middleware hooks that call out
-    // to firebase. The results of the calls are handled by RECEIVE_USER_SETTINGS
-    // case SET_ANONYMOUS: No direct reducer action, only API middleware.
-    // case SET_QUESTION_SELECTED: No direct reducer action, only API middleware.
+    // The following actions trigger API middleware that invokes the FireStore API.
+    // The results of middleware invocation are handled by the `RECEIVE_USER_SETTINGS` action.
+    // These FireStore API calls return immediately.
+    // See: https://firebase.google.com/docs/firestore/query-data/listen
+
+    // Two NO-OP Named actions only call the FireStore middleware:
+    // case SET_ANONYMOUS: ; // No direct reducer action, only API middleware.
+    // case SET_QUESTION_SELECTED: ; // No direct reducer action, only API middleware.
     case HIDE_UNSELECTED_QUESTIONS:
       return hideUnselectedQuestions(state);
     case SHOW_UNSELECTED_QUESTIONS:


### PR DESCRIPTION
We save the teachers settings for the offering at this FireStore path:
/sources/${sourceId}/user_settings/${platformUserId}/offering/${contextId}

We dispatch all user settings updates to FireStore via the middleware API.
The RECEIVE_USER_SETTINGS action is the one which changes the active store.

Even when the network is disabled (wifi disconnected) the FireStore API dispatch method
works, and the RECEIVE_USER_SETTINGS is reliably called with valid parameters.

The FireStore rules are setup to allow unfettered access to:
`/sources/fake.portal/user_settings/1/offering/class123`

This allows us to test the report settings with fake portal data, without a valid JWT.

https://www.pivotaltracker.com/story/show/166240880