### PR TITLE
Add synced level viewer and response table scrolling

### DIFF
--- a/css/portal-dashboard/class-nav.less
+++ b/css/portal-dashboard/class-nav.less
@@ -6,6 +6,7 @@
   height: @top-nav-height;
   width: 240px;
   background-color: @cc-teal-light6;
+  z-index: 1;
 
   .chooseClass {
     margin: 20px 0 15px 19px;

--- a/css/portal-dashboard/level-viewer.less
+++ b/css/portal-dashboard/level-viewer.less
@@ -10,8 +10,17 @@
   height: @top-nav-level-viewer-height;
   user-select: none;
 
+  .cover {
+    width: 100%;
+    height: 44px;
+    background-color: white;
+    position: absolute;
+    bottom: -46px;
+  }
+
   .activityButtons {
     display: flex;
+    position: relative;
     height: 158px;
     margin-top: 19px;
     margin-left: 3px;
@@ -19,7 +28,6 @@
     font-size: 14px;
     font-weight: 500;
     color: @cc-teal-dark1;
-    overflow: hidden;
 
     .animateLevelButton {
       position: relative;

--- a/css/portal-dashboard/progress-legend.less
+++ b/css/portal-dashboard/progress-legend.less
@@ -16,25 +16,26 @@
     line-height: 32px;
     background-color: white;
     left: calc(((100vw - @left-panel-width) / 2) - @half-width);
-    margin-left:auto;
-    margin-right:auto;
+    margin-left: auto;
+    margin-right: auto;
     position: absolute;
-    bottom:-19px;
+    bottom: -19px;
   }
+
   .legendLabel{
-    display:inline-block;
-    position:relative;
-    bottom:2px;
+    display: inline-block;
+    position: relative;
+    bottom: 2px;
   }
   .legendKey {
-    display:inline-block;
+    display: inline-block;
     height: 20px;
     vertical-align: text-bottom;
     padding-right: 9px;
   }
   .legendText {
-    display:inline-block;
-    position:relative;
+    display: inline-block;
+    position: relative;
     bottom:10px;
     line-height: 17px;
     vertical-align: text-bottom;
@@ -42,26 +43,26 @@
   }
   .progressIcon {
     margin: 5px;
-    position:relative;
-    bottom:3px;
+    position: relative;
+    bottom: 3px;
     box-sizing: border-box;
     border: 1px solid @cc-orange;
-    height:16px;
-    width:16px;
+    height: 16px;
+    width: 16px;
   }
   .completed {
     background-color: @cc-orange;
     border-radius: 50%;
-    display:inline-block;
+    display: inline-block;
   }
   .inProgress {
     background-color: @cc-orange-light3;
     border-radius: 50% 20% 20% 50%;
-    display:inline-block;
+    display: inline-block;
   }
   .notYetStarted {
     background-color: white;
     border-radius: 20%;
-    display:inline-block;
+    display: inline-block;
   }
 

--- a/css/portal-dashboard/student-answers.less
+++ b/css/portal-dashboard/student-answers.less
@@ -9,6 +9,7 @@
   overflow-x: auto;
   overflow-y: auto;
   height: fit-content;
+  z-index: 1;
 
   .studentAnswersRow {
     display: flex;

--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Map } from "immutable";
+import { ProgressLegendContainer } from "./legend-container";
 
 import css from "../../../css/portal-dashboard/level-viewer.less";
-import { ProgressLegendContainer } from "./legend-container";
 
 // from level-viewer.less
 const questionWidth = 50;
@@ -15,18 +15,23 @@ interface IProps {
   currentQuestion?: Map<string, any>;
   toggleCurrentActivity: (activityId: string) => void;
   toggleCurrentQuestion: (questionId: string) => void;
+  leftPosition: number;
 }
 
 export class LevelViewer extends React.PureComponent<IProps> {
   render() {
-    const { activities } = this.props;
+    const { activities, leftPosition } = this.props;
+    const position = {
+      left: leftPosition,
+    };
     return (
       <div className={css.levelViewer} data-cy="level-viewer">
-        <div className={css.activityButtons}>
+        <div className={css.activityButtons} style={position}>
           {
             activities.toArray().map(this.renderActivityButton(activities.toArray().length))
           }
         </div>
+        <div className={css.cover} />
         <ProgressLegendContainer />
       </div>
     );

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -46,13 +46,15 @@ interface IProps {
 
 interface IState {
   initialLoading: boolean;
+  scrollLeft: number;
 }
 
 class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      initialLoading: true
+      initialLoading: true,
+      scrollLeft: 0
     };
   }
 
@@ -97,9 +99,10 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 currentQuestion={currentQuestion}
                 toggleCurrentActivity={toggleCurrentActivity}
                 toggleCurrentQuestion={toggleCurrentQuestion}
+                leftPosition={this.state.scrollLeft}
               />
             </div>
-            <div className={css.progressTable}>
+            <div className={css.progressTable} onScroll={this.handleScroll}>
               <StudentNames
                 students={students}
                 isAnonymous={isAnonymous}
@@ -125,6 +128,13 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
         { initialLoading && <LoadingIcon /> }
       </div>
     );
+  }
+
+  private handleScroll = (e: React.UIEvent<HTMLElement>) => {
+    const element = e.target as HTMLElement;
+    if (element && element.scrollLeft) {
+      this.setState({ scrollLeft: -1 * element.scrollLeft });
+    }
   }
 }
 


### PR DESCRIPTION
This PR locks the scrolling between the level viewer and the response table.

![image](https://user-images.githubusercontent.com/5126913/83917682-289d0480-a72c-11ea-94a9-6f220331b049.png)
