### PR TITLE
Add anonymize students control, and feedback skeleton control

### DIFF
--- a/css/portal-dashboard/anonymize-students.less
+++ b/css/portal-dashboard/anonymize-students.less
@@ -1,0 +1,15 @@
+@import "./variables";
+
+.anonymizeStudents {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 30px;
+  margin: 0 0 3px 15px;
+
+  .label {
+    font-size: 16px;
+    margin: 0 5px 0 5px;
+    height: 20px;
+  }
+}

--- a/css/portal-dashboard/class-nav.less
+++ b/css/portal-dashboard/class-nav.less
@@ -2,9 +2,16 @@
 
 .classNav {
   position: relative;
-  box-sizing: border-box;
+  flex-shrink: 0;
   height: @top-nav-height;
   width: 240px;
-  padding: 20px;
   background-color: @cc-teal-light6;
+
+  .title {
+    height: 65px;
+  }
+
+  .studentSort {
+    margin-left: 19px;
+  }
 }

--- a/css/portal-dashboard/feedback.less
+++ b/css/portal-dashboard/feedback.less
@@ -1,0 +1,15 @@
+@import "./variables";
+
+.feedback {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 30px;
+  margin: 0 0 3px 15px;
+
+  .label {
+    font-size: 16px;
+    margin: 0 5px 0 5px;
+    height: 20px;
+  }
+}

--- a/css/portal-dashboard/num-students.less
+++ b/css/portal-dashboard/num-students.less
@@ -1,20 +1,27 @@
 @import "./variables";
 
 .numStudentsContainer {
-    width: 168px;
-    height: 30px;
-    border-radius: 15px 0px 0px 15px;
-    background-color: @cc-teal-light7;
-    position: absolute;
-    top: 150px;
-    left: 72px;
-    color: @cc-charcoal;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin: 20px 0 16px 0;
+
+    .numStudents {
+        width: 168px;
+        height: 30px;
+        border-radius: 15px 0px 0px 15px;
+        background-color: @cc-teal-light7;
+        color: @cc-charcoal;
+    }
+    .containerLabel {
+        font-weight: bold;
+        padding-left: 20px;
+    }
+    .numStudents span {
+        position: relative;
+        line-height: 30px;
+    }
+
 }
-.containerLabel {
-    font-weight: bold;
-    padding-left: 20px;
-}
-.numStudentsContainer span {
-    position: relative;
-    line-height: 30px;
-}
+

--- a/css/portal-dashboard/toggle-control.less
+++ b/css/portal-dashboard/toggle-control.less
@@ -1,0 +1,54 @@
+@import "./variables";
+
+.toggle {
+  width: 34px;
+  height: 14px;
+  cursor: pointer;
+
+  .track {
+    width: 34px;
+    height: 14px;
+    border-radius: 7px;
+    background-color: @cc-charcoal-light1;
+
+    &.toggleOn {
+      background-color: @cc-teal;
+    }
+  }
+
+  .ball {
+    position: relative;
+    top: -17px;
+    width: 17px;
+    height: 17px;
+    border-radius: 50%;
+    border: 2px solid @cc-charcoal-light1;
+    background-color: @cc-teal-light6;
+    transition-property: transform;
+    transition-duration: .25s;
+
+    &:hover {
+      background-color: @cc-teal-light4;
+    }
+    &:active {
+      background-color: @cc-teal;
+      border-color: white;
+    }
+
+    &.toggleOn {
+      transform: translate(17px, 0);
+      background-color: @cc-teal;
+      border-color: white;
+    }
+
+    &:hover.toggleOn {
+      background-color: @cc-teal-light4;
+    }
+    &:active.toggleOn {
+      background-color: @cc-teal-light6;
+      border-color: @cc-charcoal-light1;
+    }
+
+  }
+
+}

--- a/cypress/integration/portal-dashboard-smoke-test.spec.js
+++ b/cypress/integration/portal-dashboard-smoke-test.spec.js
@@ -18,6 +18,18 @@ context("Portal Dashboard UI",()=>{
         it('verify class nav loads',()=>{
             cy.get('[data-cy=class-nav]').should('be.visible');
             cy.get('[data-cy=sort-students]').should('be.visible');
+            cy.get('[data-cy=anonymize-students]').should('be.visible');
+            cy.get('[data-cy=anonymize-students]').within(() => {
+                cy.get('[data-cy=toggle-control]').click();
+            });
+            cy.get('[data-cy=student-name]')
+                .each(function(student, i){
+                    cy.get(student).should("contain", "Student");
+                });
+            cy.get('[data-cy=students-feedback]').should('be.visible');
+            cy.get('[data-cy=students-feedback]').within(() => {
+                cy.get('[data-cy=toggle-control]').click();
+            });
         });
     });
     describe('student list',()=>{

--- a/cypress/integration/portal-dashboard-smoke-test.spec.js
+++ b/cypress/integration/portal-dashboard-smoke-test.spec.js
@@ -37,7 +37,7 @@ context("Portal Dashboard UI",()=>{
     describe('Number of students in class',()=>{
         let numStudents = 6; //TODO: it would be better if numStudents is not hard coded.
         it('verify number of students in a class loads',()=>{
-            getByCypressTag('num-student-container').should('be.visible').and('contain', numStudents+ ' students');
+            getByCypressTag('num-students').should('be.visible').and('contain', numStudents+ ' students');
         });
     });
 });

--- a/js/components/portal-dashboard/anonymize-students.tsx
+++ b/js/components/portal-dashboard/anonymize-students.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { ToggleControl } from "./toggle-control";
+
+import css from "../../../css/portal-dashboard/anonymize-students.less";
+
+interface IProps {
+  setAnonymous: (value: boolean) => void;
+}
+
+export const AnonymizeStudents: React.FC<IProps> = (props) => {
+  return (
+    <div className={css.anonymizeStudents}>
+      <ToggleControl onToggle={props.setAnonymous}/>
+      <div className={css.label}>
+        Anonymize students
+      </div>
+    </div>
+  );
+};

--- a/js/components/portal-dashboard/anonymize-students.tsx
+++ b/js/components/portal-dashboard/anonymize-students.tsx
@@ -9,7 +9,7 @@ interface IProps {
 
 export const AnonymizeStudents: React.FC<IProps> = (props) => {
   return (
-    <div className={css.anonymizeStudents}>
+    <div className={css.anonymizeStudents} data-cy="anonymize-students">
       <ToggleControl onToggle={props.setAnonymous}/>
       <div className={css.label}>
         Anonymize students

--- a/js/components/portal-dashboard/class-nav.tsx
+++ b/js/components/portal-dashboard/class-nav.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { CustomSelect, SelectItem } from "./custom-select";
+import { AnonymizeStudents } from "./anonymize-students";
+import { Feedback } from "./feedback";
 import { SORT_BY_NAME, SORT_BY_MOST_PROGRESS, SORT_BY_LEAST_PROGRESS } from "../../actions/dashboard";
 
 import css from "../../../css/portal-dashboard/class-nav.less";
@@ -10,6 +12,7 @@ interface IProps {
   setStudentSort: (value: string) => void;
   trackEvent: (category: string, action: string, label: string) => void;
   studentCount: number;
+  setAnonymous: (value: boolean) => void;
 }
 
 export class ClassNav extends React.PureComponent<IProps> {
@@ -17,18 +20,22 @@ export class ClassNav extends React.PureComponent<IProps> {
     const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
                                  { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
                                  { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
-    const { clazzName, setStudentSort, trackEvent } = this.props;
+    const { clazzName, setStudentSort, trackEvent, setAnonymous } = this.props;
     return (
       <div className={css.classNav} data-cy="class-nav">
-        class nav for {clazzName}
-        <CustomSelect
-          items={items}
-          onSelectItem={setStudentSort}
-          trackEvent={trackEvent}
-          iconId={"icon-sort"}
-          dataCy={"sort-students"}
-        />
+        <div className={css.title}>{clazzName}</div>
+        <AnonymizeStudents setAnonymous={setAnonymous} />
+        <Feedback />
         <NumberOfStudentsContainer studentCount={this.props.studentCount} />
+        <div className={css.studentSort}>
+          <CustomSelect
+            items={items}
+            onSelectItem={setStudentSort}
+            trackEvent={trackEvent}
+            iconId={"icon-sort"}
+            dataCy={"sort-students"}
+          />
+        </div>
       </div>
     );
   }

--- a/js/components/portal-dashboard/feedback.tsx
+++ b/js/components/portal-dashboard/feedback.tsx
@@ -9,7 +9,7 @@ interface IProps {
 
 export const Feedback: React.FC<IProps> = (props) => {
   return (
-    <div className={css.feedback}>
+    <div className={css.feedback} data-cy="students-feedback">
       <ToggleControl />
       <div className={css.label}>
         Feedback

--- a/js/components/portal-dashboard/feedback.tsx
+++ b/js/components/portal-dashboard/feedback.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { ToggleControl } from "./toggle-control";
+
+import css from "../../../css/portal-dashboard/feedback.less";
+
+interface IProps {
+  setFeedback?: () => void;
+}
+
+export const Feedback: React.FC<IProps> = (props) => {
+  return (
+    <div className={css.feedback}>
+      <ToggleControl />
+      <div className={css.label}>
+        Feedback
+      </div>
+    </div>
+  );
+};

--- a/js/components/portal-dashboard/num-students-container.tsx
+++ b/js/components/portal-dashboard/num-students-container.tsx
@@ -10,9 +10,11 @@ export class NumberOfStudentsContainer extends React.PureComponent<IProps> {
   render() {
     return (
       <div className={css.numStudentsContainer} data-cy="num-student-container">
-        <span className={css.containerLabel}>Class: </span>
-        <span data-cy="student-number">{this.props.studentCount}</span>
-        <span> students</span>
+        <div className={css.numStudents} data-cy="num-students">
+          <span className={css.containerLabel}>Class: </span>
+          <span data-cy="student-number">{this.props.studentCount}</span>
+          <span> students</span>
+        </div>
       </div>
     );
   }

--- a/js/components/portal-dashboard/student-list.tsx
+++ b/js/components/portal-dashboard/student-list.tsx
@@ -15,7 +15,7 @@ export class StudentList extends React.PureComponent<IProps> {
       <div className={css.studentList} data-cy="student-list">
         { students && students.map((student: any, i: number) => {
           const formattedName = isAnonymous
-                                ? `Student ${i + 1}`
+                                ? `Student ${student.get("id")}`
                                 : `${student.get("lastName")}, ${student.get("firstName")}`;
           return (
             <StudentRow key={`student ${i}`} name={formattedName}/>

--- a/js/components/portal-dashboard/student-row.tsx
+++ b/js/components/portal-dashboard/student-row.tsx
@@ -12,7 +12,7 @@ export class StudentRow extends React.PureComponent<IProps> {
     return (
       <div className={css.studentRow}>
         <div className={css.student}>
-          <div className={css.name}>{name}</div>
+          <div className={css.name} data-cy="student-name">{name}</div>
         </div>
         <div className={css.responses}>
           <div>response content</div>

--- a/js/components/portal-dashboard/toggle-control.tsx
+++ b/js/components/portal-dashboard/toggle-control.tsx
@@ -17,7 +17,7 @@ export const ToggleControl: React.FC<IProps> = (props) => {
   const onClass = toggleOn ? css.toggleOn : "";
 
   return (
-    <div className={css.toggle} onClick={handleToggle}>
+    <div className={css.toggle} onClick={handleToggle} data-cy="toggle-control">
       <div className={`${css.track} ${onClass}`}/>
       <div className={`${css.ball} ${onClass}`}/>
     </div>

--- a/js/components/portal-dashboard/toggle-control.tsx
+++ b/js/components/portal-dashboard/toggle-control.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from "react";
+
+import css from "../../../css/portal-dashboard/toggle-control.less";
+
+interface IProps {
+  onToggle?: (value: boolean) => void;
+}
+
+export const ToggleControl: React.FC<IProps> = (props) => {
+  const [toggleOn, setToggleOn] = useState(false);
+
+  const handleToggle = () => {
+    props.onToggle && props.onToggle(!toggleOn);
+    setToggleOn(!toggleOn);
+  };
+
+  const onClass = toggleOn ? css.toggleOn : "";
+
+  return (
+    <div className={css.toggle} onClick={handleToggle}>
+      <div className={`${css.track} ${onClass}`}/>
+      <div className={`${css.ball} ${onClass}`}/>
+    </div>
+  );
+};

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -18,16 +18,16 @@ import { RootState } from "../../reducers";
 
 interface IProps {
   clazzName: string;
-  error: IResponse;
-  students: any;
-  sequenceTree: Map<any, any>;
-  studentCount: number;
   currentActivity?: Map<string, any>;
+  error: IResponse;
   fetchAndObserveData: () => void;
   isFetching: boolean;
   report: any;
+  sequenceTree: Map<any, any>;
   setAnonymous: (value: boolean) => void;
   setStudentSort: (value: string) => void;
+  studentCount: number;
+  students: any;
   toggleCurrentActivity: (activityId: string) => void;
   trackEvent: (category: string, action: string, label: string) => void;
 }
@@ -58,7 +58,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   }
 
   render() {
-    const { clazzName, students, error, sequenceTree, currentActivity, setAnonymous, report, setStudentSort, toggleCurrentActivity, trackEvent } = this.props;
+    const { clazzName, currentActivity, error, report, sequenceTree, setAnonymous, setStudentSort, students, toggleCurrentActivity, trackEvent } = this.props;
     const { initialLoading } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
@@ -103,11 +103,11 @@ function mapStateToProps(state: RootState): Partial<IProps> {
   const dataDownloaded = !error && !data.get("isFetching");
   return {
     clazzName: dataDownloaded ? state.getIn(["report", "clazzName"]) : undefined,
+    currentActivity: getCurrentActivity(state),
     error,
     isFetching: data.get("isFetching"),
     report: dataDownloaded && reportState,
     sequenceTree: dataDownloaded && getSequenceTree(state),
-    currentActivity: getCurrentActivity(state),
     students: dataDownloaded && getSortedStudents(state),
   };
 }

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Map } from "immutable";
 import { connect } from "react-redux";
-import { fetchAndObserveData, trackEvent } from "../../actions/index";
+import { fetchAndObserveData, trackEvent, setAnonymous } from "../../actions/index";
 import { getSortedStudents, getCurrentActivity } from "../../selectors/dashboard-selectors";
 import { Header } from "../../components/portal-dashboard/header";
 import { ClassNav } from "../../components/portal-dashboard/class-nav";
@@ -17,15 +17,16 @@ import css from "../../../css/portal-dashboard/portal-dashboard-app.less";
 import { RootState } from "../../reducers";
 
 interface IProps {
-  isFetching: boolean;
-  error: IResponse;
   clazzName: string;
+  error: IResponse;
   students: any;
   sequenceTree: Map<any, any>;
   studentCount: number;
   currentActivity?: Map<string, any>;
-
   fetchAndObserveData: () => void;
+  isFetching: boolean;
+  report: any;
+  setAnonymous: (value: boolean) => void;
   setStudentSort: (value: string) => void;
   toggleCurrentActivity: (activityId: string) => void;
   trackEvent: (category: string, action: string, label: string) => void;
@@ -57,8 +58,9 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   }
 
   render() {
-    const { clazzName, students, error, sequenceTree, currentActivity, setStudentSort, toggleCurrentActivity, trackEvent } = this.props;
+    const { clazzName, students, error, sequenceTree, currentActivity, setAnonymous, report, setStudentSort, toggleCurrentActivity, trackEvent } = this.props;
     const { initialLoading } = this.state;
+    const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
     // they must be obtained via the child reference in the sequenceTree …
     const activityTrees: Map<any, any> | false = sequenceTree && sequenceTree.get("children");
@@ -72,7 +74,8 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 clazzName={clazzName}
                 setStudentSort={setStudentSort}
                 trackEvent={trackEvent}
-                studentCount = {students.size}
+                studentCount={students.size}
+                setAnonymous={setAnonymous}
               />
               <LevelViewer
                 activities={activityTrees}
@@ -82,7 +85,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
             </div>
             <StudentList
               students={students}
-              isAnonymous={false}
+              isAnonymous={isAnonymous}
             />
           </div>
         }
@@ -96,20 +99,23 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
 function mapStateToProps(state: RootState): Partial<IProps> {
   const data = state.get("data");
   const error = data.get("error");
+  const reportState = state.get("report");
   const dataDownloaded = !error && !data.get("isFetching");
   return {
-    isFetching: data.get("isFetching"),
-    error,
     clazzName: dataDownloaded ? state.getIn(["report", "clazzName"]) : undefined,
-    students: dataDownloaded && getSortedStudents(state),
+    error,
+    isFetching: data.get("isFetching"),
+    report: dataDownloaded && reportState,
     sequenceTree: dataDownloaded && getSequenceTree(state),
     currentActivity: getCurrentActivity(state),
+    students: dataDownloaded && getSortedStudents(state),
   };
 }
 
 const mapDispatchToProps = (dispatch: any, ownProps: any): Partial<IProps> => {
   return {
     fetchAndObserveData: () => dispatch(fetchAndObserveData()),
+    setAnonymous: (value: boolean) => dispatch(setAnonymous(value)),
     setStudentSort: (value: string) => dispatch(setStudentSort(value)),
     toggleCurrentActivity: (activityId: string) =>  dispatch(toggleCurrentActivity(activityId)),
     trackEvent: (category: string, action: string, label: string) => dispatch(trackEvent(category, action, label)),


### PR DESCRIPTION
This PR adds a generic toggle control that is used to anonymize student names and  turn on/off feedback.  At present, anonymizing student names is complete and the feedback control is in place but the underlying functionality is not yet in place.  Changes includes:
 - add toggle control
 - add anonymize student control
 - add feedback control (functionality not yet in place)
 - restructure controls in class nav to match UI spec