### PR TITLE
Fix errant clicks on list items

### DIFF
--- a/css/portal-dashboard/custom-select.less
+++ b/css/portal-dashboard/custom-select.less
@@ -72,9 +72,12 @@
     opacity: 0;
     transition-property: opacity;
     transition-duration: .25s;
+    pointer-events: none;
 
     &.show {
       opacity: 1;
+      pointer-events: auto;
+      cursor: pointer;
     }
 
     .listItem {
@@ -87,7 +90,6 @@
       padding: 0 5px 0 5px;
       background-color: white;
       font-size: 16px;
-      cursor: pointer;
 
       &.selected {
         font-weight: bold;


### PR DESCRIPTION
This PR fixes a small click issue that was introduced in the custom select component.  To achieve the spec's requested fade in/fade out animation, the list of items is kept in the DOM and the opacity is changed depending on if it is shown or hidden.  However, the items could still be clicked even when they were hidden.  Changes in this PR disable pointer events and show the normal cursor when the list of items is hidden.