### PR TITLE
use appropriate keys for feedback documents vs answer documents

### DIFF
--- a/cypress/integration/student-report.spec.js
+++ b/cypress/integration/student-report.spec.js
@@ -7,7 +7,7 @@ context("Student Report", () => {
   const body = new ReportBody();
 
   beforeEach(() => {
-    cy.visit("/?studentId=3");
+    cy.visit("/?studentId=3&fake-user-type=learner");
     cy.fixture("sequence-structure.json").as("sequenceData");
 
   });

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -201,16 +201,16 @@ function watchFirestoreFeedbackSettings(db: firebase.firestore.Firestore, rawPor
 // Ugh the feedback system uses diffent keys than the answer system
 function correctKey(keyName: string, receiveMsg: string) {
   const feedbackKeys = {
-    "platform_id": "platformId",
-    "platform_user_id": "platformStudentId",
-    "resource_link_id": "resourceLinkId",
-    "context_id": "contextId"
-  }
+    platform_id: "platformId",
+    platform_user_id: "platformStudentId",
+    resource_link_id: "resourceLinkId",
+    context_id: "contextId"
+  };
 
   switch (receiveMsg){
     case RECEIVE_QUESTION_FEEDBACKS:
     case RECEIVE_ACTIVITY_FEEDBACKS:
-      return feedbackKeys[keyName]
+      return feedbackKeys[keyName];
     case RECEIVE_ANSWERS:
     default:
       return keyName;

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -198,9 +198,14 @@ function watchFirestoreFeedbackSettings(db: firebase.firestore.Firestore, rawPor
   });
 }
 
+interface IStringMap {
+  [key: string]: string;
+}
+
 // Ugh the feedback system uses diffent keys than the answer system
-function correctKey(keyName: string, receiveMsg: string) {
-  const feedbackKeys = {
+// export this function so we can test it
+export function correctKey(keyName: string, receiveMsg: string) {
+  const feedbackKeys: IStringMap = {
     platform_id: "platformId",
     platform_user_id: "platformStudentId",
     resource_link_id: "resourceLinkId",

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -198,17 +198,37 @@ function watchFirestoreFeedbackSettings(db: firebase.firestore.Firestore, rawPor
   });
 }
 
+// Ugh the feedback system uses diffent keys than the answer system
+function correctKey(keyName: string, receiveMsg: string) {
+  const feedbackKeys = {
+    "platform_id": "platformId",
+    "platform_user_id": "platformStudentId",
+    "resource_link_id": "resourceLinkId",
+    "context_id": "contextId"
+  }
+
+  switch (receiveMsg){
+    case RECEIVE_QUESTION_FEEDBACKS:
+    case RECEIVE_ACTIVITY_FEEDBACKS:
+      return feedbackKeys[keyName]
+    case RECEIVE_ANSWERS:
+    default:
+      return keyName;
+  }
+}
+
 function watchCollection(db: firebase.firestore.Firestore, path: string, receiveMsg: string,
                          rawPortalData: IPortalRawData, dispatch: Dispatch) {
   let query = db.collection(path)
-   .where("platformId", "==", rawPortalData.platformId)
-   .where("resourceLinkId", "==", rawPortalData.resourceLinkId);
+   .where(correctKey("platform_id", receiveMsg), "==", rawPortalData.platformId)
+   .where(correctKey("resource_link_id", receiveMsg), "==", rawPortalData.resourceLinkId);
   if (rawPortalData.userType === "learner") {
-     query = query.where("platformStudentId", "==", rawPortalData.platformUserId.toString());
+     query = query.where(correctKey("platform_user_id", receiveMsg), "==",
+       rawPortalData.platformUserId.toString());
   } else {
      // "context_id" is theoretically redundant here, since we already filter by resource_link_id,
      // but that lets us use context_id value in the Firestore security rules.
-     query = query.where("contextId", "==", rawPortalData.contextId);
+     query = query.where(correctKey("context_id", receiveMsg), "==", rawPortalData.contextId);
   }
 
   addSnapshotDispatchListener(query, receiveMsg, dispatch,

--- a/js/api.ts
+++ b/js/api.ts
@@ -143,6 +143,14 @@ export function authFirestore(rawFirestoreJWT: string) {
   });
 }
 
+function fakeUserType(): "teacher" | "learner" {
+  const userType = urlParam("fake-user-type");
+  if (userType === "teacher" || userType === "learner") {
+    return userType;
+  }
+  return "teacher";
+}
+
 export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
   if (!getPortalBaseUrl()) {
     // disable the network when we don't have a portal url. This way the demo report will not update
@@ -187,7 +195,7 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
           offering: offeringData,
           resourceLinkId: offeringData.id.toString(),
           classInfo: classData,
-          userType: "teacher",
+          userType: fakeUserType(),
           platformId: "https://fake.portal",
           platformUserId: "1",
           contextId: classData.class_hash,

--- a/test/actions/index_spec.js
+++ b/test/actions/index_spec.js
@@ -1,0 +1,15 @@
+import {
+  RECEIVE_ANSWERS,
+  RECEIVE_QUESTION_FEEDBACKS,
+  correctKey } from "../../js/actions/index";
+
+describe("actions/index", () => {
+  describe("correctKey", () => {
+    it("Should not change keys for RECEIVE_ANSWERS", () => {
+      expect(correctKey("platform_user_id", RECEIVE_ANSWERS)).toBe("platform_user_id");
+    });
+    it("Should change keys for RECEIVE_QUESTION_FEEDBACKS", () => {
+      expect(correctKey("platform_user_id", RECEIVE_QUESTION_FEEDBACKS)).toBe("platformStudentId");
+    });
+  });
+});


### PR DESCRIPTION
Earlier I had refactored this code to reduce redundant logic when creating the collection queries. But I missed the fact the the answer documents and the feedback documents use different keys for the platform info. So this PR introduces extra logic to use the right keys.

I think the redundant refactoring is still worth it since it makes this inconsistency more visible Hopefully we can unify these keys in the future and remove the extra key logic.