### PR TITLE
Better 🐞 fix  for Activity scrambled in dashboard

### DIFF
--- a/js/containers/dashboard/dashboard-app.js
+++ b/js/containers/dashboard/dashboard-app.js
@@ -15,7 +15,7 @@ import Header from "../../components/common/header";
 import HelpModal from "../../components/dashboard/help-modal";
 import DataFetchError from "../../components/report/data-fetch-error";
 import LoadingIcon from "../../components/report/loading-icon";
-import { getActivityTrees } from "../../selectors/report-tree";
+import { getActivityTrees, getSequenceTree } from "../../selectors/report-tree";
 import { getStudentProgress, getSortedStudents, getSelectedQuestion } from "../../selectors/dashboard-selectors";
 import css from "../../../css/dashboard/dashboard-app.less";
 
@@ -51,7 +51,11 @@ class DashboardApp extends PureComponent {
 
   render() {
     const { initialLoading } = this.state;
-    const { error, clazzName, activityTrees, students, studentProgress, expandedStudents, expandedActivities, expandedQuestions, setActivityExpanded, setStudentExpanded, setQuestionExpanded, setStudentsExpanded, setStudentSort, selectedQuestion, selectQuestion, trackEvent } = this.props;
+    const { error, clazzName, sequenceTree, students, studentProgress, expandedStudents, expandedActivities, expandedQuestions, setActivityExpanded, setStudentExpanded, setQuestionExpanded, setStudentsExpanded, setStudentSort, selectedQuestion, selectQuestion, trackEvent } = this.props;
+
+    // In order to get list the activies in correct right order,
+    // they must be obtained via the child reference in the sequenceTree …
+    const activityTrees = sequenceTree && sequenceTree.get("children");
     return (
       <div className={css.dashboardApp}>
         <Header onHelpButtonClick={this.toggleHelpModal} background="#6fc6da" />
@@ -96,7 +100,7 @@ function mapStateToProps(state) {
     error: error,
     clazzName: dataDownloaded && state.getIn(["report", "clazzName"]),
     students: dataDownloaded && getSortedStudents(state),
-    activityTrees: dataDownloaded && getActivityTrees(state),
+    sequenceTree: dataDownloaded && getSequenceTree(state),
     studentProgress: dataDownloaded && getStudentProgress(state),
     expandedActivities: state.getIn(["dashboard", "expandedActivities"]),
     expandedStudents: state.getIn(["dashboard", "expandedStudents"]),

--- a/test/selectors/report-tree_spec.js
+++ b/test/selectors/report-tree_spec.js
@@ -32,12 +32,16 @@ describe("report tree selectors", () => {
         1: { id: 1, children: [ 1 ], someSectionProp: "x" },
         2: { id: 2, children: [ 2 ], someSectionProp: "y" }
       },
+
+      // NB: Activities is a map, its order is not guarenteed:
       activities: {
-        1: { id: 1, children: [ 1 ], someActivityProp: "x" },
-        2: { id: 2, children: [ 2 ], someActivityProp: "y" }
+        "1-act": { id: "1-act", children: [ 2 ], someActivityProp: "y" },
+        "2-act": { id: "2-act", children: [ 1 ], someActivityProp: "x" }
       },
+
+      // NB: In the sequence 2-act comes before 1-act
       sequences: {
-        1: { id: 1, children: [ 1, 2 ], someSequenceProp: "x" }
+        1: { id: 1, children: [ "2-act", "1-act" ], someSequenceProp: "x" }
       },
       // additional props that get merged into tree:
       hideSectionNames: hideSectionNames
@@ -99,17 +103,19 @@ describe("report tree selectors", () => {
       children: [ expectedPageTrees({})[2] ]
     }
   });
+
+  // NB: 2-act is the first activity, 1-act is the second activity
   const expectedActivityTrees = ({ questionVisible = true }) => ({
-    1: {
-      id: 1,
+    "2-act": {
+      id: "2-act",
       someActivityProp: "x",
       visible: questionVisible,
       children: [ expectedSectionTrees({ questionVisible })[1] ],
       pages: [ expectedPageTrees({ questionVisible })[1] ],
       questions: [ expectedQuestionTrees({ questionVisible })["open_response-1"] ]
     },
-    2: {
-      id: 2,
+    "1-act": {
+      id: "1-act",
       someActivityProp: "y",
       visible: true,
       children: [ expectedSectionTrees({})[2] ],
@@ -117,12 +123,14 @@ describe("report tree selectors", () => {
       questions: [ expectedQuestionTrees({})["image_question-2"] ]
     }
   });
+
   const expectedSequenceTree = ({ questionVisible = true }) => ({
     id: 1,
     someSequenceProp: "x",
     children: [
-      expectedActivityTrees({ questionVisible })[1],
-      expectedActivityTrees({})[2]
+      // NB: 2-act is the first activity, 1-act is the second activity
+      expectedActivityTrees({ questionVisible })["2-act"],
+      expectedActivityTrees({})["1-act"]
     ]
   });
 


### PR DESCRIPTION
A better fix for 🐞 Activity order scrambled in teacher dashboard
[#170757052]

The previous PR sorted the activities (from activityTree) by the position attributes.

That sorting is not required if we use the `getSequenceTree()` Selector which is careful to
map deep references to children by `id` from the shallow normalized representation of the children array.

`report-tree_spec.js` was modified to use keys instead of numeric indexes.

The activity map in the spec was modified so that the keys were out of sort order.

[#170757052]

https://www.pivotaltracker.com/story/show/170757052