### PR TITLE
Use url parameters to chose FireStore DB source.

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -1,4 +1,4 @@
-import db from "../db";
+import { db } from "../db";
 import fakeSequenceStructure from "../data/sequence-structure.json";
 import fakeAnswers from "../data/answers.json";
 import {AnyAction, Dispatch} from "redux";

--- a/js/api.ts
+++ b/js/api.ts
@@ -9,7 +9,9 @@ import { getActivityStudentFeedbackKey, IActivityFeedbackRecord } from "./util/a
 import * as db from "./db";
 import set = Reflect.set;
 
-const FIREBASE_APP = "report-service-dev";
+const FIREBASE_APP = urlParam("firebase-app") || "report-service-dev";
+db.initializeDB(FIREBASE_APP);
+
 const FAKE_FIRESTORE_JWT = "fake firestore JWT";
 
 export interface ILTIPartial {
@@ -65,7 +67,7 @@ export interface IFirebaseJWT {
   };
 }
 
-const urlParam = (name: string): string | null => {
+function urlParam(name: string): string | null{
   const result = queryString.parse(window.location.search)[name];
   if (typeof result === "string") {
     return result;
@@ -74,7 +76,7 @@ const urlParam = (name: string): string | null => {
   } else {
     return null;
   }
-};
+}
 
 const getPortalBaseUrl = () => {
   const portalUrl = urlParam("class") || urlParam("offering");

--- a/js/db.ts
+++ b/js/db.ts
@@ -1,16 +1,46 @@
 import * as firebase from "firebase";
 import "firebase/firestore";
 
-// Initialize Cloud Firestore through Firebase
-firebase.initializeApp({
-  apiKey: "AIzaSyCvxKWuYDgJ4r4o8JeNAOYusx0aV71_YuE",
-  authDomain: "report-service-dev.firebaseapp.com",
-  databaseURL: "https://report-service-dev.firebaseio.com",
-  projectId: "report-service-dev",
-  storageBucket: "report-service-dev.appspot.com",
-  messagingSenderId: "402218300971",
-  appId: "1:402218300971:web:32b7266ef5226ff7"
-});
+interface IConfig {
+  apiKey: string;
+  authDomain: string;
+  databaseURL: string;
+  projectId: string;
+  storageBucket: string;
+  messagingSenderId: string;
+  appId: string;
+}
+interface IConfigs {
+  [index: string]: IConfig;
+}
+const configurations: IConfigs = {
+  "report-service-dev": {
+    apiKey: "AIzaSyCvxKWuYDgJ4r4o8JeNAOYusx0aV71_YuE",
+    authDomain: "report-service-dev.firebaseapp.com",
+    databaseURL: "https://report-service-dev.firebaseio.com",
+    projectId: "report-service-dev",
+    storageBucket: "report-service-dev.appspot.com",
+    messagingSenderId: "402218300971",
+    appId: "1:402218300971:web:32b7266ef5226ff7"
+  },
+  "report-service-pro": {
+    apiKey: "AIzaSyBmNSa2Uz3DaEwKclsvHPBwfucSmZWAAzg",
+    authDomain: "report-service-pro.firebaseapp.com",
+    databaseURL: "https://report-service-pro.firebaseio.com",
+    projectId: "report-service-pro",
+    storageBucket: "report-service-pro.appspot.com",
+    messagingSenderId: "22386066971",
+    appId: "1:22386066971:web:e0cdec7cb0f0893a8a5abe"
+  }
+};
+
+export let db: firebase.firestore.Firestore;
+
+export function initializeDB(name: string) {
+  const config = configurations[name];
+  firebase.initializeApp(config);
+  db = firebase.firestore();
+}
 
 // Useful only for manual testing Firebase rules.
 const SKIP_SIGN_IN = false;
@@ -24,5 +54,3 @@ export const signInWithToken = (rawFirestoreJWT: string) => {
     return signOutPromise;
   }
 };
-
-export default firebase.firestore();


### PR DESCRIPTION
This PR changes how an App initializes its firebase connection.

The new method looks for a `firebase-app` in the url parameters.  If it doesn't find one, it uses `report-service-dev` by default.

Because DB initialization happens later as a result. The `db` was modified, so that it wouldn't immediately initialize FireStore when loading. 

PT Story "Report should be configurable to run on Production"

[#168486280]
https://www.pivotaltracker.com/story/show/168486280