### PR TITLE
Fix font color

### DIFF
--- a/css/portal-dashboard/portal-dashboard-app.less
+++ b/css/portal-dashboard/portal-dashboard-app.less
@@ -2,7 +2,7 @@
 
 .portalDashboardApp {
   height: 100%;
-  color: black;
+  color: @cc-charcoal;
   font-family: lato, arial, helvetica, sans-serif;
   overflow: hidden;
 


### PR DESCRIPTION
A default font color of black was cascading through the portal dashboard application from a parent component.  Replace with `cc-charcoal` which is the default font color used in the UI spec.