### PR TITLE
Improve automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ script:
 after_success:
   - ./s3_deploy.sh
 after_script:
-  - ./cc-test-reporter format-coverage -t lcov -o codeclimate.jest.json coverage-jest/lcov.info"
-  - ./cc-test-reporter format-coverage -t lcov -o codeclimate.cypress.json coverage-cypress/lcov.info"
+  - ./cc-test-reporter format-coverage -t lcov -o codeclimate.jest.json coverage-jest/lcov.info
+  - ./cc-test-reporter format-coverage -t lcov -o codeclimate.cypress.json coverage-cypress/lcov.info
   - ./cc-test-reporter sum-coverage -p 2 codeclimate.*.json
   - ./cc-test-reporter upload-coverage
 cache:

--- a/cypress/integration/compare-project.spec.js
+++ b/cypress/integration/compare-project.spec.js
@@ -1,0 +1,19 @@
+import ReportBody from "../support/elements/portal-report/report-body";
+
+describe("Compare or Project", function() {
+  const body = new ReportBody();
+
+  beforeEach(() => {
+      cy.visit("/");
+  });
+
+  it("can open the compare dialog", () => {
+    body.getShowResponses(0).click();
+    // this should check everything (I hope)
+    cy.get(".select-answer-column input").click({multiple: true});
+    cy.get(".select-answer-column [data-cy='button']").first().click();
+    cy.get(".compare-view").should("be.visible");
+    cy.get(".compare-view").should("contain", "Amy Galloway");
+    cy.get(".compare-view").should("contain", "John Jenkins");
+  });
+});

--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -3,8 +3,11 @@
 import React from "react";
 // import fakeData from "../../js/data/report.json";
 import sampleRubric from "../../public/sample-rubric";
+import Feedback from "../support/elements/portal-report/feedback";
 
 describe("Provide Feedback", function() {
+  const feedback = new Feedback();
+
   beforeEach(() => {
     // cypress currently doesn't handle window.fetch so:
     // disable browser's fetch this way the fetch polyfill is used which uses XHR
@@ -48,18 +51,15 @@ describe("Provide Feedback", function() {
     cy.get(".feedback-panel").should("be.visible");
   });
 
-  it.skip("Sends feedback to the server", function() {
-    // This is the first put that happens when the UI is initialized
-    cy.wait("@putReportSettings");
+  it.only("Allows teacher to provide written feedback on a question", function() {
     cy.get(".question [data-cy=feedbackButton]").first().click();
-    cy.get("[data-cy=feedbackBox]").first().type("Your answer was great!").blur();
-    // This is the second put that happens when the user finishes typing
-    cy.wait("@putReportSettings");
-    cy.get("@putReportSettings").should((xhr) => {
-      // Newer versions of Chai have a 'nested' chained method that would simplify this
-      expect(xhr.requestBody).to.have.property("feedback");
-      expect(xhr.requestBody.feedback).to.have.property("feedback", "Your answer was great!");
+    cy.get("#feedbackEnabled").click();
+    feedback.getScoredStudentsCount().should("be.visible").and("contain", "0");
+    cy.get(".feedback-row").first().within(() => {
+      cy.get("[data-cy=feedbackBox]").type("Your answer was great!").blur();
+      cy.get(".feedback-complete input").check();
     });
+    feedback.getScoredStudentsCount().should("be.visible").and("contain", "1");
   });
 
   it.skip("Shows error if feedback fails to send", function() {

--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -51,7 +51,7 @@ describe("Provide Feedback", function() {
     cy.get(".feedback-panel").should("be.visible");
   });
 
-  it.only("Allows teacher to provide written feedback on a question", function() {
+  it("Allows teacher to provide written feedback on a question", function() {
     cy.get(".question [data-cy=feedbackButton]").first().click();
     cy.get("#feedbackEnabled").click();
     feedback.getScoredStudentsCount().should("be.visible").and("contain", "0");

--- a/cypress/integration/geode-dashboard-smoke-test.spec.js
+++ b/cypress/integration/geode-dashboard-smoke-test.spec.js
@@ -1,9 +1,19 @@
 import Dashboard from "../support/elements/geode-dashboard/dashboard";
+import {
+  getAnswerByQuestionType,
+  getPageQuestionData,
+  getActivityData,
+  getPageData,
+  getActivityQuestionData
+ } from "../utils";
 
 context("Geode Dashboard Smoke Test", () => {
 
     const dashboard = new Dashboard();
     const studentsToTest = ["", "", ""];
+
+    before(() => {
+    });
 
     beforeEach(() => {
         cy.visit("/?dashboard=true");
@@ -25,53 +35,7 @@ context("Geode Dashboard Smoke Test", () => {
         }
     }
 
-    function getActivityData(structure) {
-        let activityData;
-
-        activityData = structure.children;
-        if (activityData != null) {
-            return activityData;
-        } else {
-            cy.log("There was no activity with this index");
-        }
-    }
-
-    function getPageData(activityData) {
-        let pageData;
-
-        pageData = activityData.children[0].children;
-        if (pageData != null) {
-            return pageData;
-        } else {
-            cy.log("There was no activity page data");
-        }
-    }
-
-    function getPageQuestionData(pageData) {
-        let questionData;
-
-        questionData = pageData.children;
-        if (questionData != null) {
-            return questionData;
-        } else {
-            cy.log("There was no question data");
-        }
-    }
-
-    function getActivityQuestionData(activityData) {
-        let questionData = [];
-
-        let pageData = getPageData(activityData) || [];
-        pageData.forEach(page => {
-          questionData = questionData.concat(getPageQuestionData(page) || []);
-        });
-        if (questionData.length > 0) {
-            return questionData;
-        } else {
-            cy.log("There was no question data");
-        }
-    }
-
+    // This isn't valid anymore
     function getAnswerData(questionData) {
         let allAnswers;
 
@@ -87,35 +51,9 @@ context("Geode Dashboard Smoke Test", () => {
 
             let studentAnswerData = answerData[i];
             if (studentAnswerData.student_id === studentID) {
-                answer = getAnswerType(studentAnswerData);
+                answer = getAnswerByQuestionType(studentAnswerData);
                 return answer;
             }
-        }
-    }
-
-    function getAnswerType(answerData) {
-        let answer;
-        let questionType;
-        questionType = answerData.type;
-
-        if (answerData.type != null) {
-            switch (questionType) {
-                case ("Embeddable::MultipleChoice"):
-                    answer = answerData.answer[0].choice;
-                    break;
-                case ("Embeddable::OpenResponse"):
-                    answer = answerData.answer;
-                    break;
-                case ("Embeddable::ImageQuestion"):
-                    answer = answerData.answer.image_url;
-                    break;
-                case ("Embeddable::Iframe"):
-                    answer = answerData.answer;
-                    break;
-            }
-            return answer;
-        } else {
-            cy.log("Could not find answer for question type " + questionType);
         }
     }
 
@@ -175,11 +113,12 @@ context("Geode Dashboard Smoke Test", () => {
     });
 
     describe("Verifies for Activity/Seq data", function() {
+        beforeEach(() => {
+            cy.get("@sequenceStructure").its('children').as('activities');
+        });
 
         it("Checks for activity names", () => {
-            cy.get("@sequenceStructure").then((structure) => {
-                const activities = structure.children;
-
+            cy.get('@activities').then(activities => {
                 dashboard.getActivityNames()
                     .should("have.length", activities.length);
 
@@ -191,10 +130,9 @@ context("Geode Dashboard Smoke Test", () => {
             });
         });
         it("can expand activity questions", () => {
-            cy.get("@sequenceStructure").then((structure) => {
-                const activityData = getActivityData(structure)[0];
-
-                let questionData = getActivityQuestionData(activityData);
+            cy.get('@activities').then(activities => {
+                let firstActivity = activities[0];
+                let questionData = getActivityQuestionData(firstActivity);
                 let questionTotal = questionData.length;
                 let currentQuestionPrompt;
 
@@ -236,8 +174,8 @@ context("Geode Dashboard Smoke Test", () => {
         it("can expand activities to show questions", () => {
             dashboard.getActivityNames().eq(0)
                 .click({ force: true });
-            cy.get("@sequenceStructure").then((structure) => {
-                const questionData = getActivityQuestionData(getActivityData(structure)[0]);
+            cy.get("@activities").then((activities) => {
+                const questionData = getActivityQuestionData(activities[0]);
 
                 dashboard.getActivityQuestions().eq(0).within(() => {
                   dashboard.getActivityQuestionToggle()
@@ -320,8 +258,10 @@ context("Geode Dashboard Smoke Test", () => {
                 .click({ force: true });
             dashboard.getExpandQuestionDetails().eq(multipleChoiceQuestionIndex)
                 .click({ force: true });
-            cy.get("@sequenceStructure").then((structure) => {
-                const questionData = getActivityQuestionData(getActivityData(structure)[0])[multipleChoiceQuestionIndex];
+            cy.get("@sequenceStructure")
+              .its('children')
+              .then((activities) => {
+                const questionData = getActivityQuestionData(activities[0])[multipleChoiceQuestionIndex];
 
                 dashboard.getExpandedMCAnswerDetails()
                     .should("exist")

--- a/cypress/integration/geode-dashboard-smoke-test.spec.js
+++ b/cypress/integration/geode-dashboard-smoke-test.spec.js
@@ -276,9 +276,7 @@ context("Geode Dashboard Smoke Test", () => {
                     .then(() => {
                         dashboard.getExpandedMCAnswers()
                             .should("exist")
-                            // FIXME: this seems to be an error in the code student names
-                            // should always be shown in the dashboard
-                            .and("contain", "Student 1");
+                            .and("contain", "Jenna Armstrong");
                     });
             });
             dashboard.getCloseExpandedQuestion()
@@ -326,7 +324,7 @@ context("Geode Dashboard Smoke Test", () => {
             dashboard.getExpandedMCAnswers()
                 .should("exist")
                 // FIXME should be a real student name here
-                .and("contain", "Student 1");
+                .and("contain", "Jenna Armstrong");
             dashboard.getCloseExpandedQuestion()
                 .should("exist")
                 .click({ force: true });

--- a/cypress/integration/geode-dashboard-smoke-test.spec.js
+++ b/cypress/integration/geode-dashboard-smoke-test.spec.js
@@ -12,9 +12,6 @@ context("Geode Dashboard Smoke Test", () => {
     const dashboard = new Dashboard();
     const studentsToTest = ["", "", ""];
 
-    before(() => {
-    });
-
     beforeEach(() => {
         cy.visit("/?dashboard=true");
         cy.fixture("class-data.json").as("classData");
@@ -31,16 +28,6 @@ context("Geode Dashboard Smoke Test", () => {
             } else {
                 cy.log("No student with this ID found in class");
             }
-        }
-    }
-
-    // This isn't valid anymore
-    function getAnswerData(questionData) {
-        let allAnswers;
-
-        allAnswers = questionData.answers;
-        if (allAnswers != null) {
-            return allAnswers;
         }
     }
 
@@ -323,7 +310,6 @@ context("Geode Dashboard Smoke Test", () => {
                 .click({ force: true });
             dashboard.getExpandedMCAnswers()
                 .should("exist")
-                // FIXME should be a real student name here
                 .and("contain", "Jenna Armstrong");
             dashboard.getCloseExpandedQuestion()
                 .should("exist")

--- a/cypress/integration/geode-dashboard-smoke-test.spec.js
+++ b/cypress/integration/geode-dashboard-smoke-test.spec.js
@@ -22,9 +22,8 @@ context("Geode Dashboard Smoke Test", () => {
     });
 
     function getStudentName(classData, id) {
-        let students;
+        let students = classData.students;
 
-        students = classData.students;
         for (let i = 0; i < students.length; i++) {
             if (students[i].id === id) {
                 let student = students[i];
@@ -114,11 +113,11 @@ context("Geode Dashboard Smoke Test", () => {
 
     describe("Verifies for Activity/Seq data", function() {
         beforeEach(() => {
-            cy.get("@sequenceStructure").its('children').as('activities');
+            cy.get("@sequenceStructure").its("children").as("activities");
         });
 
         it("Checks for activity names", () => {
-            cy.get('@activities').then(activities => {
+            cy.get("@activities").then(activities => {
                 dashboard.getActivityNames()
                     .should("have.length", activities.length);
 
@@ -130,7 +129,7 @@ context("Geode Dashboard Smoke Test", () => {
             });
         });
         it("can expand activity questions", () => {
-            cy.get('@activities').then(activities => {
+            cy.get("@activities").then(activities => {
                 let firstActivity = activities[0];
                 let questionData = getActivityQuestionData(firstActivity);
                 let questionTotal = questionData.length;
@@ -259,7 +258,7 @@ context("Geode Dashboard Smoke Test", () => {
             dashboard.getExpandQuestionDetails().eq(multipleChoiceQuestionIndex)
                 .click({ force: true });
             cy.get("@sequenceStructure")
-              .its('children')
+              .its("children")
               .then((activities) => {
                 const questionData = getActivityQuestionData(activities[0])[multipleChoiceQuestionIndex];
 

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -79,31 +79,28 @@ context("Portal Report Smoke Test", () => {
             body.getActivities().eq(activityIndex + 1).should("have.class", "hidden");
         });
 
-        // This test is dying in the application code, perhaps it is something that got
-        // fixed
+        function checkStudentNames(students, contains) {
+          students.forEach(student => {
+            body.checkForStudentNames(contains, student.first_name);
+          });
+        }
+
+        // This test is failing becuase firestore is not returning a valid reponse
+        // when the show/hide student names button is pressed. It seems like the connection
+        // to firestore is failing here. When running the report directly the state of the
+        // button is saved in firestore even when using the mock data
         it.skip("Shows/Hides student names", () => { // Add into context
             cy.get("@classData").then((classData) => {
                 const students = classData.students;
-                let student;
 
                 body.getResponseTable().should("not.exist");
                 body.getActivities().eq(activityIndex).within(() => {
                     body.getShowResponses(questionIndex).should("exist").and("be.visible").click({ force: true });
                 });
                 body.getResponseTable().should("exist").and("be.visible");
-                for (let i = 0; i < students.length; i++) {
-                    student = students[i];
-                    if (students[i].started_offering === true) {
-                        body.checkForStudentNames(true, student[i].first_name);
-                    }
-                }
+                checkStudentNames(students, true);
                 header.getHideShowNames().should("be.visible").click({ force: true });
-                for (let i = 0; i < students.length; i++) {
-                    student = students[i];
-                    if (students[i].started_offering === true) {
-                        body.checkForStudentNames(false, student[i].first_name);
-                    }
-                }
+                checkStudentNames(students, false);
             });
         });
 

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -91,10 +91,6 @@ context("Portal Report Smoke Test", () => {
           });
         }
 
-        // This test is failing becuase firestore is not returning a valid reponse
-        // when the show/hide student names button is pressed. It seems like the connection
-        // to firestore is failing here. When running the report directly the state of the
-        // button is saved in firestore even when using the mock data
         it("Shows/Hides student names", () => { // Add into context
             cy.get("@classData").then((classData) => {
                 const students = classData.students;

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -1,6 +1,13 @@
 import Header from "../support/elements/portal-report/header";
 import ReportBody from "../support/elements/portal-report/report-body";
 import Feedback from "../support/elements/portal-report/feedback";
+import {
+  getAnswerByQuestionType,
+  getPageQuestionData,
+  getActivityData,
+  getPageData,
+  getActivityQuestionData
+ } from "../utils";
 
 context("Portal Report Smoke Test", () => {
 
@@ -17,64 +24,6 @@ context("Portal Report Smoke Test", () => {
     const body = new ReportBody();
     const feedback = new Feedback();
 
-    function getActivityData(sequenceData) {
-        let activityData;
-
-        activityData = sequenceData.children;
-        if (activityData != null) {
-            return activityData;
-        } else {
-            cy.log("There was no activity with this index");
-        }
-    }
-
-    function getPageData(activityData) {
-        let pageData;
-
-        pageData = activityData.children[0].children;
-        if (pageData != null) {
-            return pageData;
-        } else {
-            cy.log("There was no activity page data");
-        }
-    }
-
-    function getQuestionData(pageData) {
-        let questionData;
-
-        questionData = pageData.children;
-        if (questionData != null) {
-            return questionData;
-        } else {
-            cy.log("There was no question data");
-        }
-    }
-
-    function getAnswerByQuestionType(answerData) {
-        let answer;
-        let questionType;
-        questionType = answerData.type;
-
-        if (answerData.type != null) {
-            switch (questionType) {
-                case ("Embeddable::MultipleChoice"):
-                    answer = answerData.answer[0].choice;
-                    break;
-                case ("Embeddable::OpenResponse"):
-                    answer = answerData.answer;
-                    break;
-                case ("Embeddable::ImageQuestion"):
-                    answer = answerData.answer.image_url;
-                    break;
-                case ("Embeddable::Iframe"):
-                    answer = answerData.answer;
-                    break;
-            }
-            return answer;
-        } else {
-            cy.log("Could not find answer for question type " + questionType);
-        }
-    }
 
     context("Header components", () => {
         it("Verifies the logo appears correctly", () => {
@@ -119,7 +68,7 @@ context("Portal Report Smoke Test", () => {
                 let questionData;
                 // Get unhidden report, for each page check each question header for checkbox then check
                 for (let i = 0; i < pageData.length; i++) {
-                    questionData = getQuestionData(pageData[i]);
+                    questionData = getPageQuestionData(pageData[i]);
                     for (let j = 0; j < questionData.length; j++) {
                         header.getCheckbox(checkboxCount).check().should("be.checked");
                         checkboxCount++;
@@ -179,7 +128,7 @@ context("Portal Report Smoke Test", () => {
 
                         for (let j = 0; j <= pages.length; j++){
                             currentPage = pages[j];
-                            questions = getQuestionData(currentPage);
+                            questions = getPageQuestionData(currentPage);
 
                             for (let k = 0; k < questions.length; k++) {
                                 currentQuestion = questions[k];

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -24,7 +24,6 @@ context("Portal Report Smoke Test", () => {
     const body = new ReportBody();
     const feedback = new Feedback();
 
-
     context("Header components", () => {
         it("Verifies the logo appears correctly", () => {
             header.getLogo().should("exist").and("have.length", 1).and("be.visible");

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -220,7 +220,12 @@ context("Portal Report Smoke Test", () => {
             body.pullUpFeedbackForActivity(activityIndex);
             feedback.getGiveScoreCheckbox().click();
             feedback.getShowAllStudentsToggle().click();
-            feedback.getStudentWorkLink(studentIndex).should("be.visible").click({ force: true });
+            feedback.getStudentWorkLink(studentIndex).should("be.visible")
+              .then(($studentWorkLink) => {
+                // remove target=_blank so the link opens in the same window
+                $studentWorkLink.attr("target", null);
+              }).click();
+            cy.contains("Amy Galloway");
         });
     });
 });

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -179,7 +179,6 @@ context("Portal Report Smoke Test", () => {
             });
         });
 
-
         it("check scoring options", () => {
             body.pullUpFeedbackForActivity(activityIndex);
             // the rubric only shows up if there is a rubric defined for the resource

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -181,15 +181,13 @@ context("Portal Report Smoke Test", () => {
 
         it("check scoring options", () => {
             body.pullUpFeedbackForActivity(activityIndex);
-            // the rubric only shows up if there is a rubric defined for the resource
-            // feedback.getRubricCheckbox().should("exist").and("be.visible").and("be.checked").check();
+            feedback.getRubricCheckbox().should("exist").and("be.visible").and("not.be.checked").check();
             feedback.getGiveScoreCheckbox().should("exist").and("be.visible").and("not.be.checked");
             feedback.getWrittenFeedbackCheckbox().should("exist").and("be.visible").and("not.be.checked");
             feedback.getManualScoringOption().should("exist").and("be.visible").and("not.be.checked");
             cy.root();
             feedback.getAutoScoringOption().should("exist").and("be.visible").and("not.be.checked");
-            // the rubric only shows up if there is a rubric defined for the resource
-            // feedback.getRubricScoringOption().should("exist").and("be.visible").and("not.be.checked");
+            feedback.getRubricScoringOption().should("exist").and("be.visible").and("not.be.checked");
         });
 
         it("checks toggle for show all students", () => {

--- a/cypress/integration/student-report.spec.js
+++ b/cypress/integration/student-report.spec.js
@@ -1,0 +1,50 @@
+import ReportBody from "../support/elements/portal-report/report-body";
+import {
+  getActivityData,
+ } from "../utils";
+
+context("Student Report", () => {
+  const body = new ReportBody();
+
+  beforeEach(() => {
+    cy.visit("/?studentId=3");
+    cy.fixture("sequence-structure.json").as("sequenceData");
+
+  });
+
+  it("Shows the student's name", () => {
+    cy.contains("Amy Galloway");
+  });
+
+  context("Module Details", () => {
+    it("Verifies sequence name", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+        const moduleName = sequenceData.name;
+        // There is some header content in a .report-content div which is hidden
+        // until the user starts scrolling, so we have to explicitly select the unhidden div
+        cy.get(".report-content:not(.hidden) h2").contains(moduleName).should("be.visible");
+      });
+    });
+  });
+
+  context("Activity Level", () => {
+    const activityIndex = 0;
+
+    it("Verifies activity Name", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+          const activityName = getActivityData(sequenceData)[activityIndex].name;
+          cy.get(".report-content:not(.hidden) .activity").eq(activityIndex)
+            .should("be.visible")
+            .and("contain", activityName);
+      });
+    });
+
+    it("Shows no feedback", () => {
+      cy.get(".student-feedback-panel").contains("No feedback yet");
+    });
+
+    it("Shows the open response prompt", () => {
+      cy.get(".prompt").contains("Open response question prompt");
+    });
+  });
+});

--- a/cypress/support/elements/portal-report/header.js
+++ b/cypress/support/elements/portal-report/header.js
@@ -10,31 +10,20 @@ class Header {
     }
 
     getShowSelectedButton() {
-        return cy.get(".report-content").not(".hidden")
-            .within(() => {
-                cy.get(".controls").eq(0).children().eq(0);
-            });
+        return cy.contains(".report-content .controls a", /show selected/i);
     }
 
     getShowAll() {
-        return cy.get(".report-content").not(".hidden")
-            .within(() => {
-                cy.get(".controls").eq(0).children().eq(1);
-            });
+        return cy.contains(".report-content .controls a", /show all/i);
     }
 
     getHideShowNames() {
-        return cy.get(".report-content").not(".hidden")
-            .within(() => {
-                cy.get(".controls").eq(0).children().eq(2);
-            });
+        return cy.contains(".report-content .controls a", /names/i);
     }
 
     getPrintStudentReports() {
-        return cy.get(".report-content").not(".hidden")
-        .within(() => {
-            cy.get(".controls").eq(0).children().eq(3);
-        });    }
+        return cy.contains(".report-content .controls a", /print/i);
+    }
 
     getCheckbox(i) {
         return cy.get(".report-content")

--- a/cypress/support/sequence-helper.js
+++ b/cypress/support/sequence-helper.js
@@ -1,0 +1,28 @@
+// A little meta programming to make your brain hurt
+function generate(childrenFunction, label) {
+  const capitalizedLabel = label.charAt(0).toUpperCase() + label.slice(1);
+  const childrenFunctionName = "get" + capitalizedLabel;
+  return function() {
+    let children = this.children;
+    if (children != null) {
+      if (childrenFunction) {
+        children.each(child => {
+          child[childrenFunctionName] = childrenFunction;
+        });
+      }
+      return children;
+    } else {
+      cy.log("no " + label + " found");
+    }
+  };
+}
+
+getQuestions = generate(null, "questions");
+getPages = generate(getQuestions, "pages");
+getSections = generate(getPages, "sections");
+getActivities = generate(getSections, "activities");
+
+function sequenceHelper(sequence) {
+  sequence.getActivities = getActivities;
+  return sequence;
+}

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -1,9 +1,91 @@
+function getChildrenData(parent, label) {
+    let children = parent.children;
+
+    if (children != null) {
+        return children;
+    } else {
+        cy.log("There were no " + label);
+    }
+}
+
+function getByCypressTag ( cypressTag ) {
+  return cy.get(`[data-cy=${cypressTag}]`);
+}
+
+function getAnswerByQuestionType (answerData) {
+    let answer;
+    let questionType;
+    questionType = answerData.type;
+
+    if (answerData.type != null) {
+        switch (questionType) {
+            case ("Embeddable::MultipleChoice"):
+                answer = answerData.answer[0].choice;
+                break;
+            case ("Embeddable::OpenResponse"):
+                answer = answerData.answer;
+                break;
+            case ("Embeddable::ImageQuestion"):
+                answer = answerData.answer.image_url;
+                break;
+            case ("Embeddable::Iframe"):
+                answer = answerData.answer;
+                break;
+        }
+        return answer;
+    } else {
+        cy.log("Could not find answer for question type " + questionType);
+    }
+}
+
+function getPageQuestionData(pageData) {
+    return getChildrenData(pageData, 'questions');
+}
+
+function getActivityData(sequenceData) {
+    return getChildrenData(sequenceData, 'activities');
+}
+
+function getSectionData(activityData) {
+  return getChildrenData(activityData, 'sections');
+}
+
+function getPageData(activityData) {
+    let pageData;
+
+    // this is only looking at the first section
+    pageData = getSectionData(activityData)[0].children;
+    if (pageData != null) {
+        return pageData;
+    } else {
+        cy.log("There was no activity page data");
+    }
+}
+
+function getActivityQuestionData(activityData) {
+    let questionData = [];
+
+    let pageData = getPageData(activityData) || [];
+    pageData.forEach(page => {
+      questionData = questionData.concat(getPageQuestionData(page) || []);
+    });
+    if (questionData.length > 0) {
+        return questionData;
+    } else {
+        cy.log("There was no question data");
+    }
+}
+
 module.exports = {
 
   // CSS modules randomize class names, so it is safest to select with explicit data-* attributes
   // https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
-  getByCypressTag: function( cypressTag ) {
-    return cy.get(`[data-cy=${cypressTag}]`);
-  },
+  getByCypressTag: getByCypressTag,
 
+  getAnswerByQuestionType: getAnswerByQuestionType,
+  getPageQuestionData: getPageQuestionData,
+  getActivityData: getActivityData,
+  getSectionData:  getSectionData,
+  getPageData:  getPageData,
+  getActivityQuestionData: getActivityQuestionData
 };

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -8,11 +8,11 @@ function getChildrenData(parent, label) {
     }
 }
 
-function getByCypressTag ( cypressTag ) {
+function getByCypressTag(cypressTag) {
   return cy.get(`[data-cy=${cypressTag}]`);
 }
 
-function getAnswerByQuestionType (answerData) {
+function getAnswerByQuestionType(answerData) {
     let answer;
     let questionType;
     questionType = answerData.type;
@@ -39,15 +39,15 @@ function getAnswerByQuestionType (answerData) {
 }
 
 function getPageQuestionData(pageData) {
-    return getChildrenData(pageData, 'questions');
+    return getChildrenData(pageData, "questions");
 }
 
 function getActivityData(sequenceData) {
-    return getChildrenData(sequenceData, 'activities');
+    return getChildrenData(sequenceData, "activities");
 }
 
 function getSectionData(activityData) {
-  return getChildrenData(activityData, 'sections');
+  return getChildrenData(activityData, "sections");
 }
 
 function getPageData(activityData) {

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -8,11 +8,13 @@ function getChildrenData(parent, label) {
     }
 }
 
-function getByCypressTag(cypressTag) {
+// CSS modules randomize class names, so it is safest to select with explicit data-* attributes
+// https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
+export function getByCypressTag(cypressTag) {
   return cy.get(`[data-cy=${cypressTag}]`);
 }
 
-function getAnswerByQuestionType(answerData) {
+export function getAnswerByQuestionType(answerData) {
     let answer;
     let questionType;
     questionType = answerData.type;
@@ -38,19 +40,19 @@ function getAnswerByQuestionType(answerData) {
     }
 }
 
-function getPageQuestionData(pageData) {
+export function getPageQuestionData(pageData) {
     return getChildrenData(pageData, "questions");
 }
 
-function getActivityData(sequenceData) {
+export function getActivityData(sequenceData) {
     return getChildrenData(sequenceData, "activities");
 }
 
-function getSectionData(activityData) {
+export function getSectionData(activityData) {
   return getChildrenData(activityData, "sections");
 }
 
-function getPageData(activityData) {
+export function getPageData(activityData) {
     let pageData;
 
     // this is only looking at the first section
@@ -62,7 +64,7 @@ function getPageData(activityData) {
     }
 }
 
-function getActivityQuestionData(activityData) {
+export function getActivityQuestionData(activityData) {
     let questionData = [];
 
     let pageData = getPageData(activityData) || [];
@@ -75,17 +77,3 @@ function getActivityQuestionData(activityData) {
         cy.log("There was no question data");
     }
 }
-
-module.exports = {
-
-  // CSS modules randomize class names, so it is safest to select with explicit data-* attributes
-  // https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
-  getByCypressTag: getByCypressTag,
-
-  getAnswerByQuestionType: getAnswerByQuestionType,
-  getPageQuestionData: getPageQuestionData,
-  getActivityData: getActivityData,
-  getSectionData:  getSectionData,
-  getPageData:  getPageData,
-  getActivityQuestionData: getActivityQuestionData
-};

--- a/js/api.ts
+++ b/js/api.ts
@@ -188,6 +188,11 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
           })
         );
       } else {
+        // disable the network when faking the JWT. This way the demo report will not update
+        // a shared settings in firestore, and any tests running against it will be
+        // repeatable
+        firebase.firestore().disableNetwork();
+
         // We're using fake data, including fake JWT.
         return {
           offering: offeringData,

--- a/js/api.ts
+++ b/js/api.ts
@@ -220,6 +220,8 @@ export function reportSettingsFireStorePath(LTIData: ILTIPartial) {
   // `/sources/fake.portal/user_settings/1/offering/class123` which has
   // special FireStore Rules to allow universal read and write to that document.
   // Allows us to test limited report settings with fake portal data, sans JWT.
+  // SC: 2019-11-12 this has been updated so the firestore network is disabled so these
+  // fake user_settings should not be saved to or loaded from the actual firestore database
   return `/sources/${sourceKey}/user_settings/${validFsId(platformUserId)}/resource_link/${validFsId(resourceLinkId)}`;
 }
 
@@ -310,6 +312,8 @@ export function reportQuestionFeedbacksFireStorePath(sourceKey: string, answerId
   // `/sources/fake.authoring.system/question_feedbacks/1/` which has
   // special FireStore Rules to allow universal read and write to that document.
   // Allows us to test limited report settings with fake portal data, without a JWT.
+  // SC: 2019-11-12 this has been updated so the firestore network is disabled so these
+  // fake question_feedbacks should not be saved to or loaded from the actual firestore database
   const path = `/sources/${sourceKey}/question_feedbacks`;
   if (answerId) {
     return path + `/${answerId}`;
@@ -322,6 +326,8 @@ export function reportActivityFeedbacksFireStorePath(sourceKey: string, activity
   // `/sources/fake.authoring.system/question_feedbacks/1/` which has
   // special FireStore Rules to allow universal read and write to that document.
   // Allows us to test limited report settings with fake portal data, without a JWT.
+  // SC: 2019-11-12 this has been updated so the firestore network is disabled so these
+  // fake activity_feedbacks should not be saved to or loaded from the actual firestore database
   const path = `/sources/${sourceKey}/activity_feedbacks`;
   if (activityUserKey) {
     return path + `/${activityUserKey}`;

--- a/js/data/offering-data.json
+++ b/js/data/offering-data.json
@@ -1,4 +1,5 @@
 {
   "activity_url": "http://fake.authoring.system/activity/1",
-  "id": 1
+  "id": 1,
+  "rubric_url": "sample-rubric.json"
 }

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -69,7 +69,11 @@ function setAnonymous(state, anonymous) {
 
 function setUserSettings(state, response) {
   const {visibility_filter, anonymous_report} = response;
-  const selectedQuestions = visibility_filter.questions || [];
+  let selectedQuestions = [];
+  // The visibility_filter might not be setup on the user settings yet
+  if (visibility_filter && visibility_filter.questions) {
+    selectedQuestions = visibility_filter.questions;
+  }
   return state.withMutations(state => {
     state.get("questions").forEach((value, key) => {
       const selected = selectedQuestions.indexOf(key) > -1;


### PR DESCRIPTION
This PR:
- refactors some of the cypress tests to remove redundant code
- fixes an issue with the travis config that was preventing it from sending the code coverage to code climate.
- disables firestore networking when the demo report is loaded
- fixes some cypress tests that were previously skipped because they were failing
- updates some cypress tests now that the user settings are starting empty on each test run

The most invasive change is the disabling of the firestore networking. This should only affect the demo report: the report that loads when you aren't coming from the portal.  Now the demo report won't remember any changes you made, but within the current tab session it should work as normal.