### PR TITLE
Simplify activity feedback updates, send only changed value

### DIFF
--- a/js/components/report/activity-feedback-row.js
+++ b/js/components/report/activity-feedback-row.js
@@ -19,9 +19,7 @@ export default class ActivityFeedbackRow extends PureComponent {
 
   changeFeedback(newData) {
     const { activityId, studentId, activityIndex, updateActivityFeedback } = this.props;
-    const oldData = this.fieldValues();
-    const newRecord = Object.assign({}, oldData, newData);
-    updateActivityFeedback(activityId, activityIndex, studentId, newRecord);
+    updateActivityFeedback(activityId, activityIndex, studentId, newData);
   }
 
   scoreChange(e) {

--- a/js/containers/report/activity.js
+++ b/js/containers/report/activity.js
@@ -12,7 +12,7 @@ import {
   makeGetAutoScores,
   makeGetComputedMaxScore,
 } from "../../selectors/activity-feedback-selectors";
-import { isAutoScoring, MANUAL_SCORE, MAX_SCORE_DEFAULT } from '../../util/scoring-constants'
+import { isAutoScoring, MANUAL_SCORE, MAX_SCORE_DEFAULT } from "../../util/scoring-constants";
 
 import "../../../css/report/activity.less";
 

--- a/js/containers/report/activity.js
+++ b/js/containers/report/activity.js
@@ -12,11 +12,7 @@ import {
   makeGetAutoScores,
   makeGetComputedMaxScore,
 } from "../../selectors/activity-feedback-selectors";
-
-import {
-  isAutoScoring,
-  MANUAL_SCORE,
-} from "../../util/scoring-constants";
+import { isAutoScoring, MANUAL_SCORE, MAX_SCORE_DEFAULT } from '../../util/scoring-constants'
 
 import "../../../css/report/activity.less";
 
@@ -66,7 +62,7 @@ class Activity extends PureComponent {
     const activityName = activity.get("name");
     const showText = feedbackSettings.get("textFeedbackEnabled");
     const scoreType = feedbackSettings.get("scoreType");
-    const maxScore = scoreType === MANUAL_SCORE ? feedbackSettings.get("maxScore") : computedMaxScore;
+    const maxScore = scoreType === MANUAL_SCORE ? (feedbackSettings.get("maxScore") || MAX_SCORE_DEFAULT) : computedMaxScore;
     const summaryScores = scoreType === MANUAL_SCORE ? scores : Object.values(autoScores.toJS());
     const showScore = scoreType !== "none";
     const useRubric = feedbackSettings.get("useRubric");


### PR DESCRIPTION
[#168148207]

This is related to https://github.com/concord-consortium/rigse/pull/683
and this other PR describes details of the problem better.

Send only updated value. Some fields delay their update, so sending everything all the time could cause unexpected results.