### PR TITLE
automated student feedback test

### DIFF
--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -4,6 +4,7 @@ import React from "react";
 // import fakeData from "../../js/data/report.json";
 import sampleRubric from "../../public/sample-rubric";
 import Feedback from "../support/elements/portal-report/feedback";
+import * as firebase from "firebase";
 
 describe("Provide Feedback", function() {
   const feedback = new Feedback();
@@ -13,6 +14,11 @@ describe("Provide Feedback", function() {
     // disable browser's fetch this way the fetch polyfill is used which uses XHR
     cy.on("window:before:load", win => {
       win.fetch = null;
+    });
+
+    cy.on("window:load", win => {
+      // expose firebase to the window to help with debugging tests
+      win.firebase = firebase;
     });
 
     cy.server();
@@ -39,11 +45,23 @@ describe("Provide Feedback", function() {
     }).as("putReportSettings");
 
     let fakeServer = "http://portal.test";
-    cy.visit(`/?reportUrl=${encodeURIComponent(fakeServer)}`);
+    cy.visit(`/?reportUrl=${encodeURIComponent(fakeServer)}` +
+      "&enableFirestorePersistence=true&clearFirestorePersistence=true");
   });
 
   it("Is visible", function() {
     cy.get(".question [data-cy=feedbackButton]").should("be.visible");
+  });
+
+  it("Allows teacher to provide written feedback on the activity", function() {
+    cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
+    cy.get("#feedbackEnabled").click();
+    feedback.getScoredStudentsCount().should("be.visible").and("contain", "0");
+    cy.get(".feedback-row").first().within(() => {
+      cy.get("[data-cy=feedbackBox]").type("Your work was great!").blur();
+      cy.get(".feedback-complete input").check();
+    });
+    feedback.getScoredStudentsCount().should("be.visible").and("contain", "1");
   });
 
   it("Shows dialog when clicked", function() {
@@ -60,6 +78,27 @@ describe("Provide Feedback", function() {
       cy.get(".feedback-complete input").check();
     });
     feedback.getScoredStudentsCount().should("be.visible").and("contain", "1");
+  });
+
+  it("Shows student the feedback from the teacher", function() {
+    cy.get("[data-cy=feedbackButton]:contains('overall')").first().click();
+    cy.get("#feedbackEnabled").check();
+    cy.get("#giveScore").check();
+    feedback.getScoredStudentsCount().should("be.visible").and("contain", "0");
+    cy.get(".feedback-row:contains('Galloway')").first().within(() => {
+      cy.get("[data-cy=feedbackBox]").type("Your work was great!").blur();
+      cy.get("input.score-input").clear().type("5");
+      // TODO improve the feedbackBox so it doesn't wait a second before sending
+      // the data to the store
+      cy.wait(1000);
+      cy.get(".feedback-complete input").check();
+    });
+    feedback.getScoredStudentsCount().should("be.visible").and("contain", "1");
+
+    // Open the student page
+    cy.visit("/?studentId=3&enableFirestorePersistence=true");
+    cy.get(".act-feedback-panel").should("contain", "Your work was great!");
+    cy.get(".studentScore").should("contain", "5");
   });
 
   // with the switch to firestore this test needs to be updated

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -129,15 +129,17 @@ function fireStoreError(dispatchType: string, dispatch: Dispatch) {
   };
 }
 
+type SnapshotHandler = (snapshot: firebase.firestore.QuerySnapshot) => any;
+
 function addSnapshotDispatchListener(query: firebase.firestore.Query, receiveMsg: string,
-                                     dispatch: Dispatch, handler: function) {
+                                     dispatch: Dispatch,
+                                     handler: SnapshotHandler) {
   query.onSnapshot(snapshot => {
     if (!snapshot.empty) {
       dispatch({
         type: receiveMsg,
         response: handler(snapshot)
       });
-
     }
   }, fireStoreError(receiveMsg, dispatch));
 }

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -7,6 +7,7 @@ import {
   APIError,
   fetchRubric
 } from "./api";
+import { firestoreInitialized } from "./db";
 
 // This middleware is executed only if action includes .callAPI object.
 // It calls API action defined in callAPI.type.
@@ -49,7 +50,8 @@ export const API_FETCH_RUBRIC = "fetchRubric";
 function callApi(type, data, state) {
   switch (type) {
     case API_FETCH_PORTAL_DATA_AND_AUTH_FIRESTORE:
-      return fetchPortalDataAndAuthFirestore();
+      // Make sure firestore db is ready before fetching data
+      return firestoreInitialized.then(() => fetchPortalDataAndAuthFirestore());
     case API_UPDATE_REPORT_SETTINGS:
       return updateReportSettings(data, state.get("report").toJS());
     case API_UPDATE_FEEDBACK_SETTINGS:

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,6 @@
+// import * as firebase from "firebase";
+// firebase.firestore.setLogLevel("debug");
+
 import { Provider } from "react-redux";
 import React from "react";
 import { render } from "react-dom";

--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -1,5 +1,6 @@
 import { Map } from "immutable";
 import md5 from "md5";
+import queryString from "query-string";
 
 // Truncate strings eg:
 // truncate("this is a sentence", 5) // → "this i…"
@@ -52,3 +53,14 @@ export const validFsId = (anyPath: string) => {
     .replace(/\.\./g, safeCharacter)
     .replace(/__/g, safeCharacter);
 };
+
+export function urlParam(name: string): string | null{
+  const result = queryString.parse(window.location.search)[name];
+  if (typeof result === "string") {
+    return result;
+  } else if (result && result.length) {
+    return result[0];
+  } else {
+    return null;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2132,165 +2132,240 @@
         }
       }
     },
-    "@firebase/app": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.4.3.tgz",
-      "integrity": "sha512-UB/CLBU9ONA0m9ajPJHtHHSl/6nNQfQ0wvnpTuHFuy7e/0jeKIuBeE+18DGyCBetv20T1/1EXDtv8YF3KISong==",
+    "@firebase/analytics": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.2.6.tgz",
+      "integrity": "sha512-ttuR26j0tT0Uz5Cic/xsbCdXY2VcYAo3jF1ybAvSelq0DDpHkX9J3vLm99L266eVEPCVmM3cmxRX7Iw/wPIsOQ==",
       "requires": {
-        "@firebase/app-types": "0.4.0",
-        "@firebase/logger": "0.1.14",
-        "@firebase/util": "0.2.17",
+        "@firebase/analytics-types": "0.2.2",
+        "@firebase/installations": "0.3.5",
+        "@firebase/util": "0.2.33",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@firebase/analytics-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.2.2.tgz",
+      "integrity": "sha512-5qLwkztNdRiLMQCsxmol1FxfGddb9xpensM2y++3rv1e0L4yI+MRR9SHSC00i847tGZDrMt2u67Dyko/xmrgCA=="
+    },
+    "@firebase/app": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.4.24.tgz",
+      "integrity": "sha512-QkyagyuBWFaBPROLuF1h+JKsZJMFREJwykwRyxxgEaH0bvfQb64AP8OMcpBswPrh2IVHv7EZXgUAzwSWNTNHdw==",
+      "requires": {
+        "@firebase/app-types": "0.4.7",
+        "@firebase/logger": "0.1.30",
+        "@firebase/util": "0.2.33",
         "dom-storage": "2.1.0",
-        "tslib": "1.9.3",
+        "tslib": "1.10.0",
         "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/app-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.4.0.tgz",
-      "integrity": "sha512-8erNMHc0V26gA6Nj4W9laVrQrXHsj9K2TEM7eL2IQogGSHLL4vet3UNekYfcGQ2cjfvwUjMzd+BNS/8S7GnfiA=="
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.4.7.tgz",
+      "integrity": "sha512-4LnhDYsUhgxMBnCfQtWvrmMy9XxeZo059HiRbpt3ufdpUcZZOBDOouQdjkODwHLhcnNrB7LeyiqYpS2jrLT8Mw=="
     },
     "@firebase/auth": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.11.2.tgz",
-      "integrity": "sha512-vx8rP85rxKg4oOhPROrQqXvFhFNCy2jCHd359mugfm3VBezBGqs15KHTFGL+agQY9hdhVbGw+EIGk3Y/ou/9zw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.13.0.tgz",
+      "integrity": "sha512-MwQA/NFUxtaqFM3wZa3iGJfs3msFzEtBL1H35oYeYlYSdq2ow023GvIioMXxs+BR5982Pia1HmzPQK6fBQu4oA==",
       "requires": {
-        "@firebase/auth-types": "0.7.0"
+        "@firebase/auth-types": "0.9.0"
       }
     },
     "@firebase/auth-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.7.0.tgz",
-      "integrity": "sha512-QEG9azYwssGWcb4NaKFHe3Piez0SG46nRlu76HM4/ob0sjjNpNTY1Z5C3IoeJYknp2kMzuQi0TTW8tjEgkUAUA=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.9.0.tgz",
+      "integrity": "sha512-G1DU4wCtcyvHCPKOhcRtlXNP7soxM8X1Fi4TlmUkYvF4sRzuL2fP7EsjkBwkscP9rqHifyjdWfrV2ry31CTd3g=="
     },
     "@firebase/database": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.4.3.tgz",
-      "integrity": "sha512-dJm76D/+L5o0h61B1CoM039/h2SxppvbKV9HbDKo4JsGbN2FOru27XXC3/JLWauILq38bxk95vzIpMqlPWcDSw==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.5.12.tgz",
+      "integrity": "sha512-DIljaH+XspE6hRHErAkXAKLDiNIJkdmz0QaAWxSxqIumXgNDcxP8jEoJUXtuztWIqAhgD8z8q9/eNyYpM/p3nA==",
       "requires": {
-        "@firebase/database-types": "0.4.0",
-        "@firebase/logger": "0.1.14",
-        "@firebase/util": "0.2.17",
-        "faye-websocket": "0.11.1",
-        "tslib": "1.9.3"
+        "@firebase/database-types": "0.4.7",
+        "@firebase/logger": "0.1.30",
+        "@firebase/util": "0.2.33",
+        "faye-websocket": "0.11.3",
+        "tslib": "1.10.0"
       },
       "dependencies": {
         "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
+        },
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
         }
       }
     },
     "@firebase/database-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.4.0.tgz",
-      "integrity": "sha512-2piRYW7t+2s/P1NPpcI/3+8Y5l2WnJhm9KACoXW5zmoAPlya8R1aEaR2dNHLNePTMHdg04miEDD9fEz4xUqzZA=="
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.4.7.tgz",
+      "integrity": "sha512-7UHZ0n6aj3sR5W4HsU18dysHMSIS6348xWTMypoA0G4mORaQSuleCSL6zJLaCosarDEojnncy06yW69fyFxZtA==",
+      "requires": {
+        "@firebase/app-types": "0.4.7"
+      }
     },
     "@firebase/firestore": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.3.3.tgz",
-      "integrity": "sha512-aO7K1Y/O8FSbVhbWhictD5NlJy2Q2W98NSkQkNoQj0J0aqHai8e3L/oj56ogbcdt6rnseiv9uHdlx6ELsQcy6Q==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.7.1.tgz",
+      "integrity": "sha512-6FOmUVdpIqVrYlGeO33YkxNrRfzizNoULxZW0pilDA/i76OcEInK2qG6dTMLmXLKTVqCLySdq0LvyZVa7zpR0w==",
       "requires": {
-        "@firebase/firestore-types": "1.3.0",
-        "@firebase/logger": "0.1.14",
-        "@firebase/webchannel-wrapper": "0.2.20",
+        "@firebase/firestore-types": "1.7.0",
+        "@firebase/logger": "0.1.30",
+        "@firebase/util": "0.2.33",
+        "@firebase/webchannel-wrapper": "0.2.31",
         "@grpc/proto-loader": "^0.5.0",
-        "grpc": "1.20.3",
-        "tslib": "1.9.3"
+        "grpc": "1.24.2",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.3.0.tgz",
-      "integrity": "sha512-XPnfAaYsKgYivgl/U1+M5ulBG9Hxv52zrZR5TuaoKCU791t/E3K85rT1ZGtEHu9Fj4CPTep2NSl8I30MQpUlHA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.7.0.tgz",
+      "integrity": "sha512-mmWeP6XRZXYHC4LIBm69LMk6QXJDp2nVct8Xs1yH3gz517w6S7KAj0NcM7ZvvGwcUoXsm79eGukkvzQWnceTJw=="
     },
     "@firebase/functions": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.7.tgz",
-      "integrity": "sha512-k0Rn2c1Nsb90Qwk9O2JCSPoH6ozxyp0WZgIPU2OoLzYrrg+fVdcEnG3Sb1YhlOU5yRA9Nuxh1pPBQA3/e/A98g==",
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.25.tgz",
+      "integrity": "sha512-NPbwZpWPpMt/YacJ4QYapOITyKd+Zvpk4f7Yiy+F6bS+X5u8RI8yyhFaF1dzWD8e3y8OD4zCKbpCVWKkYDThhA==",
       "requires": {
-        "@firebase/functions-types": "0.3.5",
-        "@firebase/messaging-types": "0.2.11",
+        "@firebase/functions-types": "0.3.10",
+        "@firebase/messaging-types": "0.3.4",
         "isomorphic-fetch": "2.2.1",
-        "tslib": "1.9.3"
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/functions-types": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.5.tgz",
-      "integrity": "sha512-3hTMqfSugCfxzT6vZPbzQ58G4941rsFr99fWKXGKFAl2QpdMBCnKmEKdg/p5M47xIPyzIQn6NMF5kCo/eICXhA=="
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.10.tgz",
+      "integrity": "sha512-QDh7HOxfUzLxj49szekgXxdkXz6ZwwK/63DKeDbRYMKzxo17I01+2GVisdBmUW5NkllVLgVvtOfqKbbEfndqdw=="
     },
     "@firebase/installations": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.1.3.tgz",
-      "integrity": "sha512-yUuiODTSvaS7fHR9KpreTG97aSWn9Ofx5/TfTsVnhlpZKOcuJtDfrfE+3CTacJ2LPQNzjxJqIxH/z6vJukQXIA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.3.5.tgz",
+      "integrity": "sha512-i/5emquF4adUM1qfxiAIc7f6bpGmU4k+OG9aowwQkhToeQGtHR1QIaxRxFqNTaThJgxvKOMP7LzZpuhzOejloQ==",
       "requires": {
-        "@firebase/installations-types": "0.1.1",
-        "@firebase/util": "0.2.17",
+        "@firebase/installations-types": "0.2.1",
+        "@firebase/util": "0.2.33",
         "idb": "3.0.2",
-        "tslib": "1.9.3"
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/installations-types": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.1.1.tgz",
-      "integrity": "sha512-M+plQIOt6p+/j/ExUgsfXe1JFAKymhBU0K3+cp7hzj52vLSpklOqNJi4LkFl41pgRFPZeKf7MrTkMhVowg3Ukw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.2.1.tgz",
+      "integrity": "sha512-647hwBhMKOjoLndCyi9XmT1wnrRc2T8aGIAoZBqy7rxFqu3c9jZRk3THfufLy1xvAJC3qqYavETrRYF3VigM7Q=="
     },
     "@firebase/logger": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.14.tgz",
-      "integrity": "sha512-WREaY2n6HzypeoovOjYefjLJqT9+zlI1wQlLMXnkSPhwuM+udIQ87orjVL6tfmuHW++u5bZh3JJAyvuRv/nciA=="
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.30.tgz",
+      "integrity": "sha512-smlUDMiOLZD7kgBzcdSbICCvDblglq0X3NUcvV450kjZxOOPY1jPK54Qd/m0qbKrRlHWwr83reJGcPQDVBXd+A=="
     },
     "@firebase/messaging": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.3.22.tgz",
-      "integrity": "sha512-fkT+6Vjz5itcvePNKrbQ99D9SKA4y8TI0Rjtig5KR8dM3tClQYepXEWdsSURKiD3cETPU8BSJ01sXdgT90Kb0A==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.5.6.tgz",
+      "integrity": "sha512-82c7R559grAuAYKMWZtV2WyT/3MuSCaO8E0Ks/77Ner293cAPiMckUPoqmavn7n2qZqhwAtZxEMtsBOM0Um9bQ==",
       "requires": {
-        "@firebase/messaging-types": "0.2.11",
-        "@firebase/util": "0.2.17",
-        "tslib": "1.9.3"
+        "@firebase/installations": "0.3.5",
+        "@firebase/messaging-types": "0.3.4",
+        "@firebase/util": "0.2.33",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/messaging-types": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.2.11.tgz",
-      "integrity": "sha512-uWtzPMj1mAX8EbG68SnxE12Waz+hRuO7vtosUFePGBfxVNNmPx5vJyKZTz+hbM4P77XddshAiaEkyduro4gNgA=="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.3.4.tgz",
+      "integrity": "sha512-ytOzB08u8Z15clbq9cAjhFzUs4WRy13A7gRphjnf5rQ+gsrqb4mpcsGIp0KeOcu7MjcN9fqjO5nbVaw0t2KJpQ=="
     },
     "@firebase/performance": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.4.tgz",
-      "integrity": "sha512-JWurXwaq+1OjOCO8mRZboWRHKQ6/+u4vPGqGrx0pelXSlG2Wnuk0tNlilmtLI2sfSTaKhRfP1HSTcpLY8RRCXw==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.25.tgz",
+      "integrity": "sha512-XFm+Xmdzeo/bO//a2OMI7bstopalgkEiTGVySIV598SG6LZ5fIHRTOVN4h5fDqfizWek9kLUVrg3g4i7F/h/Fg==",
       "requires": {
-        "@firebase/installations": "0.1.3",
-        "@firebase/logger": "0.1.14",
-        "@firebase/performance-types": "0.0.1",
-        "@firebase/util": "0.2.17",
-        "tslib": "1.9.3"
+        "@firebase/installations": "0.3.5",
+        "@firebase/logger": "0.1.30",
+        "@firebase/performance-types": "0.0.5",
+        "@firebase/util": "0.2.33",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/performance-types": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.1.tgz",
-      "integrity": "sha512-U45GbVAnPyz7wPLd3FrWdTeaFSvgsnGfGK58VojfEMmFnMAixCM3qBv1XJ0xfhyKbK1xZN4+usWAR8F3CwRAXw=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.5.tgz",
+      "integrity": "sha512-7BOQ2sZZzaIvxscgan/uP8GcH2FZXzqGcQnXvUZBXfXignAM80hJ7UOjVRETa4UjtDehWcD/pZDDivupKtKUyg=="
     },
     "@firebase/polyfill": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.14.tgz",
-      "integrity": "sha512-MnJRIS2iqGfQ4SGFFZ441B1VBHgmHiGznpA3gN+FzSdqg9di4sIHw2gM0VOGS6e7jRJxYeyHL3rwzzU43kP+UQ==",
+      "version": "0.3.28",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.28.tgz",
+      "integrity": "sha512-sDYzcxx94oripcZb/bl3BkAVmCWkRQBc0l0hh+18yztrJR0F7BaltGgxVpy/T0Ntv5ZoQfMupHaDOTjYVnXT6g==",
       "requires": {
-        "core-js": "3.0.1",
-        "promise-polyfill": "8.1.0",
+        "core-js": "3.4.0",
+        "promise-polyfill": "8.1.3",
         "whatwg-fetch": "2.0.4"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-          "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.0.tgz",
+          "integrity": "sha512-lQxb4HScV71YugF/X28LtePZj9AB7WqOpcB+YztYxusvhrgZiQXPmCYfPC5LHsw/+ScEtDbXU3xbqH3CjBRmYA=="
         },
         "whatwg-fetch": {
           "version": "2.0.4",
@@ -2299,37 +2374,76 @@
         }
       }
     },
-    "@firebase/storage": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.2.16.tgz",
-      "integrity": "sha512-R/qLIqp7ht7T0P2w3LWB5JvXUZMCWzrHOyublAa4iSVcuqN2SLMIpqnYXNKYk+o/NcW7jO8DE8c62mnpvsS+pw==",
+    "@firebase/remote-config": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.6.tgz",
+      "integrity": "sha512-SD9kT24PWiyV9quNb81PJsHPHw/txhnlGO3Uv5ihAINcYLSOAukjSuWUrtNMa0ISOtS5fP2e+4wUU+zc7VXZrg==",
       "requires": {
-        "@firebase/storage-types": "0.2.11",
-        "tslib": "1.9.3"
+        "@firebase/installations": "0.3.5",
+        "@firebase/logger": "0.1.30",
+        "@firebase/remote-config-types": "0.1.2",
+        "@firebase/util": "0.2.33",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@firebase/remote-config-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.2.tgz",
+      "integrity": "sha512-V1LutCn9fHC5ckkjJFGGB7z72xdg50RVaCkR80x4iJXqac0IpbEr1/k29HSPKiAlf+aIYyj6gFzl7gn4ZzsUcA=="
+    },
+    "@firebase/storage": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.19.tgz",
+      "integrity": "sha512-mPq1UL82rzpZjXWWJPeEYxPhStvNUChx2wYEehpGEyD9cNwrFIJFUzgFH7cobENWt3+lnJjHbF0BgxdGY2iS8Q==",
+      "requires": {
+        "@firebase/storage-types": "0.3.5",
+        "@firebase/util": "0.2.33",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/storage-types": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.2.11.tgz",
-      "integrity": "sha512-vGTFJmKbfScmCAVUamREIBTopr5Uusxd8xPAgNDxMZwICvdCjHO0UH0pZZj6iBQuwxLe/NEtFycPnu1kKT+TPw=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.5.tgz",
+      "integrity": "sha512-rbG6ge3xmte0nUt0asMToPqmNRU4tCJuu73Uy0UJV4uMBQA7e27EXbPza3nBpeOrgASBV9eWPD5AzecjBvTyzQ=="
     },
     "@firebase/util": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.17.tgz",
-      "integrity": "sha512-RvHkhQUkihI4JafJmB7S7Q8qVDFPD+kQdSmUyVTR2sEzxkk92MsIq4dBYnSjOMmnCe7L5lmB6hJdzkHa/TAP5A==",
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.33.tgz",
+      "integrity": "sha512-Z4gUew2wtPhLU9SKrHL8c3H66+MjY2JKtrlGLNdIVJGgR4i7AoNPnPdi13mpTXPKVuHe9ANDq/O04GfY89WXug==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.20.tgz",
-      "integrity": "sha512-TpqR1qCn117fY4mrxSGqv/CT/iAM58sHdlS8ujj0Roa7DoleAHJzqOhNNoHCNncwvNDWcvygLsEiTBuDQZsv3A=="
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.31.tgz",
+      "integrity": "sha512-o3eXD0g9hFVcJIncFcW4/tYFEgQb+KF7tPU46wQBBh5pR7dHNOOkp3SQC1xoduqghcT5nr3N5LUIT/7Bde3D/A=="
     },
     "@grpc/proto-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.1.tgz",
-      "integrity": "sha512-3y0FhacYAwWvyXshH18eDkUI40wT/uGio7MAegzY8lO5+wVsc19+1A7T0pPptae4kl7bdITL+0cHpnAPmryBjQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
+      "integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -2823,6 +2937,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2924,8 +3047,7 @@
     "@types/node": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
-      "dev": true
+      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -3852,7 +3974,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -4011,6 +4134,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4885,7 +5009,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -6662,22 +6787,24 @@
       }
     },
     "firebase": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-6.0.4.tgz",
-      "integrity": "sha512-y/A30wf9MQU4Ca/2WUiPdCNWCB/3WMFgwrqmOCV5NDK2tkPC5Ls7uswTzsx9eWMlj4FvqbmbDpXlgio24ePVhw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.4.0.tgz",
+      "integrity": "sha512-wGUMmtzKSmmHP1P0wCQYutg6b19RuoqW7CLYoQu5YtaCOGR0OACA8VbHuPm88iQh/v/Qj3r/tHgmFEygnMkc/w==",
       "requires": {
-        "@firebase/app": "0.4.3",
-        "@firebase/app-types": "0.4.0",
-        "@firebase/auth": "0.11.2",
-        "@firebase/database": "0.4.3",
-        "@firebase/firestore": "1.3.3",
-        "@firebase/functions": "0.4.7",
-        "@firebase/installations": "0.1.3",
-        "@firebase/messaging": "0.3.22",
-        "@firebase/performance": "0.2.4",
-        "@firebase/polyfill": "0.3.14",
-        "@firebase/storage": "0.2.16",
-        "@firebase/util": "0.2.17"
+        "@firebase/analytics": "0.2.6",
+        "@firebase/app": "0.4.24",
+        "@firebase/app-types": "0.4.7",
+        "@firebase/auth": "0.13.0",
+        "@firebase/database": "0.5.12",
+        "@firebase/firestore": "1.7.1",
+        "@firebase/functions": "0.4.25",
+        "@firebase/installations": "0.3.5",
+        "@firebase/messaging": "0.5.6",
+        "@firebase/performance": "0.2.25",
+        "@firebase/polyfill": "0.3.28",
+        "@firebase/remote-config": "0.1.6",
+        "@firebase/storage": "0.3.19",
+        "@firebase/util": "0.2.33"
       }
     },
     "flush-write-stream": {
@@ -6887,7 +7014,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.9",
@@ -7506,6 +7634,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7609,14 +7738,15 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.20.3.tgz",
-      "integrity": "sha512-GsEsi0NVj6usS/xor8pF/xDbDiwZQR59aZl5NUZ59Sy2bdPQFZ3UePr5wevZjHboirRCIQCKRI1cCgvSWUe2ag==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
       "requires": {
+        "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
-        "node-pre-gyp": "^0.13.0",
+        "node-pre-gyp": "^0.14.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
@@ -7653,7 +7783,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true
         },
         "cliui": {
@@ -7682,6 +7812,13 @@
           "version": "1.0.2",
           "bundled": true
         },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true
@@ -7695,10 +7832,10 @@
           "bundled": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -7719,19 +7856,31 @@
             "wide-align": "^1.1.0"
           }
         },
+        "glob": {
+          "version": "7.1.4",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -7746,7 +7895,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -7789,7 +7938,7 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -7797,10 +7946,10 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -7816,30 +7965,21 @@
             }
           }
         },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true
+        },
         "needle": {
-          "version": "2.3.1",
+          "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "bundled": true
-            }
           }
         },
         "node-pre-gyp": {
-          "version": "0.13.0",
+          "version": "0.14.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -7851,7 +7991,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -7867,7 +8007,7 @@
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.6",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -7928,7 +8068,7 @@
           "bundled": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true
         },
         "protobufjs": {
@@ -7966,24 +8106,10 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "requires": {
             "glob": "^7.1.3"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.3",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "safe-buffer": {
@@ -7999,7 +8125,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "set-blocking": {
@@ -8038,16 +8164,16 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -8071,7 +8197,7 @@
           "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true
         },
         "yargs": {
@@ -8544,6 +8670,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8552,7 +8679,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -11157,6 +11285,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11935,6 +12064,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -12297,7 +12427,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -12661,9 +12792,9 @@
       "dev": true
     },
     "promise-polyfill": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
-      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA=="
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
     },
     "prompts": {
       "version": "2.2.1",
@@ -12732,9 +12863,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
-          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
+          "version": "10.17.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
+          "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
         }
       }
     },
@@ -15860,7 +15991,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "aws-sdk": "^2.451.0",
     "bootstrap": "^3.3.6",
     "chroma-js": "^2.0.3",
-    "firebase": "^6.0.4",
+    "firebase": "^7.4.0",
     "formik": "^1.5.4",
     "humps": "^2.0.1",
     "iframe-phone": "^1.2.0",

--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,10 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'UA-6899787-60');
+    // Add dev tools support when debugging cypress tests
+    if (window.Cypress) {
+      window['__REACT_DEVTOOLS_GLOBAL_HOOK__'] = window.parent['__REACT_DEVTOOLS_GLOBAL_HOOK__'];
+    }
   </script>
   <script src='https://use.typekit.com/juj7nhw.js'></script>
   <script>


### PR DESCRIPTION
- upgrades firebase to version 7.4.0 which includes the clearPersistence method
- adds two new url param flags to the report: enableFirestorePersistence and clearFirestorePersistence
- in order to support clearing the firestore persistence most calls to firebase.firestore() needed to be moved into promises so they could be delayed and not called until the clearing of the database was complete.  This was done by adding a 'global' promise called firestoreInitialized. Then having code that waits for this promise to resolve.
- disabling firestore Networking needed to moved earlier because in the student view some firestore requests were happening before the networking was disabled
- refactored actions/index.ts to remove redundant code which also reduced un tested code since the same function is now used in the fake data path and the real data path
- adds support for react dev tools when running app inside of cypress test runner

[#169921193]