### PR TITLE
Save feedback data to Portal

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -363,7 +363,7 @@ export function updateQuestionFeedback(answerId: string, feedback: any) {
   };
 }
 
-export function updateActivityFeedback(activityId: string, platformStudentId: string, feedback: any) {
+export function updateActivityFeedback(activityId: string, activityIndex: number, platformStudentId: string, feedback: any) {
   const feedbackData = mappedCopy(feedback, {});
   return {
     type: API_CALL,
@@ -373,7 +373,8 @@ export function updateActivityFeedback(activityId: string, platformStudentId: st
       data: {
         feedback: feedbackData,
         activityId,
-        platformStudentId
+        platformStudentId,
+        activityIndex
       },
     },
   };
@@ -386,24 +387,30 @@ export function updateQuestionFeedbackSettings(questionId: string, settings: any
       type: API_UPDATE_FEEDBACK_SETTINGS,
       errorAction: fetchError,
       data: {
-        questionSettings: {
-          [questionId]: settings
+        settings: {
+          questionSettings: {
+            [questionId]: settings
+          }
         }
       }
     }
   };
 }
 
-export function updateActivityFeedbackSettings(activityId: string, settings: any) {
+export function updateActivityFeedbackSettings(activityId: string, activityIndex: number, settings: any) {
   return {
     type: API_CALL,
     callAPI: {
       type: API_UPDATE_FEEDBACK_SETTINGS,
       errorAction: fetchError,
       data: {
-        activitySettings: {
-          [activityId]: settings
-        }
+        settings: {
+          activitySettings: {
+            [activityId]: settings
+          }
+        },
+        activityId,
+        activityIndex
       }
     }
   };
@@ -416,7 +423,9 @@ export function saveRubric(rubricContent: any) {
       type: API_UPDATE_FEEDBACK_SETTINGS,
       errorAction: fetchError,
       data: {
-        rubric: rubricContent
+        settings: {
+          rubric: rubricContent
+        }
       }
     }
   };

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -169,6 +169,7 @@ function watchFireStoreReportSettings(rawPortalData: IPortalRawData, dispatch: D
 
 function watchFirestoreFeedbackSettings(rawPortalData: IPortalRawData, dispatch: Dispatch) {
   const path = feedbackSettingsFirestorePath(rawPortalData.sourceId);
+  const rubricUrl = rawPortalData.offering.rubric_url;
   let rubricRequested = false;
   db.collection(path)
     .where("contextId", "==", rawPortalData.contextId)
@@ -182,8 +183,8 @@ function watchFirestoreFeedbackSettings(rawPortalData: IPortalRawData, dispatch:
         });
       }
       // Note that this should be called even if snapshot is empty (no feedback settings saved yet).
-      if (!rubricRequested) {
-        dispatch(requestRubric(rawPortalData.offering.rubric_url) as any as AnyAction);
+      if (rubricUrl && !rubricRequested) {
+        dispatch(requestRubric(rubricUrl) as any as AnyAction);
         rubricRequested = true;
       }
     }, fireStoreError(RECEIVE_FEEDBACK_SETTINGS, dispatch));

--- a/js/actions/rubric.js
+++ b/js/actions/rubric.js
@@ -18,15 +18,15 @@ const receiveRubric = (data) => {
 export function requestRubric(rubricUrl) {
   return (dispatch, getState) => {
     const state = getState();
-    const cachedRubrics = state.getIn(["feedback", "settings", "rubrics"]);
-    if (!cachedRubrics || !cachedRubrics.has(rubricUrl)) {
+    const cachedRubric = state.getIn(["feedback", "settings", "rubric"]);
+    if (!cachedRubric) {
       dispatch({
         type: REQUEST_RUBRIC,
         callAPI: {
           type: API_FETCH_RUBRIC,
           data: rubricUrl,
           successAction: receiveRubric,
-        },
+        }
       });
     }
   };

--- a/js/api.ts
+++ b/js/api.ts
@@ -268,6 +268,13 @@ export function updateFeedbackSettings(data: any, state: IStateReportPartial) {
       }
     });
   }
+  if (settings.rubric) {
+    updateReportSettingsInPortal({
+      rubric_v2: {
+        rubric: settings.rubric
+      }
+    });
+  }
 
   // Then, send it to Firestore.
   settings.platformId = state.platformId;

--- a/js/components/report/activity-feedback-options.js
+++ b/js/components/report/activity-feedback-options.js
@@ -18,29 +18,33 @@ export default class ActivityFeedbackOptions extends PureComponent {
   }
 
   enableText(event) {
+    const { activityIndex, updateActivityFeedbackSettings } = this.props;
     const activityId = this.props.activity.get("id");
-    this.props.updateActivityFeedbackSettings(
-      activityId, {
+    updateActivityFeedbackSettings(
+      activityId, activityIndex, {
         textFeedbackEnabled: event.target.checked,
       });
   }
 
   enableRubric(event) {
+    const { activityIndex, updateActivityFeedbackSettings } = this.props;
     const activityId = this.props.activity.get("id");
-    this.props.updateActivityFeedbackSettings(
-      activityId, {
+    updateActivityFeedbackSettings(
+      activityId, activityIndex, {
         useRubric: event.target.checked,
       });
   }
 
   setMaxScore(value) {
+    const { activityIndex, updateActivityFeedbackSettings } = this.props;
     const activityId = this.props.activity.get("id");
-    this.props.updateActivityFeedbackSettings(activityId, {
+    updateActivityFeedbackSettings(activityId, activityIndex, {
       maxScore: value,
     });
   }
 
   changeScoreType(newV) {
+    const { activityIndex, updateActivityFeedbackSettings } = this.props;
     const activityId = this.props.activity.get("id").toString();
     const newFlags = { scoreType: newV };
     if (newV !== NO_SCORE) {
@@ -49,7 +53,7 @@ export default class ActivityFeedbackOptions extends PureComponent {
     if (isAutoScoring(newV)) {
       newFlags.maxScore = this.props.computedMaxScore;
     }
-    this.props.updateActivityFeedbackSettings(activityId, newFlags);
+    updateActivityFeedbackSettings(activityId, activityIndex, newFlags);
   }
 
   render() {

--- a/js/components/report/activity-feedback-row.js
+++ b/js/components/report/activity-feedback-row.js
@@ -76,7 +76,7 @@ export default class ActivityFeedbackRow extends PureComponent {
     score = parseInt(score, 10) || 0;
     feedback = feedback || "";
     const complete = hasBeenReviewed || false;
-    rubricFeedback = rubricFeedback || {};
+    rubricFeedback = rubricFeedback || null;
 
     return {
       score,

--- a/js/components/report/activity-feedback-row.js
+++ b/js/components/report/activity-feedback-row.js
@@ -18,10 +18,10 @@ export default class ActivityFeedbackRow extends PureComponent {
   }
 
   changeFeedback(newData) {
-    const { activityId, studentId, updateActivityFeedback } = this.props;
+    const { activityId, studentId, activityIndex, updateActivityFeedback } = this.props;
     const oldData = this.fieldValues();
     const newRecord = Object.assign({}, oldData, newData);
-    updateActivityFeedback(activityId, studentId, newRecord);
+    updateActivityFeedback(activityId, activityIndex, studentId, newRecord);
   }
 
   scoreChange(e) {

--- a/js/containers/report/activity-feedback-panel.js
+++ b/js/containers/report/activity-feedback-panel.js
@@ -153,6 +153,7 @@ class ActivityFeedbackPanel extends PureComponent {
             />
             <ActivityFeedbackOptions
               activity={this.props.activity}
+              activityIndex={activityIndex}
               showText={showText}
               scoreType={scoreType}
               maxScore={maxScore}
@@ -244,10 +245,10 @@ function makeMapStateToProps() {
   };
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    updateActivityFeedback: (activityId, platformStudentId, feedback) => dispatch(updateActivityFeedback(activityId, platformStudentId, feedback)),
-    updateActivityFeedbackSettings: (activityId, feedbackFlags) => dispatch(updateActivityFeedbackSettings(activityId, feedbackFlags)),
+    updateActivityFeedback: (activityId, activityIndex, platformStudentId, feedback) => dispatch(updateActivityFeedback(activityId, activityIndex, platformStudentId, feedback)),
+    updateActivityFeedbackSettings: (activityId, activityIndex, feedbackFlags) => dispatch(updateActivityFeedbackSettings(activityId, activityIndex, feedbackFlags)),
   };
 };
 

--- a/js/selectors/activity-feedback-selectors.js
+++ b/js/selectors/activity-feedback-selectors.js
@@ -29,16 +29,16 @@ const keyFor = (activity, student) => `${activity.get("id")}-${student.get("id")
 const isNumeric = obj => obj !== undefined && typeof (obj) === "number" && !isNaN(obj);
 
 // If a student has no feedback yet, use this template:
-const newFeedback = (activityMap, studentMap) => {
+const newFeedback = (activityMap, studentMap, activityStarted) => {
   const student = studentMap.toJS();
-  const key = keyFor(activityMap, studentMap);
   const newFeedbackRecord = {
     student,
     platformStudentId: student.id,
     feedback: "",
     score: 0,
     activityId: activityMap.get("id"),
-    hasBeenReviewed: false
+    hasBeenReviewed: false,
+    activityStarted
   };
   return fromJS(newFeedbackRecord);
 };
@@ -53,12 +53,13 @@ const addRealName = (student) => {
 const activityFeedbackFor = (activity, student, feedbacks, progress) => {
   const key = keyFor(activity, student);
   const found = feedbacks.get(key);
+  const activityStarted = progress.getIn([student.get("id"), activity.get("id")]) > 0;
   if (found) {
     return found
       .set("student", student)
-      .set("activityStarted", progress.getIn([student.get("id"), activity.get("id")]) > 0);
+      .set("activityStarted", activityStarted);
   }
-  return newFeedback(activity, student);
+  return newFeedback(activity, student, activityStarted);
 };
 
 const formatStudents = (students) => students


### PR DESCRIPTION
We have to do that, so the progress table in Portal keeps working.

Note that Portal progress table displays only activity-level feedback, so this data is being sent there.

This PR is relying on new Portal API:
https://github.com/concord-consortium/rigse/pull/681
