### PR TITLE
Fix modal dialogs

### DIFF
--- a/css/report/bootstrap-components.less
+++ b/css/report/bootstrap-components.less
@@ -23,7 +23,7 @@
 }
 
 .modal-backdrop {
-  background-color: transparent;
+  background-color: rgba(0, 0, 0, 0.5);
 }
 
 .modal-dialog .modal-body {

--- a/css/report/bootstrap-components.less
+++ b/css/report/bootstrap-components.less
@@ -22,6 +22,10 @@
   }
 }
 
+.modal-backdrop {
+  background-color: transparent;
+}
+
 .modal-dialog .modal-body {
   padding: 5px;
 }

--- a/js/components/dashboard/help-modal.js
+++ b/js/components/dashboard/help-modal.js
@@ -10,7 +10,7 @@ export default class HelpModal extends PureComponent {
   render() {
     const { toggleHelpModal, helpViewVisible } = this.props;
     return (
-      <Modal show={helpViewVisible} onHide={toggleHelpModal}>
+      <Modal show={helpViewVisible} onHide={toggleHelpModal} animation={false}>
         <Modal.Body>
           <div className={css.helpContent} data-cy="helpPanel">
             <h2>Help</h2>

--- a/js/components/report/image-answer-modal.js
+++ b/js/components/report/image-answer-modal.js
@@ -22,7 +22,7 @@ export default class ImageAnswerModal extends PureComponent {
     const { answer, show, onHide } = this.props;
     if (!answer) { return null; }
     return (
-      <Modal show={show} onHide={onHide}>
+      <Modal show={show} onHide={onHide} animation={false}>
         <Modal.Header closeButton closeLabel="" />
         <Modal.Body>
           <img src={answer.getIn(["answer", "imageUrl"])} style={{display: "block", margin: "0 auto"}} data-cy="image-answer-modal"/>

--- a/js/containers/dashboard/question-details.js
+++ b/js/containers/dashboard/question-details.js
@@ -29,6 +29,7 @@ export default class QuestionDetails extends PureComponent {
       <Modal
         show={selectedQuestion !== null}
         onHide={onClose}
+        animation={false}
       >
         <Modal.Body>
           {

--- a/js/containers/report/report-app.js
+++ b/js/containers/report/report-app.js
@@ -52,7 +52,7 @@ class ReportApp extends PureComponent {
       question = report.getIn(["questions", questionId]);
     }
     return (
-      <Modal show={showCompare} bsStyle="compare-view" onHide={hideCompareView}>
+      <Modal show={showCompare} bsStyle="compare-view" onHide={hideCompareView} animation={false}>
         <Modal.Body>
           {compareViewAnswers && <CompareView answers={compareViewAnswers} question={question} />}
         </Modal.Body>


### PR DESCRIPTION
In mid-May we upgraded `react-bootstrap` from version 0.32 to version 1.0 which had the side-effect of breaking all of the modal dialogs in the project (`react-bootstrap` is used to display modal dialogs throughout the app - things like the help file, the image answer pop-ups, etc.).  This bug is caused by a change/issue in the dialog animation in the new version of the library.  The dialog position and opacity are left in the initial, pre-animation states (opacity = 0, position is hidden) instead of transitioning to their displayed states.  There isn't an obvious reason why this is happening after initially reviewing our implementation.  The same occurs when using the example modal dialogs in our project:
https://react-bootstrap.github.io/components/modal/
One option is to downgrade `react-bootstrap` so it is back on version 0.32 which is obviously a less than optimal solution.  Instead, I think the better solution is to continue using the new version of the library.  The quick workaround is to turn off the dialog animation (which also requires setting the background color of the backdrop for the dialog).  The downside is we lose the animation as the dialog is moved into place when activated.  If someone is feeling ambitious and has time, they can try to get the animation working again.  In the meantime, this at least gets the dialogs working.