### PR TITLE
Standalone iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,13 @@ when you view the class details, you will see a "Local Tracked Q" button next to
 
 Besides the parameters needed for loading data, the report also supports
 
-* `studentId`:  This shows the report for a single student, and removes some UI affordances. The filtering of the student
-                data happens client-side.
-* `iframeQuestionId`: This, combined with a valid `studentId`, will show a stand-alone, full-size iframe containing the
-                model referenced by iframeQuestionId, and the answer saved by studentId (either as state or as a url).
+* `studentId={id}`:   This shows the report for a single student, and removes some UI affordances. The filtering of the
+                      student data happens client-side.
+* `iframeQuestionId={id}`: This, combined with a valid `studentId`, will show a stand-alone, full-size iframe containing
+                      the model referenced by iframeQuestionId, and the answer saved by studentId (either as state or as
+                      a url).
+* `enableFirestorePersistence=true`: Uses a local firestore DB for data persistance across sessions and tabs. Clear the
+                      DB by going to `dev tools > Application > IndexedDB > firebaseLocalStorageDb > Delete database`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Besides the parameters needed for loading data, the report also supports
 
 * `studentId`:  This shows the report for a single student, and removes some UI affordances. The filtering of the student
                 data happens client-side.
+* `iframeQuestionId`: This, combined with a valid `studentId`, will show a stand-alone, full-size iframe containing the
+                model referenced by iframeQuestionId, and the answer saved by studentId (either as state or as a url).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,32 @@ Additional, useful resources:
 
 Note that conventions in the dashboard part of the code base are somewhat different than in the report part.
 
+### Using data
+
+Data is fetched using `api.js`.
+
+If the query parameters of the url does not include values for `offering` and `class`, we will load in fake data from
+the `js/data` folder. This data gets loaded in much the same way as real data, so can be used for testing.
+
+If we do have `offering` and `class` parameters, then `api.js` will first attempt to get the data for the offering and
+class from the portal. To do this it also needs a `token` parameter, which is used to authenticate with the portal and
+expires after one hour. Besides the class and offering data, we will also fetch a firestore JWT from the portal, given
+the classHash (from the fetched class data) and the token. Using this JWT, we can authenticate with Firestore. Once we
+have successfully authenticated, `receivePortalData` is called in `index.ts`, which starts watching the sequence
+structure and answer data.
+
+To test the portal using real data, the easiest way is simply to open a report as a teachers from the portal, and then
+replace the url host and path with `localhost:8080`. Alternatively, if you are able to edit the portal settings for the
+offering, you can add the "Developers Tracked Questions (Local)" report to the External Reports of the offering, and
+when you view the class details, you will see a "Local Tracked Q" button next to "Report" which will link to localhost.
+
+### Additional URL Parameters
+
+Besides the parameters needed for loading data, the report also supports
+
+* `studentId`:  This shows the report for a single student, and removes some UI affordances. The filtering of the student
+                data happens client-side.
+
 ## License
 
 [MIT](https://github.com/concord-consortium/grasp-seasons/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Note that conventions in the dashboard part of the code base are somewhat differ
 
 Data is fetched using `api.js`.
 
-If the query parameters of the url does not include values for `offering` and `class`, we will load in fake data from
+If the query parameters of the url do not include values for `offering` and `class`, we will load in fake data from
 the `js/data` folder. This data gets loaded in much the same way as real data, so can be used for testing.
 
 If we do have `offering` and `class` parameters, then `api.js` will first attempt to get the data for the offering and
@@ -118,7 +118,7 @@ the classHash (from the fetched class data) and the token. Using this JWT, we ca
 have successfully authenticated, `receivePortalData` is called in `index.ts`, which starts watching the sequence
 structure and answer data.
 
-To test the portal using real data, the easiest way is simply to open a report as a teachers from the portal, and then
+To test the portal using real data, the easiest way is simply to open a report as a teacher from the portal, and then
 replace the url host and path with `localhost:8080`. Alternatively, if you are able to edit the portal settings for the
 offering, you can add the "Developers Tracked Questions (Local)" report to the External Reports of the offering, and
 when you view the class details, you will see a "Local Tracked Q" button next to "Report" which will link to localhost.

--- a/css/report/iframe-standalone-app.less
+++ b/css/report/iframe-standalone-app.less
@@ -1,0 +1,20 @@
+html {
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  width: 100%;
+  height: 100%;
+}
+
+#app {
+  width: 100%;
+  height: 100%;
+}
+
+.full-size {
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/cypress/integration/inline-iframe.spec.js
+++ b/cypress/integration/inline-iframe.spec.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { getByCypressTag } from "../utils";
+import ReportBody from "../support/elements/portal-report/report-body";
+
+context("Iframe questions test", () => {
+
+  beforeEach(() => {
+      cy.visit("/");
+      cy.fixture("sequence-structure.json").as("sequenceData");
+      cy.fixture("class-data.json").as("classData");
+      cy.fixture("answers.json").as("answerData");
+  });
+
+  const body = new ReportBody();
+
+  it("shows the toggle and external links for an iframe with saved learner state", () => {
+    body.openAnswersForQuestion("question-mw_interactive_19");
+    cy.get(".iframe-answer").should("be.visible");
+    cy.get(".iframe-answer").should("contain", "View Work");
+    cy.get(".iframe-answer").should("contain", "Open in new tab");
+    cy.get(".iframe-answer").should("not.contain", "View work in new tab");
+  });
+
+  it("can toggle the iframe visibility", () => {
+    body.openAnswersForQuestion("question-mw_interactive_19");
+    cy.get(".iframe-answer a[data-cy=toggleIframe]").first().click({force: true});
+    cy.get(".iframe-answer iframe").should("be.visible")
+      .and('have.attr', 'src', 'https://models-resources.concord.org/table-interactive/index.html');
+  });
+
+  it("has the correct url for the external link", () => {
+    body.openAnswersForQuestion("question-mw_interactive_19");
+    cy.get(".iframe-answer a[data-cy=standaloneIframe]").first().then((link) => {
+      expect(link[0].href.indexOf("iframeQuestionId=mw_interactive_19&studentId=1")).to.be.above(-1);
+    });
+  });
+
+  it("shows the external links for an iframe with saved learner url", () => {
+    body.openAnswersForQuestion("question-mw_interactive_22");
+    cy.get(".iframe-answer").should("be.visible");
+    cy.get(".iframe-answer").should("contain", "View work in new tab");
+  });
+
+  it("has the correct url for the external link for a saved learner url", () => {
+    body.openAnswersForQuestion("question-mw_interactive_22");
+    cy.get(".iframe-answer a[data-cy=externalIframe]").first()
+      .should('have.attr', 'href', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19');
+  });
+});

--- a/cypress/integration/standalone-iframe.spec.js
+++ b/cypress/integration/standalone-iframe.spec.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { getByCypressTag } from "../utils";
+
+describe("Opening stand-alone iframe question with saved state", function() {
+  beforeEach(() => {
+    cy.visit("/?iframeQuestionId=mw_interactive_19&studentId=1");
+  });
+
+  it("should show an iframe with the base url", function() {
+    getByCypressTag("standaloneIframe").should("be.visible");
+    cy.get("iframe").should("exist")
+      .and('have.attr', 'src', 'https://models-resources.concord.org/table-interactive/index.html');
+  });
+});
+
+describe("Opening stand-alone iframe question with saved learner url", function() {
+  beforeEach(() => {
+    cy.visit("/?iframeQuestionId=mw_interactive_22&studentId=1");
+  });
+
+  it("should show an iframe with the saved url", function() {
+    getByCypressTag("standaloneIframe").should("be.visible");
+    cy.get("iframe").should("exist")
+      .and('have.attr', 'src', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19');
+  });
+});
+
+describe("Opening non-existant iframe question", function() {
+  beforeEach(() => {
+    cy.visit("/?iframeQuestionId=none&studentId=none");
+  });
+
+  it("should show an error", function() {
+    getByCypressTag("dataError").should("be.visible");
+    getByCypressTag("dataError").should("contain", "No data for question 'none' by student 'none'");
+    cy.get("iframe").should("not.exist");
+  });
+});

--- a/cypress/support/elements/portal-report/report-body.js
+++ b/cypress/support/elements/portal-report/report-body.js
@@ -81,6 +81,10 @@ class ReportBody {
             .should("be.visible")
             .click({ force: true });
     }
+
+    openAnswersForQuestion(questionId) {
+        cy.get(`[data-cy=${questionId}] .answers-toggle`).click({force: true})
+    }
 }
 
 export default ReportBody;

--- a/js/components/report/data-fetch-error.js
+++ b/js/components/report/data-fetch-error.js
@@ -18,7 +18,7 @@ export default class DataFetchError extends PureComponent {
     </div>;
   }
 
-  renderGenericInfo(error) {
+  renderGenericUrlInfo(error) {
     return (
       <div>
         <div>URL: {error.url}</div>
@@ -28,7 +28,18 @@ export default class DataFetchError extends PureComponent {
     );
   }
 
+  renderGenericMessage(error) {
+    return (
+      <div>
+        <div>{error}</div>
+      </div>
+    );
+  }
+
   renderError(error) {
+    if (error.body) {
+      return this.renderGenericMessage(error.body);
+    }
     switch (error.status) {
       case 401:
         return this.renderUnauthorized();
@@ -37,7 +48,7 @@ export default class DataFetchError extends PureComponent {
       case 599:
         return this.renderNetworkError(error);
       default:
-        return this.renderGenericInfo(error);
+        return this.renderGenericUrlInfo(error);
     }
   }
 
@@ -45,7 +56,7 @@ export default class DataFetchError extends PureComponent {
     const { error } = this.props;
     return (
       <div className="data-fetch-error">
-        <h2>Connection to server failed</h2>
+        <h2>{error.title || "Connection to server failed"}</h2>
         {this.renderError(error)}
       </div>
     );

--- a/js/components/report/data-fetch-error.js
+++ b/js/components/report/data-fetch-error.js
@@ -55,7 +55,7 @@ export default class DataFetchError extends PureComponent {
   render() {
     const { error } = this.props;
     return (
-      <div className="data-fetch-error">
+      <div className="data-fetch-error" data-cy="dataError">
         <h2>{error.title || "Connection to server failed"}</h2>
         {this.renderError(error)}
       </div>

--- a/js/components/report/iframe-answer.js
+++ b/js/components/report/iframe-answer.js
@@ -64,12 +64,12 @@ export default class IframeAnswer extends PureComponent {
       const standaloneLinkUrl = this.getStandaloneLinkUrl(question, answer);
       return (
         <React.Fragment>
-          <a onClick={this.toggleIframe} target="_blank">{toggleText}</a> |{" "}
-          <a href={standaloneLinkUrl} target="_blank">Open in new tab {externalLinkIcon}</a>
+          <a onClick={this.toggleIframe} target="_blank" data-cy="toggleIframe">{toggleText}</a> |{" "}
+          <a href={standaloneLinkUrl} target="_blank" data-cy="standaloneIframe">Open in new tab {externalLinkIcon}</a>
         </React.Fragment>
       );
     } else {
-      return <a href={linkUrl} target="_blank">View work in new tab {externalLinkIcon}</a>;
+      return <a href={linkUrl} target="_blank" data-cy="externalIframe">View work in new tab {externalLinkIcon}</a>;
     }
   }
 

--- a/js/components/report/iframe-answer.js
+++ b/js/components/report/iframe-answer.js
@@ -62,10 +62,12 @@ export default class IframeAnswer extends PureComponent {
     if (question.get("displayInIframe")) {
       const toggleText = iframeVisible ? "Hide" : "View Work";
       const standaloneLinkUrl = this.getStandaloneLinkUrl(question, answer);
-      return <React.Fragment>
-      <a onClick={this.toggleIframe} target="_blank">{toggleText}</a> |{" "}
-      <a href={standaloneLinkUrl} target="_blank">Open in new tab {externalLinkIcon}</a>
-    </React.Fragment>;
+      return (
+        <React.Fragment>
+          <a onClick={this.toggleIframe} target="_blank">{toggleText}</a> |{" "}
+          <a href={standaloneLinkUrl} target="_blank">Open in new tab {externalLinkIcon}</a>
+        </React.Fragment>
+      );
     } else {
       return <a href={linkUrl} target="_blank">View work in new tab {externalLinkIcon}</a>;
     }

--- a/js/components/report/interactive-iframe.js
+++ b/js/components/report/interactive-iframe.js
@@ -42,14 +42,14 @@ export default class InteractiveIframe extends PureComponent {
   }
 
   render() {
-    const { src, width, height } = this.props;
+    const { src, width, height, style } = this.props;
     return (
       // eslint-disable-next-line react/no-string-refs
       <iframe ref="iframe"
         src={src}
         width={width || "300px"}
         height={height || "300px"}
-        style={{border: "none", marginTop: "0.5em"}}
+        style={style || {border: "none", marginTop: "0.5em"}}
         allow={"fullscreen"} />
     );
   }

--- a/js/components/report/question-for-class.js
+++ b/js/components/report/question-for-class.js
@@ -29,7 +29,7 @@ export default class QuestionForClass extends PureComponent {
     return (
       <div>
         <div className={`question ${question.get("visible") ? "" : "hidden"}`}>
-          <div className="question-header">
+          <div className="question-header" data-cy={"question-" + question.get("id")}>
             <SelectionCheckbox selected={question.get("selected")} questionKey={question.get("id")} trackEvent={trackEvent} />
             <QuestionHeader question={question} url={url} />
             <a className="answers-toggle" onClick={this.toggleAnswersVisibility}>

--- a/js/containers/app.tsx
+++ b/js/containers/app.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import ReportApp from "./report/report-app";
 import DashboardApp from "./dashboard/dashboard-app";
 import PortalDashboardApp from "./portal-dashboard/portal-dashboard-app";
+import IframeStandaloneApp from "./report/iframe-standalone-app";
 import { connect } from "react-redux";
-import { DASHBOARD, PORTAL_DASHBOARD } from "../reducers";
+import { DASHBOARD, PORTAL_DASHBOARD, IFRAME_STANDALONE, FULL_REPORT } from "../reducers";
 
 interface IProps {
   viewType: string;
@@ -12,13 +13,17 @@ interface IProps {
 export class App extends React.PureComponent<IProps> {
   render() {
     const { viewType } = this.props;
-    return (
-      viewType === PORTAL_DASHBOARD
-        ? <PortalDashboardApp />
-        : viewType === DASHBOARD
-          ? <DashboardApp />
-          : <ReportApp />
-    );
+    switch (viewType) {
+      case DASHBOARD:
+        return <DashboardApp />;
+      case PORTAL_DASHBOARD:
+        return <PortalDashboardApp />;
+      case IFRAME_STANDALONE:
+        return <IframeStandaloneApp />;
+      case FULL_REPORT:
+      default:
+        return <ReportApp />;
+    }
   }
 }
 

--- a/js/containers/report/iframe-standalone-app.js
+++ b/js/containers/report/iframe-standalone-app.js
@@ -83,9 +83,9 @@ function mapStateToProps(state) {
   return {
     report: dataDownloaded && reportState,
     iframeQuestionId: iframeQuestionId,
-    answers: answers,
+    answers,
     isFetching: data.get("isFetching"),
-    error: error,
+    error,
   };
 }
 

--- a/js/containers/report/iframe-standalone-app.js
+++ b/js/containers/report/iframe-standalone-app.js
@@ -1,0 +1,104 @@
+import React, { PureComponent } from "react";
+import { connect } from "react-redux";
+import {
+  fetchAndObserveData, hideCompareView,
+  hideUnselectedQuestions, showUnselectedQuestions, setNowShowing,
+  setAnonymous, trackEvent } from "../../actions/index";
+import DataFetchError from "../../components/report/data-fetch-error";
+import LoadingIcon from "../../components/report/loading-icon";
+import InteractiveIframe from "../../components/report/interactive-iframe";
+
+import "../../../css/report/report-app.less";
+import "../../../css/report/iframe-standalone-app.less";
+import config from "../../config";
+
+class IframeStandaloneApp extends PureComponent {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    const { fetchAndObserveData } = this.props;
+    fetchAndObserveData();
+  }
+
+  renderIframe() {
+    const { report, iframeQuestionId, answers } = this.props;
+
+    const question = report.get("questions").get(iframeQuestionId);
+
+    const studentId = config("studentId");
+    const answer = answers.filter(a =>
+      a.get("questionId") === iframeQuestionId &&
+      a.get("platformUserId") === studentId
+    ).first();
+
+    if (!answer) {
+      const errorText =
+        !iframeQuestionId ? "Parameter 'iframeQuestionId' is missing" :
+        !studentId ? "Parameter 'studentId' is missing" :
+        `No data for question '${iframeQuestionId}' by student '${studentId}'`;
+      return <DataFetchError error={{title: "Unable to fetch data", body: errorText}} />;
+    }
+
+    let url;
+    let state;
+    // There are two supported answer types handled by iframe question: simple link or interactive state.
+    if (answer.get("type") === "external_link") {
+      // Answer field is just the reportable URL. We don't need any state.
+      url = answer.get("answer");
+      state = null;
+    } else if (answer.get("type") === "interactive_state") {
+      // URL field is provided by question. Answer field is a state that will be passed
+      // to the iframe using iframe-phone.
+      url = question.get("url");
+      state = answer.get("answer");
+    }
+    return (
+      <InteractiveIframe src={url} state={state} style={{border: "none"}} width="100%" height="100%" />
+    );
+  }
+
+  render() {
+    const { report, error, isFetching } = this.props;
+    return (
+      <div className="report-app full-size">
+        <div className="report full-size" style={{ opacity: isFetching ? 0.3 : 1 }}>
+          {report && this.renderIframe()}
+          {error && <DataFetchError error={error} />}
+        </div>
+        {isFetching && <LoadingIcon />}
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  const data = state.get("data");
+  const error = data.get("error");
+  const reportState = state.get("report");
+  const iframeQuestionId = reportState && reportState.get("iframeQuestionId");
+  const answers = reportState && reportState.get("answers");
+  const dataDownloaded = !error && !data.get("isFetching");
+  return {
+    report: dataDownloaded && reportState,
+    iframeQuestionId: iframeQuestionId,
+    answers: answers,
+    isFetching: data.get("isFetching"),
+    error: error,
+  };
+}
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    fetchAndObserveData: () => dispatch(fetchAndObserveData()),
+    hideUnselectedQuestions: () => dispatch(hideUnselectedQuestions()),
+    showUnselectedQuestions: () => dispatch(showUnselectedQuestions()),
+    setNowShowing: (nowShowingValue, selectedStudentIds) => dispatch(setNowShowing(nowShowingValue, selectedStudentIds)),
+    setAnonymous: value => dispatch(setAnonymous(value)),
+    hideCompareView: () => dispatch(hideCompareView()),
+    trackEvent: (category, action, label) => dispatch(trackEvent(category, action, label)),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(IframeStandaloneApp);

--- a/js/containers/report/iframe-standalone-app.js
+++ b/js/containers/report/iframe-standalone-app.js
@@ -91,13 +91,7 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    fetchAndObserveData: () => dispatch(fetchAndObserveData()),
-    hideUnselectedQuestions: () => dispatch(hideUnselectedQuestions()),
-    showUnselectedQuestions: () => dispatch(showUnselectedQuestions()),
-    setNowShowing: (nowShowingValue, selectedStudentIds) => dispatch(setNowShowing(nowShowingValue, selectedStudentIds)),
-    setAnonymous: value => dispatch(setAnonymous(value)),
-    hideCompareView: () => dispatch(hideCompareView()),
-    trackEvent: (category, action, label) => dispatch(trackEvent(category, action, label)),
+    fetchAndObserveData: () => dispatch(fetchAndObserveData())
   };
 };
 

--- a/js/containers/report/iframe-standalone-app.js
+++ b/js/containers/report/iframe-standalone-app.js
@@ -63,7 +63,7 @@ class IframeStandaloneApp extends PureComponent {
     const { report, error, isFetching } = this.props;
     return (
       <div className="report-app full-size">
-        <div className="report full-size" style={{ opacity: isFetching ? 0.3 : 1 }}>
+        <div className="report full-size" style={{ opacity: isFetching ? 0.3 : 1 }} data-cy="standaloneIframe">
           {report && this.renderIframe()}
           {error && <DataFetchError error={error} />}
         </div>

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -16,7 +16,7 @@ import {
 import { MANUAL_SCORE, RUBRIC_SCORE } from "../util/scoring-constants";
 import feedbackReducer from "./feedback-reducer";
 import dashboardReducer from "./dashboard-reducer";
-import { configBool } from "../config";
+import config, { configBool } from "../config";
 import {
   normalizeResourceJSON,
   preprocessPortalDataJSON,
@@ -27,15 +27,18 @@ import queryString from "query-string";
 export const FULL_REPORT = "fullReport";
 export const DASHBOARD = "dashboard";
 export const PORTAL_DASHBOARD = "portalDashboard";
+export const IFRAME_STANDALONE = "iframe-standalone";
 
 export function isDashboardView(viewType) {
   return (viewType === DASHBOARD) || (viewType === PORTAL_DASHBOARD);
 }
 
 const INITIAL_VIEW = Map({
-  type: configBool("portal-dashboard")
-          ? PORTAL_DASHBOARD
-          : (configBool("dashboard") ? DASHBOARD : FULL_REPORT)
+  type: config("iframeQuestionId")
+          ? IFRAME_STANDALONE :
+          configBool("portal-dashboard")
+            ? PORTAL_DASHBOARD
+            : (configBool("dashboard") ? DASHBOARD : FULL_REPORT)
 });
 
 // Defines which view / app is going to be used. A full report or a compact dashboard.
@@ -148,6 +151,7 @@ const INITIAL_REPORT_STATE = Map({
   hideSectionNames: false,
   // Note that this filter will be respected only in Dashboard report. Check report-tree.js and isQuestionVisible helper.
   showFeaturedQuestionsOnly: true,
+  iframeQuestionId: config("iframeQuestionId") || "",
 });
 
 function report(state = INITIAL_REPORT_STATE, action) {


### PR DESCRIPTION
This creates a stand-alone iframe container, to view full-size versions of student models, which can be viewed by including the url query parameters `iframeQuestionId` and `studentId`.

E.g. http://portal-report.concord.org/branch/172324236-standalone-iframe/?iframeQuestionId=mw_interactive_19&studentId=1

This also adds links for opening the stand-alone view to the main report, alongside the iframe toggles.

Currently, this just adds the link to all answers that have the property `displayInIframe`, i.e. those that should show embedded. Eventually we may want to have additional authorable properties defined in LARA which determine how the models should be displayed.