### PR TITLE
Fix: Activity order scrambled in teacher dashboard

### DIFF
--- a/js/components/dashboard/dashboard.js
+++ b/js/components/dashboard/dashboard.js
@@ -133,7 +133,15 @@ export default class Dashboard extends PureComponent {
     const anyStudentExpanded = expandedStudents.includes(true);
     const anyQuestionExpanded = expandedQuestions.includes(true);
     const showTallQuestionHeader = anyStudentExpanded || anyQuestionExpanded;
-    const activitiesList = activities.toList().filter(activity => activity.get("visible"));
+    const compareActivityByIndex = (a1, a2) => {
+      return a1.get("activityIndex") - a2.get("activityIndex");
+    };
+
+    const activitiesList = activities
+      .toList()
+      .filter(activity => activity.get("visible"))
+      .sort(compareActivityByIndex);
+
     return (
       <div ref={el => { this.mainContainer = el; }} className={css.dashboard}>
         <div className={css.innerContainer}>


### PR DESCRIPTION
The `toList()` call in the dashboard view made the assumption that the index order would be preserved in the conversion from map → list.
We need to manually sort on index after the conversion to a list.

I was trying to find a better place to do this sort, but its easy and clear to do it here in the `Dashboard` rendering.

[#170757052]
https://www.pivotaltracker.com/n/projects/736901/stories/170757052