### PR TITLE
Add activity progress bar in level viewer

### DIFF
--- a/css/portal-dashboard/level-viewer.less
+++ b/css/portal-dashboard/level-viewer.less
@@ -136,6 +136,18 @@
         border-radius: 3px;
         border: solid 1.5px @cc-orange;
         background-color: white;
+
+        .started {
+          position: absolute;
+          height: 19px;
+          background-color: @cc-orange-light3;
+        }
+        .completed {
+          position: absolute;
+          height: 19px;
+          background-color: @cc-orange;
+        }
+
       }
 
       &.expanded {

--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -7,6 +7,7 @@ import CorrectIcon from "../../../img/svg-icons/q-mc-scored-correct-icon.svg";
 import css from "../../../css/portal-dashboard/level-viewer.less";
 
 // from level-viewer.less
+const progressWidth = 120;
 const questionWidth = 50;
 const margin = 20;
 const getTotalQuestionsWidth = (numQuestions: number) => Math.max(0, numQuestions * (questionWidth + margin) - margin);
@@ -15,9 +16,10 @@ interface IProps {
   activities: Map<any, any>;
   currentActivity?: Map<string, any>;
   currentQuestion?: Map<string, any>;
+  leftPosition: number;
+  studentProgress: any;
   toggleCurrentActivity: (activityId: string) => void;
   toggleCurrentQuestion: (questionId: string) => void;
-  leftPosition: number;
 }
 
 export class LevelViewer extends React.PureComponent<IProps> {
@@ -64,8 +66,36 @@ export class LevelViewer extends React.PureComponent<IProps> {
               </svg>
             </a>
           </div>
-          <div className={css.progressBar} />
+          { this.renderProgressBar(activity.get("id")) }
         </div>
+      </div>
+    );
+  }
+
+  private renderProgressBar = (activityId: string) => {
+    const { studentProgress } = this.props;
+    const total = studentProgress.size;
+    let complete = 0;
+    let started = 0;
+    studentProgress.forEach((student: any) => {
+      const progress = student.get(activityId);
+      if (progress === 1) {
+        complete++;
+        started++;
+      } else if (progress > 0) {
+        started++;
+      }
+    });
+    const completedWidth = {
+      width: complete / total * progressWidth,
+    };
+    const startedWidth = {
+      width: started / total * progressWidth,
+    };
+    return (
+      <div className={css.progressBar}>
+        <div className={css.started} style={startedWidth} />
+        <div className={css.completed} style={completedWidth} />
       </div>
     );
   }

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -108,9 +108,10 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 activities={activityTrees}
                 currentActivity={currentActivity}
                 currentQuestion={currentQuestion}
+                leftPosition={this.state.scrollLeft}
+                studentProgress={studentProgress}
                 toggleCurrentActivity={toggleCurrentActivity}
                 toggleCurrentQuestion={toggleCurrentQuestion}
-                leftPosition={this.state.scrollLeft}
               />
             </div>
               <div className={css.progressTable} onScroll={this.handleScroll}>


### PR DESCRIPTION
Add activity student progress bar to the level viewer beneath each activity.  Progress bar displays progress in terms of both started and completed activities.

![image](https://user-images.githubusercontent.com/5126913/85107627-24a8c200-b1c3-11ea-9950-c00b17398389.png)
