### PR TITLE
Do not modify the `platform_id` here in the report view code.

### DIFF
--- a/js/api.ts
+++ b/js/api.ts
@@ -147,7 +147,7 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
             offering: offeringData,
             classInfo: classData,
             userType: verifiedFirebaseJWT.claims.user_type,
-            platformId: verifiedFirebaseJWT.claims.platform_id.replace(/\/$/, ""), // remove trailing slash if present
+            platformId: verifiedFirebaseJWT.claims.platform_id,
             platformUserId: verifiedFirebaseJWT.claims.platform_user_id.toString(),
             contextId: classInfo.class_hash
           })


### PR DESCRIPTION
1. Technically it's OK to have trailing slashes in field values.
2. The platform is the authority on `platform_id` and it should be trusted here.

Full discussion can be found in the
[PT story](https://www.pivotaltracker.com/story/show/166241318)

[#166241318]