### PR TITLE
Add stub for class selection control

### DIFF
--- a/css/portal-dashboard/class-nav.less
+++ b/css/portal-dashboard/class-nav.less
@@ -7,8 +7,8 @@
   width: 240px;
   background-color: @cc-teal-light6;
 
-  .title {
-    height: 65px;
+  .chooseClass {
+    margin: 20px 0 15px 19px;
   }
 
   .studentSort {

--- a/css/portal-dashboard/custom-select.less
+++ b/css/portal-dashboard/custom-select.less
@@ -70,6 +70,7 @@
     border-radius: 0 0 4px 4px;
     box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
     opacity: 0;
+    z-index: 1;
     transition-property: opacity;
     transition-duration: .25s;
     pointer-events: none;

--- a/cypress/integration/portal-dashboard-smoke-test.spec.js
+++ b/cypress/integration/portal-dashboard-smoke-test.spec.js
@@ -17,6 +17,7 @@ context("Portal Dashboard UI",()=>{
     describe('class nav',()=>{
         it('verify class nav loads',()=>{
             cy.get('[data-cy=class-nav]').should('be.visible');
+            cy.get('[data-cy=choose-class]').should('be.visible');
             cy.get('[data-cy=sort-students]').should('be.visible');
             cy.get('[data-cy=anonymize-students]').should('be.visible');
             cy.get('[data-cy=anonymize-students]').within(() => {

--- a/js/components/portal-dashboard/class-nav.tsx
+++ b/js/components/portal-dashboard/class-nav.tsx
@@ -23,7 +23,15 @@ export class ClassNav extends React.PureComponent<IProps> {
     const { clazzName, setStudentSort, trackEvent, setAnonymous } = this.props;
     return (
       <div className={css.classNav} data-cy="class-nav">
-        <div className={css.title}>{clazzName}</div>
+        <div className={css.chooseClass}>
+          <CustomSelect
+            items={[{action: "", name: clazzName}]}
+            onSelectItem={(() => {})}
+            trackEvent={trackEvent}
+            iconId={"icon-class"}
+            dataCy={"choose-class"}
+          />
+        </div>
         <AnonymizeStudents setAnonymous={setAnonymous} />
         <Feedback />
         <NumberOfStudentsContainer studentCount={this.props.studentCount} />

--- a/js/components/portal-dashboard/class-nav.tsx
+++ b/js/components/portal-dashboard/class-nav.tsx
@@ -17,33 +17,47 @@ interface IProps {
 
 export class ClassNav extends React.PureComponent<IProps> {
   render() {
-    const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
-                                 { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
-                                 { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
-    const { clazzName, setStudentSort, trackEvent, setAnonymous } = this.props;
+    const { setAnonymous } = this.props;
     return (
       <div className={css.classNav} data-cy="class-nav">
-        <div className={css.chooseClass}>
-          <CustomSelect
-            items={[{action: "", name: clazzName}]}
-            onSelectItem={(() => {})}
-            trackEvent={trackEvent}
-            iconId={"icon-class"}
-            dataCy={"choose-class"}
-          />
-        </div>
+        { this.renderClassSelect() }
         <AnonymizeStudents setAnonymous={setAnonymous} />
         <Feedback />
         <NumberOfStudentsContainer studentCount={this.props.studentCount} />
-        <div className={css.studentSort}>
-          <CustomSelect
-            items={items}
-            onSelectItem={setStudentSort}
-            trackEvent={trackEvent}
-            iconId={"icon-sort"}
-            dataCy={"sort-students"}
-          />
-        </div>
+        { this.renderStudentSort() }
+      </div>
+    );
+  }
+
+  private renderClassSelect = () => {
+    const { clazzName, trackEvent } = this.props;
+    return (
+      <div className={css.chooseClass}>
+        <CustomSelect
+          items={[{action: "", name: clazzName}]}
+          onSelectItem={(() => {})}
+          trackEvent={trackEvent}
+          iconId={"icon-class"}
+          dataCy={"choose-class"}
+        />
+      </div>
+    );
+  }
+
+  private renderStudentSort = () => {
+    const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
+                                 { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
+                                 { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
+    const { setStudentSort, trackEvent } = this.props;
+    return (
+      <div className={css.studentSort}>
+        <CustomSelect
+          items={items}
+          onSelectItem={setStudentSort}
+          trackEvent={trackEvent}
+          iconId={"icon-sort"}
+          dataCy={"sort-students"}
+        />
       </div>
     );
   }

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,9 @@
         <title>sort</title>
         <path d="M2.5 15h5v-1.667h-5V15zm0-10v1.667h15V5h-15zm0 5.833h10V9.167h-10v1.666z"/>
       </symbol>
+      <symbol id="icon-class" viewBox="0 0 20 20">
+        <path d="M15 1.667H5c-.917 0-1.667.75-1.667 1.666v13.334c0 .916.75 1.666 1.667 1.666h10c.917 0 1.667-.75 1.667-1.666V3.333c0-.916-.75-1.666-1.667-1.666zM5 3.333h4.167V10L7.083 8.75 5 10V3.333z"/>
+      </symbol>
       <symbol id="icon-check" viewBox="0 0 24 24">
         <title>check</title>
         <path d="M10 17L5 12 6.41 10.59 10 14.17 17.59 6.58 19 8z"/>


### PR DESCRIPTION
This PR adds in a UI stub for the class selection dropdown in the upper left navigation area.  A custom dropdown control is added that, at present, contains only the current, default class.  Eventually we will need to add other additional classes to the dropdown and change classes when a list item is selected.  However, this PR at least puts the basic UI in place.
![image](https://user-images.githubusercontent.com/5126913/83480270-af619100-a44f-11ea-9148-f9ba11ff5c53.png)
