### PR TITLE
Add tool id param

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -72,7 +72,7 @@ function receivePortalData(rawPortalData: IPortalRawData) {
       // We can't replace all the HTTP protocols to HTTPS not to break dev environments.
       resourceUrl = resourceUrl.replace("http", "https");
     }
-    const source = rawPortalData.sourceId;
+    const source = rawPortalData.sourceKey;
     if (source === "fake.authoring.system") { // defined in data/offering-data.json
       // Use fake data.
       dispatch({
@@ -168,7 +168,7 @@ function watchFireStoreReportSettings(rawPortalData: IPortalRawData, dispatch: D
 }
 
 function watchFirestoreFeedbackSettings(rawPortalData: IPortalRawData, dispatch: Dispatch) {
-  const path = feedbackSettingsFirestorePath(rawPortalData.sourceId);
+  const path = feedbackSettingsFirestorePath(rawPortalData.sourceKey);
   const rubricUrl = rawPortalData.offering.rubric_url;
   let rubricRequested = false;
   db.collection(path)
@@ -191,7 +191,7 @@ function watchFirestoreFeedbackSettings(rawPortalData: IPortalRawData, dispatch:
 }
 
 function watchFirestoreQuestionFeedback(rawPortalData: IPortalRawData, dispatch: Dispatch) {
-  const feedbackFireStorePath = reportQuestionFeedbacksFireStorePath(rawPortalData.sourceId);
+  const feedbackFireStorePath = reportQuestionFeedbacksFireStorePath(rawPortalData.sourceKey);
   let feedbacksQuery = db.collection(feedbackFireStorePath)
     .where("platformId", "==", rawPortalData.platformId)
     .where("resourceLinkId", "==", rawPortalData.resourceLinkId);
@@ -213,7 +213,7 @@ function watchFirestoreQuestionFeedback(rawPortalData: IPortalRawData, dispatch:
 }
 
 function watchFirestoreActivityFeedback(rawPortalData: IPortalRawData, dispatch: Dispatch) {
-  const feedbackFireStorePath = reportActivityFeedbacksFireStorePath(rawPortalData.sourceId);
+  const feedbackFireStorePath = reportActivityFeedbacksFireStorePath(rawPortalData.sourceKey);
   let feedbacksQuery = db.collection(feedbackFireStorePath)
     .where("platformId", "==", rawPortalData.platformId)
     .where("resourceLinkId", "==", rawPortalData.resourceLinkId);

--- a/js/api.ts
+++ b/js/api.ts
@@ -83,7 +83,7 @@ function urlParam(name: string): string | null{
 
 // This matches the make_source_key method in LARA's report_service.rb
 function makeSourceKey(toolId: string): string | null{
-  return toolId.replace(/https?:\/\/([^\/]+)/, "$1")
+  return toolId.replace(/https?:\/\/([^\/]+)/, "$1");
 }
 
 const getPortalBaseUrl = () => {

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -172,7 +172,7 @@ function report(state = INITIAL_REPORT_STATE, action) {
         .set("contextId", data.contextId)
         .set("resourceLinkId", data.offering.id.toString())
         .set("platformId", data.platformId)
-        .set("sourceId", data.sourceId);
+        .set("sourceKey", data.sourceKey);
       return state;
     case RECEIVE_RESOURCE_STRUCTURE:
       data = normalizeResourceJSON(action.response);


### PR DESCRIPTION
This PR addes a new optional tool-id parameter. This parameter makes it possible for developers to configure the external report in their local portal so it uses a unique tool-id. By default the tool-id is taken from the resource url that is being reported on. Which for local development is typically `http://app.lara.docker`.  Since most developers use that same lara domain name it means by default all developers share the same data in firestore.

This PR also renames sourceId to sourceKey. The sourceKey is derived from the toolId, so by using a unique toolId the developer also gets a unique sourceKey.