### PR TITLE
fix feedback autoscore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ script:
   - npm run test:coverage
   - CODE_COVERAGE=true npm run start &
   - wait-on http://localhost:8080
-  - $(npm bin)/cypress run --config video=false
+  # The recording key is stored in a ENV variable
+  - $(npm bin)/cypress run --record --config video=false
 after_success:
   - ./s3_deploy.sh
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - CODE_COVERAGE=true npm run start &
   - wait-on http://localhost:8080
   # The recording key is stored in a ENV variable
-  - $(npm bin)/cypress run --record --config video=false
+  - $(npm bin)/cypress run --record
 after_success:
   - ./s3_deploy.sh
 after_script:

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "baseUrl": "http://localhost:8080",
-  "fixturesFolder": "js/data"
+  "fixturesFolder": "js/data",
+  "projectId": "er5qci"
 }

--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -53,7 +53,7 @@ describe("Provide Feedback", function() {
 
   it("Allows teacher to provide written feedback on a question", function() {
     cy.get(".question [data-cy=feedbackButton]").first().click();
-    cy.get("#feedbackEnabled").click();
+    cy.get("#feedbackEnabled").check();
     feedback.getScoredStudentsCount().should("be.visible").and("contain", "0");
     cy.get(".feedback-row").first().within(() => {
       cy.get("[data-cy=feedbackBox]").type("Your answer was great!").blur();
@@ -61,6 +61,25 @@ describe("Provide Feedback", function() {
     });
     feedback.getScoredStudentsCount().should("be.visible").and("contain", "1");
   });
+
+  it("Allows teacher to use the sum of question scores as the activity score", function() {
+    // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
+    cy.get(".question [data-cy=feedbackButton]").first().click();
+    cy.get("#giveScore").check();
+    cy.get(".feedback-row:contains('Jenkins')").within(() => {
+      cy.get("[data-cy=question-feedback-score] input").type("10");
+      cy.get(".feedback-complete input").check();
+    });
+    cy.get("[data-cy=feedback-done-button]").click();
+    cy.get("[data-cy=feedbackButton]").first().click();
+    cy.get("#giveScore").check();
+    cy.get("[data-cy=automatic-score-option]").check();
+
+    cy.get(".feedback-row:contains('Jenkins')").first().within(() => {
+      cy.get("[data-cy=question-feedback-score] input").should("have.value", "10");
+    });
+  });
+
 
   // with the switch to firestore this test needs to be updated
   it.skip("Shows error if feedback fails to send", function() {

--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -62,19 +62,153 @@ describe("Provide Feedback", function() {
     feedback.getScoredStudentsCount().should("be.visible").and("contain", "1");
   });
 
-  it("Allows teacher to use the sum of question scores as the activity score", function() {
+  it("shows the same question level score after closing and opening the dialog", function () {
     // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
     cy.get(".question [data-cy=feedbackButton]").first().click();
     cy.get("#giveScore").check();
+
+    // Give Jenkins a score 10 on one question
     cy.get(".feedback-row:contains('Jenkins')").within(() => {
       cy.get("[data-cy=question-feedback-score] input").type("10");
       cy.get(".feedback-complete input").check();
     });
     cy.get("[data-cy=feedback-done-button]").click();
+
+    // Open the feedback for a another question
+    cy.get(".question [data-cy=feedbackButton]").eq(1).click();
+    cy.get("#giveScore").check();
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    cy.get(".question [data-cy=feedbackButton]").first().click();
+    cy.get("#all").check();
+    cy.get(".feedback-row:contains('Jenkins')").within(() => {
+      cy.get("[data-cy=question-feedback-score] input").should("have.value", "10");
+    });
+  });
+
+  it("shows the same max question score after closing and opening the dialog", function () {
+    // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
+    cy.get(".question [data-cy=feedbackButton]").first().click();
+    cy.get("#giveScore").check();
+    cy.get(".max-score-input").should("have.value", "10");
+    cy.get(".max-score-input").clear().type("11");
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    // Open the feedback for a another question
+    cy.get(".question [data-cy=feedbackButton]").eq(1).click();
+    cy.get("#giveScore").check();
+    cy.get(".max-score-input").clear().type("12");
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    cy.get(".question [data-cy=feedbackButton]").first().click();
+    cy.get(".max-score-input").should("have.value", "11");
+  });
+
+  it("shows the same activity level score after closing and opening the dialog", function () {
+    // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
+    cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
+    cy.get("#giveScore").check();
+
+    // Give Jenkins a score 12 on activity 1
+    cy.get(".feedback-row:contains('Jenkins')").within(() => {
+      cy.get("[data-cy=question-feedback-score] input").type("12");
+      cy.get(".feedback-complete input").check();
+    });
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    // Give Jenkins a score 13 on activity 2
+    cy.get("[data-cy=feedbackButton]:contains('overall')").eq(1).click();
+    cy.get("#giveScore").check();
+    cy.get(".feedback-row:contains('Jenkins')").within(() => {
+      cy.get("[data-cy=question-feedback-score] input").type("13");
+      cy.get(".feedback-complete input").check();
+    });
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    // Check original score is remembered
+    cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
+    cy.get("#all").check();
+    cy.get(".feedback-row:contains('Jenkins')").within(() => {
+      cy.get("[data-cy=question-feedback-score] input").should("have.value", "12");
+    });
+  });
+
+
+  it("shows the same max activity score after closing and opening the dialog", function() {
+    // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
+    cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
+    cy.get("#giveScore").check();
+    cy.get("[data-cy=manual-score-option]").check();
+    cy.get(".max-score-input").clear().type("13");
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    cy.get("[data-cy=feedbackButton]:contains('overall')").eq(1).click();
+    cy.get("#giveScore").check();
+    cy.get("[data-cy=manual-score-option]").check();
+    cy.get(".max-score-input").clear().type("14");
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
+    cy.get(".max-score-input").should("have.value", "13");
+  });
+
+  // TODO: check that the manually entered maxScore returns if the box is checked again
+  // this seems like it is working on the deployed master but locally it is not working
+  // for me.
+  it("shows the max activity score based on the sum of question max scores", function() {
+    // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
+    cy.get(".question [data-cy=feedbackButton]").eq(0).click();
+    cy.get("#giveScore").check();
+    cy.get(".max-score-input").clear().type("9");
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    cy.get(".question [data-cy=feedbackButton]").eq(1).click();
+    cy.get("#giveScore").check();
+    cy.get(".max-score-input").clear().type("8");
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    // Turn on automatic scoring at the activity Level
+    cy.get("[data-cy=feedbackButton]").first().click();
+    cy.get("#giveScore").check();
+    cy.get("[data-cy=automatic-score-option]").check();
+    cy.get(".max-score-input").should("have.value", "17").and("be.disabled");
+
+    // Switch to manual scoring
+    cy.get("[data-cy=manual-score-option]").check();
+    // FIXME: specify what the max score should start out with
+    cy.get(".max-score-input").should("be.enabled");
+    cy.get(".max-score-input").clear().type("19");
+
+    // Switch automatic scoring
+    cy.get("[data-cy=automatic-score-option]").check();
+    cy.get(".max-score-input").should("have.value", "17").and("be.disabled");
+
+    // Switch to manual scoring
+    cy.get("[data-cy=manual-score-option]").check();
+
+    // It should remember the original manual max score, it currently doesn't
+    // cy.get(".max-score-input").should("have.value", "19").and("be.enabled");
+
+  });
+
+  it("Allows teacher to use the sum of question scores as the activity score", function() {
+    // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
+    cy.get(".question [data-cy=feedbackButton]").first().click();
+    cy.get("#giveScore").check();
+
+    // Give Jenkins a score 10 on one question
+    cy.get(".feedback-row:contains('Jenkins')").within(() => {
+      cy.get("[data-cy=question-feedback-score] input").type("10");
+      cy.get(".feedback-complete input").check();
+    });
+    cy.get("[data-cy=feedback-done-button]").click();
+
+    // Turn on automatic scoring at the activity Level
     cy.get("[data-cy=feedbackButton]").first().click();
     cy.get("#giveScore").check();
     cy.get("[data-cy=automatic-score-option]").check();
 
+    // Make sure the score for the activity is 10
     cy.get(".feedback-row:contains('Jenkins')").first().within(() => {
       cy.get("[data-cy=question-feedback-score] input").should("have.value", "10");
     });

--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -156,9 +156,17 @@ describe("Provide Feedback", function() {
     cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
     cy.get("#giveScore").check();
     cy.get("[data-cy=manual-score-option]").check();
+
+    // for some reason the following clear fails sometimes in travis with a detached
+    // element error. The clear should wait 4 seconds for the element to be 'actionable',
+    // but that isn't working properly. So here is an explicit check to see if it helps
+    // or reveals more infomration.
+    cy.get(".max-score-input").should("be.enabled");
     cy.get(".max-score-input").clear().type("13");
     cy.get("[data-cy=feedback-done-button]").click();
 
+    // Open the second activity feedback box, just to make sure they aren't sharing
+    // data for some reason
     cy.get("[data-cy=feedbackButton]:contains('overall')").eq(1).click();
     cy.get("#giveScore").check();
     cy.get("[data-cy=manual-score-option]").check();

--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -62,7 +62,7 @@ describe("Provide Feedback", function() {
     feedback.getScoredStudentsCount().should("be.visible").and("contain", "1");
   });
 
-  it("shows the same question level score after closing and opening the dialog", function () {
+  it("shows the same question level score after closing and opening the dialog", function() {
     // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
     cy.get(".question [data-cy=feedbackButton]").first().click();
     cy.get("#giveScore").check();
@@ -86,7 +86,7 @@ describe("Provide Feedback", function() {
     });
   });
 
-  it("shows the same max question score after closing and opening the dialog", function () {
+  it("shows the same max question score after closing and opening the dialog", function() {
     // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
     cy.get(".question [data-cy=feedbackButton]").first().click();
     cy.get("#giveScore").check();
@@ -104,7 +104,7 @@ describe("Provide Feedback", function() {
     cy.get(".max-score-input").should("have.value", "11");
   });
 
-  it("shows the same activity level score after closing and opening the dialog", function () {
+  it("shows the same activity level score after closing and opening the dialog", function() {
     // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
     cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
     cy.get("#giveScore").check();
@@ -132,7 +132,6 @@ describe("Provide Feedback", function() {
       cy.get("[data-cy=question-feedback-score] input").should("have.value", "12");
     });
   });
-
 
   it("shows the same max activity score after closing and opening the dialog", function() {
     // Note: I'm not using the feedback helper object. I'm not sure it is really worth it
@@ -213,7 +212,6 @@ describe("Provide Feedback", function() {
       cy.get("[data-cy=question-feedback-score] input").should("have.value", "10");
     });
   });
-
 
   // with the switch to firestore this test needs to be updated
   it.skip("Shows error if feedback fails to send", function() {

--- a/js/components/common/button.js
+++ b/js/components/common/button.js
@@ -21,7 +21,8 @@ export default class Button extends PureComponent {
 
   render() {
     const { children } = this.props;
-    return <a className={this.className} onClick={this.handleClick} data-cy="button">{children}</a>;
+    return <a className={this.className} onClick={this.handleClick}
+      data-cy={this.props["data-cy"] || "button"}>{children}</a>;
   }
 }
 

--- a/js/components/report/activity-feedback-options.js
+++ b/js/components/report/activity-feedback-options.js
@@ -51,6 +51,18 @@ export default class ActivityFeedbackOptions extends PureComponent {
       this.setState({lastScoreType: newV});
     }
     if (isAutoScoring(newV)) {
+      // When switching from manual to automatic scores, this sets the maxScore to the
+      // default Max Score (10), and then it doesn't seem to
+      // update this maxScore in the settings when the computation changes
+      // I suspect this is because the computedMaxScore prop is based on the old score type
+      // and it defaults to 10 when the score type is manual.
+      // Perhaps this code handles switching other modes better.
+      //
+      // TODO: tests for rubric, auto, manual, and no score to see if this
+      // line is doing something worth while in some case
+      //
+      // TODO: see if there is any reason why the computedMaxScore
+      // needs to actually be saved as the maxScore
       newFlags.maxScore = this.props.computedMaxScore;
     }
     updateActivityFeedbackSettings(activityId, activityIndex, newFlags);

--- a/js/components/report/feedback-options-view.js
+++ b/js/components/report/feedback-options-view.js
@@ -18,14 +18,14 @@ export default class FeedbackOptionsView extends PureComponent {
   renderMaxScore() {
     const {scoreType, maxScore, setMaxScore, scoreEnabled} = this.props;
     if (scoreType === MANUAL_SCORE) {
+      const initialValue = typeof maxScore === "undefined" ? MAX_SCORE_DEFAULT : maxScore;
       return (
         <span>
           <label className="max-score" data-cy="max-score">Max. Score</label>
           <NumericTextField
             className="max-score-input"
-            value={maxScore}
+            initialValue={initialValue}
             min={1}
-            default={MAX_SCORE_DEFAULT}
             onChange={setMaxScore}
             disabled={!scoreEnabled}
           />

--- a/js/components/report/feedback-options-view.js
+++ b/js/components/report/feedback-options-view.js
@@ -89,7 +89,7 @@ export default class FeedbackOptionsView extends PureComponent {
         onChange={changeScoreType}
       >
         <div>
-          <Radio value={MANUAL_SCORE} />
+          <Radio value={MANUAL_SCORE} data-cy="manual-score-option"/>
           <span className="tooltip" data-tip data-for="MANUAL_SCORE">
             {MANUAL_SCORE_L}
           </span>
@@ -97,14 +97,14 @@ export default class FeedbackOptionsView extends PureComponent {
         </div>
 
         <div>
-          <Radio value={AUTOMATIC_SCORE} />
+          <Radio value={AUTOMATIC_SCORE} data-cy="automatic-score-option"/>
           <span className="tooltip" data-tip data-for="AUTOMATIC_SCORE">
             {AUTOMATIC_SCORE_L}
           </span>
         </div>
         { rubricAvailable
           ? <div className={useRubric ? "" : "disabled"}>
-            <Radio value={RUBRIC_SCORE} disabled={!useRubric} />
+            <Radio value={RUBRIC_SCORE} disabled={!useRubric} data-cy="rubric-score-option"/>
             <span className="tooltip" data-tip data-for="RUBRIC_SCORE">
               {RUBRIC_SCORE_L}
             </span>

--- a/js/components/report/numeric-text-field.js
+++ b/js/components/report/numeric-text-field.js
@@ -55,7 +55,21 @@ class NumericTextField extends PureComponent {
 
   render() {
     const { className, disabled } = this.props;
-    const { value } = this.state;
+    // If the parent component changes the props.value after the component is mounted
+    // this change isn't reflected in the UI.
+    // I think this use case only happens when the parent component also disables the
+    // NumericTextField, so the code below fixes it by ignoring the state.value.
+    //
+    // However, this doesnt seem like the right way to solve the problem. This component
+    // is trying to be an input and output at the same time. And in most cases the parent
+    // is actually managing the state. So it might be better to stop using state.value
+    // all together.
+    //
+    // It might not be useful, but this post talks about something of a similiar scenario:
+    // https://stackoverflow.com/a/49868300/3195497
+    // However the main use case of mixing state and props seems to be when computing an
+    // expensive state value. That isn't the case for us.
+    const value = disabled ? this.props.value : this.state.value;
     return (
       <input
         className={className}

--- a/js/components/report/numeric-text-field.js
+++ b/js/components/report/numeric-text-field.js
@@ -1,79 +1,60 @@
 import React, { PureComponent } from "react"; // eslint-disable-line
 
-// Numeric text fields DEFAULT value is not
-// the same thing as MAX_SCORE_DEFAULT.
-const DEFAULT_NUMERIC_INPUT_VALUE = 0;
 const DEFAULT_NUMERIC_MIN_VALUE = 0;
 
+// This is an uncontrolled component
+// it keeps a draftValue in its state as the user is typing
+// when onBlur happens the draftValue is converted to a number
+// and props.onChange is called with the new value
 class NumericTextField extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
       showOnlyNeedReview: true,
       showFeedbackPanel: false,
-      value: 0,
+      draftValue: props.initialValue || 0,
+      lastValue: props.initialValue || 0,
     };
     this.updateValue = this.updateValue.bind(this);
     this.setValue = this.setValue.bind(this);
   }
 
-  componentDidMount() {
-    const {value} = this.props;
-    this.setState({value: value});
-  }
-
   updateValue(event) {
-    this.setState({value: event.target.value});
+    this.setState({draftValue: event.target.value});
   }
 
   setValue(event) {
     const {min, onChange} = this.props;
-    const numericValue = parseInt(this.state.value, 10);
-    const lastValue = this.props.value;
-
-    const defaultValue = typeof this.props.default === "undefined"
-      ? DEFAULT_NUMERIC_INPUT_VALUE
-      : this.props.default;
+    const numericValue = parseInt(this.state.draftValue, 10);
+    const lastValue = this.state.lastValue;
 
     const minValue = typeof min === "undefined"
       ? DEFAULT_NUMERIC_MIN_VALUE
       : min;
 
     let newValue = isNaN(numericValue)
-      ? defaultValue
+      ? lastValue
       : numericValue;
 
     newValue = newValue >= minValue
       ? newValue
-      : defaultValue;
+      : lastValue;
 
     this.setState({value: newValue});
     if ((newValue !== lastValue) && onChange) {
+      this.setState({lastValue: newValue});
       onChange(newValue);
     }
   }
 
   render() {
     const { className, disabled } = this.props;
-    // If the parent component changes the props.value after the component is mounted
-    // this change isn't reflected in the UI.
-    // I think this use case only happens when the parent component also disables the
-    // NumericTextField, so the code below fixes it by ignoring the state.value.
-    //
-    // However, this doesnt seem like the right way to solve the problem. This component
-    // is trying to be an input and output at the same time. And in most cases the parent
-    // is actually managing the state. So it might be better to stop using state.value
-    // all together.
-    //
-    // It might not be useful, but this post talks about something of a similiar scenario:
-    // https://stackoverflow.com/a/49868300/3195497
-    // However the main use case of mixing state and props seems to be when computing an
-    // expensive state value. That isn't the case for us.
-    const value = disabled ? this.props.value : this.state.value;
+    const { draftValue } = this.state;
+
     return (
       <input
         className={className}
-        value={value}
+        value={draftValue}
         onChange={this.updateValue}
         onBlur={this.setValue}
         disabled={disabled}

--- a/js/components/report/score-box.js
+++ b/js/components/report/score-box.js
@@ -5,19 +5,35 @@ export default class ScoreBox extends PureComponent {
     super(props);
   }
 
+  // The score property is a little confusing here
+  // when the ScoreBox is disabled changes to the score property will be shown
+  // when it is not disable, the score property just initializes the text field.
+  // If you need the score to update you'll need to recreate the ScoreBox or switch it
+  // to disabled and then enabled.
+  renderScore(props) {
+    const {score, onChange, disabled } = props;
+    if (disabled) {
+      return <input
+        className="score-input"
+        value={score}
+        disabled="true"
+      />;
+    } else {
+      return <NumericTextField
+        className="score-input"
+        initialValue={score}
+        min={0}
+        onChange={onChange}
+        disabled={disabled}
+      />;
+    }
+  }
+
   render() {
-    const {score} = this.props;
     return (
       <div className="score" data-cy="question-feedback-score">
         Score:
-        <NumericTextField
-          className="score-input"
-          value={score}
-          min={0}
-          default={0}
-          onChange={this.props.onChange}
-          disabled={this.props.disabled}
-        />
+        {this.renderScore(this.props)}
       </div>
     );
   }

--- a/js/components/report/score-box.js
+++ b/js/components/report/score-box.js
@@ -16,7 +16,7 @@ export default class ScoreBox extends PureComponent {
       return <input
         className="score-input"
         value={score}
-        disabled="true"
+        disabled={true}
       />;
     } else {
       return <NumericTextField

--- a/js/components/report/score-box.js
+++ b/js/components/report/score-box.js
@@ -8,7 +8,7 @@ export default class ScoreBox extends PureComponent {
   render() {
     const {score} = this.props;
     return (
-      <div className="score">
+      <div className="score" data-cy="question-feedback-score">
         Score:
         <NumericTextField
           className="score-input"

--- a/js/containers/report/activity-feedback-panel.js
+++ b/js/containers/report/activity-feedback-panel.js
@@ -211,7 +211,7 @@ class ActivityFeedbackPanel extends PureComponent {
             </div>
           </div>
           <div className="footer">
-            <Button onClick={hide}>Done</Button>
+            <Button onClick={hide} data-cy="feedback-done-button">Done</Button>
           </div>
         </div>
       </div>

--- a/js/containers/report/question-feedback-panel.js
+++ b/js/containers/report/question-feedback-panel.js
@@ -216,7 +216,7 @@ class QuestionFeedbackPanel extends PureComponent {
             </div>
           </div>
           <div className="footer">
-            <Button onClick={this.hideFeedback}>Done</Button>
+            <Button onClick={this.hideFeedback} data-cy="feedback-done-button">Done</Button>
           </div>
         </div>
       </div>

--- a/js/store/configure-store.js
+++ b/js/store/configure-store.js
@@ -1,14 +1,16 @@
-import { createStore, applyMiddleware } from "redux";
+import { createStore, applyMiddleware, compose } from "redux";
 import thunkMiddleware from "redux-thunk";
 import apiMiddleware from "../api-middleware";
 import rootReducer from "../reducers";
 // import createLogger from 'redux-logger'
 
 export default function configureStore(initialState) {
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
   return createStore(
     rootReducer,
     initialState,
     // apiMiddleware can now use thunk when calling `next()`
-    applyMiddleware(apiMiddleware, thunkMiddleware), //, createLogger())
+    composeEnhancers( applyMiddleware(apiMiddleware, thunkMiddleware)), //, createLogger())
   );
 }

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,8 @@
     // Add dev tools support when debugging cypress tests
     if (window.Cypress) {
       window['__REACT_DEVTOOLS_GLOBAL_HOOK__'] = window.parent['__REACT_DEVTOOLS_GLOBAL_HOOK__'];
+      window['__REDUX_DEVTOOLS_EXTENSION__'] = window.parent['__REDUX_DEVTOOLS_EXTENSION__'];
+      window['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'] = window.parent['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'];
     }
   </script>
   <script src='https://use.typekit.com/juj7nhw.js'></script>

--- a/test/components/report/numeric-text-field_spec.js
+++ b/test/components/report/numeric-text-field_spec.js
@@ -4,8 +4,8 @@ import NumericTextField from "../../../js/components/report/numeric-text-field";
 
 describe("<NumericTextField /> minValue prop", () => {
 
-  describe("default behavior with no configuration", () => {
-    it("should not allow non-numeric values, and default to 0", () => {
+  describe("initialValue behavior with no configuration", () => {
+    it("should not allow non-numeric values, and initialValue to 0", () => {
       const wrapper = shallow(<NumericTextField />);
       wrapper.find("input").simulate("change", { target: { value: "x" } });
       wrapper.find("input").simulate("blur", {});
@@ -25,15 +25,15 @@ describe("<NumericTextField /> minValue prop", () => {
     });
   });
 
-  describe("When default value is set to 10", () => {
+  describe("When initialValue value is set to 10", () => {
     it("wont allow non-numeric values. Revert to 10", () => {
-      const wrapper = shallow(<NumericTextField default={10} />);
+      const wrapper = shallow(<NumericTextField initialValue={10} />);
       wrapper.find("input").simulate("change", { target: { value: "x" } });
       wrapper.find("input").simulate("blur", {});
       expect(wrapper.state("value")).toBe(10);
     });
     it("wont allow negative numbers. Revert to 10", () => {
-      const wrapper = shallow(<NumericTextField default={10} />);
+      const wrapper = shallow(<NumericTextField initialValue={10} />);
       wrapper.find("input").simulate("change", { target: { value: "-1" } });
       wrapper.find("input").simulate("blur", {});
       expect(wrapper.state("value")).toBe(10);
@@ -41,13 +41,13 @@ describe("<NumericTextField /> minValue prop", () => {
 
     describe("When min value is set to 0", () => {
       it("will allow 0.", () => {
-        const wrapper = shallow(<NumericTextField default={10} min={0} />);
+        const wrapper = shallow(<NumericTextField initialValue={10} min={0} />);
         wrapper.find("input").simulate("change", { target: { value: "0" } });
         wrapper.find("input").simulate("blur", {});
         expect(wrapper.state("value")).toBe(0);
       });
       it("wont allow negative numbers; will revert to 10", () => {
-        const wrapper = shallow(<NumericTextField default={10} min={0} />);
+        const wrapper = shallow(<NumericTextField initialValue={10} min={0} />);
         wrapper.find("input").simulate("change", { target: { value: "-1" } });
         wrapper.find("input").simulate("blur", {});
         expect(wrapper.state("value")).toBe(10);
@@ -56,7 +56,7 @@ describe("<NumericTextField /> minValue prop", () => {
 
     describe("When min value is set to -10", () => {
       it("will allow negative values > -10", () => {
-        const wrapper = shallow(<NumericTextField default={10} min={-10} />);
+        const wrapper = shallow(<NumericTextField initialValue={10} min={-10} />);
         wrapper.find("input").simulate("change", { target: { value: "-3" } });
         wrapper.find("input").simulate("blur", {});
         expect(wrapper.state("value")).toBe(-3);
@@ -65,7 +65,7 @@ describe("<NumericTextField /> minValue prop", () => {
 
     describe("When min value is set to 1", () => {
       it("wont allow 0. Will revert to 10", () => {
-        const wrapper = shallow(<NumericTextField default={10} min={1} />);
+        const wrapper = shallow(<NumericTextField initialValue={10} min={1} />);
         wrapper.find("input").simulate("change", { target: { value: "0" } });
         wrapper.find("input").simulate("blur", {});
         expect(wrapper.state("value")).toBe(10);


### PR DESCRIPTION
The automatic total scoring which adds up the manual scores for individual questions was not reporting the correct value to the teacher. 

The cause of this problem was that the code was assuming a change of the value property on the NumericInputComponent would change the display. This component was mixing the patterns of controlled and uncontrolled components.  To fix the problem I made the NumericInputComponent be a explicitly uncontrolled. The parent components that use NumericInputComponent now have to deal with this uncontrolled approach. In some cases this is good because it makes the score behave the same as the text feedback box which is also uncontrolled. 

Bugs found while working on this:

- the wrong maxScore is saved and sent to the server when the teacher switches from manual to automatic activity scoring. I didn't have time to fix this issue, but added a comment.  I don't think the issue is critical though since the maxScore saved on the server should not be used when the activity scoring is automatic.
- the teacher assigned score is not saved until 1 second after the teacher stops typing in it. This slows down the tests, and it also could result in lost data if the teacher sets the score and moves on too quickly.  A fix for that isn't part of this PR, but I hope to create a new PR with a fix by using a underscore's debounce utility.
- the manually entered maxScore is not remembered if a teacher quickly switches to automatic scoring and then back again. There is a comment in the tests about this, it was not fixed in this PR.

This PR includes automated tests which verify the behavior of the places where the NumericTextField component is used. It also checks that the score is shown to the student correctly, which verifies that the score is making it through the firestore apis.

PT: [#169782026]