### PR TITLE
174390612 hide feedback and class response UI elements

### DIFF
--- a/css/portal-dashboard/all-responses-popup/popup-header.less
+++ b/css/portal-dashboard/all-responses-popup/popup-header.less
@@ -69,7 +69,7 @@
       position: absolute;
       right: 0px;
       border: 1.5px solid white;
-      border-radius: 15px 0 0 15px;
+      border-radius: 0;
       justify-content: flex-end;
       margin-right: 2.5px;
       padding: 0 5px 0 5px;

--- a/cypress/integration/portal-dashboard/portal-dashboard-all-responses-popup.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-all-responses-popup.spec.js
@@ -15,27 +15,28 @@ context("Portal Dashboard Question Details Panel", () => {
       //TODO Verify title should match the sequence/activity name from dashboard
     });
     //TODO Feedback toggle opens feedback view and vice versa
-    // it('verify all responses/feedback toggle is visible', () => {
-    //   cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
-    //     expect($el).to.have.css("width", "204px");
-    //     cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
-    //       expect($el).to.have.css("width", "35px");
-    //       cy.wrap($el).click();
-    //       cy.wait(500);
-    //     });
-    //     cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
-    //       expect($el).to.have.css("width", "204px");
-    //     });
-    //     cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
-    //       expect($el).to.have.css("width", "35px");
-    //       cy.wrap($el).click();
-    //       cy.wait(500);
-    //     });
-    //     cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
-    //       expect($el).to.have.css("width", "204px");
-    //     });
-    //   });
-    // });
+    // Removed for MVP:
+    it.skip('verify all responses/feedback toggle is visible', () => {
+      cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
+        expect($el).to.have.css("width", "204px");
+        cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
+          expect($el).to.have.css("width", "35px");
+          cy.wrap($el).click();
+          cy.wait(500);
+        });
+        cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
+          expect($el).to.have.css("width", "204px");
+        });
+        cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
+          expect($el).to.have.css("width", "35px");
+          cy.wrap($el).click();
+          cy.wait(500);
+        });
+        cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
+          expect($el).to.have.css("width", "204px");
+        });
+      });
+    });
     it('verify close button closes popup', () => {
       cy.get('[data-cy=close-popup-button]').should('be.visible').click();
       cy.get('[data-cy=popup-header-title]').should('not.be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-all-responses-popup.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-all-responses-popup.spec.js
@@ -15,27 +15,27 @@ context("Portal Dashboard Question Details Panel", () => {
       //TODO Verify title should match the sequence/activity name from dashboard
     });
     //TODO Feedback toggle opens feedback view and vice versa
-    it('verify all responses/feedback toggle is visible', () => {
-      cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
-        expect($el).to.have.css("width", "204px");
-        cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
-          expect($el).to.have.css("width", "35px");
-          cy.wrap($el).click();
-          cy.wait(500);
-        });
-        cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
-          expect($el).to.have.css("width", "204px");
-        });
-        cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
-          expect($el).to.have.css("width", "35px");
-          cy.wrap($el).click();
-          cy.wait(500);
-        });
-        cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
-          expect($el).to.have.css("width", "204px");
-        });
-      });
-    });
+    // it('verify all responses/feedback toggle is visible', () => {
+    //   cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
+    //     expect($el).to.have.css("width", "204px");
+    //     cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
+    //       expect($el).to.have.css("width", "35px");
+    //       cy.wrap($el).click();
+    //       cy.wait(500);
+    //     });
+    //     cy.get('[data-cy=feedback-toggle]').should('be.visible').then(($el) => {
+    //       expect($el).to.have.css("width", "204px");
+    //     });
+    //     cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
+    //       expect($el).to.have.css("width", "35px");
+    //       cy.wrap($el).click();
+    //       cy.wait(500);
+    //     });
+    //     cy.get('[data-cy=all-students-responses-toggle]').should('be.visible').then(($el) => {
+    //       expect($el).to.have.css("width", "204px");
+    //     });
+    //   });
+    // });
     it('verify close button closes popup', () => {
       cy.get('[data-cy=close-popup-button]').should('be.visible').click();
       cy.get('[data-cy=popup-header-title]').should('not.be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -98,18 +98,19 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=question-overlay] [data-cy=question-content]').should('be.visible');
     });
   });
-  // describe('Class Response Area', () => {
-  //   it('verify class response area is visible', () => {
-  //     cy.get('[data-cy=overlay-class-response-area]').should('be.visible');
-  //   });
-  //   it('verify show/hide button behaves correctly', () => {
-  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
-  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('not.be.visible');
-  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
-  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-title]').should('be.visible');
-  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('be.visible');
-  //   });
-  // });
+  // Removed for MVP:
+  describe.skip('Class Response Area', () => {
+    it('verify class response area is visible', () => {
+      cy.get('[data-cy=overlay-class-response-area]').should('be.visible');
+    });
+    it('verify show/hide button behaves correctly', () => {
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('not.be.visible');
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-title]').should('be.visible');
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('be.visible');
+    });
+  });
   describe('Student Response area', () => {
     it('verify student response area is visible', () => {
       cy.get('[data-cy=overlay-student-response-area]').should('be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -98,18 +98,18 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=question-overlay] [data-cy=question-content]').should('be.visible');
     });
   });
-  describe('Class Response Area', () => {
-    it('verify class response area is visible', () => {
-      cy.get('[data-cy=overlay-class-response-area]').should('be.visible');
-    });
-    it('verify show/hide button behaves correctly', () => {
-      cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
-      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('not.be.visible');
-      cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
-      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-title]').should('be.visible');
-      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('be.visible');
-    });
-  });
+  // describe('Class Response Area', () => {
+  //   it('verify class response area is visible', () => {
+  //     cy.get('[data-cy=overlay-class-response-area]').should('be.visible');
+  //   });
+  //   it('verify show/hide button behaves correctly', () => {
+  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
+  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('not.be.visible');
+  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
+  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-title]').should('be.visible');
+  //     cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('be.visible');
+  //   });
+  // });
   describe('Student Response area', () => {
     it('verify student response area is visible', () => {
       cy.get('[data-cy=overlay-student-response-area]').should('be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-smoke-test.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-smoke-test.spec.js
@@ -20,10 +20,10 @@ context("Portal Dashboard UI",()=>{
             cy.get('[data-cy=choose-class]').should('be.visible');
             cy.get('[data-cy=sort-students]').should('be.visible');
             cy.get('[data-cy=anonymize-students]').should('be.visible');
-            cy.get('[data-cy=students-feedback]').should('be.visible');
-            cy.get('[data-cy=students-feedback]').within(() => {
-                cy.get('[data-cy=toggle-control]').click();
-            });
+            // cy.get('[data-cy=students-feedback]').should('be.visible');
+            // cy.get('[data-cy=students-feedback]').within(() => {
+            //     cy.get('[data-cy=toggle-control]').click();
+            // });
         });
     });
     describe('student list',()=>{

--- a/cypress/integration/portal-dashboard/portal-dashboard-smoke-test.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-smoke-test.spec.js
@@ -20,6 +20,7 @@ context("Portal Dashboard UI",()=>{
             cy.get('[data-cy=choose-class]').should('be.visible');
             cy.get('[data-cy=sort-students]').should('be.visible');
             cy.get('[data-cy=anonymize-students]').should('be.visible');
+            // Removed for MVP:
             // cy.get('[data-cy=students-feedback]').should('be.visible');
             // cy.get('[data-cy=students-feedback]').within(() => {
             //     cy.get('[data-cy=toggle-control]').click();

--- a/js/components/portal-dashboard/all-responses-popup/popup-header.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import AssignmentIcon from "../../../../img/svg-icons/assignment-icon.svg";
-import FeedbackIcon from "../../../../img/svg-icons/feedback-icon.svg";
+// Removed for MVP: import FeedbackIcon from "../../../../img/svg-icons/feedback-icon.svg";
 import GroupIcon from "../../../../img/svg-icons/group-icon.svg";
 import SmallCloseIcon from "../../../../img/svg-icons/small-close-icon.svg";
 
@@ -42,7 +42,7 @@ export class PopupHeader extends React.PureComponent<IProps, IState>{
   }
 
   private renderResponseFeedbackToggle = () => {
-    const feedbackToggleClass: string = `${css.feedbackToggle}` + (!this.state.inFeedbackMode? ` ${css.toggleOff}` : "");
+    // Removed for MVP: const feedbackToggleClass: string = `${css.feedbackToggle}` + (!this.state.inFeedbackMode? ` ${css.toggleOff}` : "");
     const responsesToggleClass: string = `${css.responseToggle}` + (this.state.inFeedbackMode? ` ${css.toggleOff}` : "");
 
     return (
@@ -53,12 +53,14 @@ export class PopupHeader extends React.PureComponent<IProps, IState>{
             <div className={`${css.toggleTitle} ${css.responseTitle} `}>All Student Responses</div>
           </div>
         </div>
+        {/* Removed for MVP:
         <div className={css.toggleHolder}>
           <div className={feedbackToggleClass} id="feedback-toggle" data-cy="feedback-toggle" onClick = {this.setFeedbackMode(true)} >
             <div className={`${css.toggleTitle} ${css.feedbackTitle}`}>Feedback to Students</div>
             <FeedbackIcon className={`${css.icon} ${css.toggleIcon} ${css.feedbackIcon}`} />
           </div>
         </div>
+        */ }
       </div>
     );
   }

--- a/js/components/portal-dashboard/class-nav.tsx
+++ b/js/components/portal-dashboard/class-nav.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { CustomSelect, SelectItem } from "./custom-select";
 import { AnonymizeStudents } from "./anonymize-students";
-import { Feedback } from "./feedback";
+// Removed for MVP: import { Feedback } from "./feedback";
 import { SORT_BY_NAME, SORT_BY_MOST_PROGRESS, SORT_BY_LEAST_PROGRESS } from "../../actions/dashboard";
 import { NumberOfStudentsContainer } from "./num-students-container";
 import SortIcon from "../../../img/svg-icons/sort-icon.svg";
@@ -24,7 +24,7 @@ export class ClassNav extends React.PureComponent<IProps> {
       <div className={css.classNav} data-cy="class-nav">
         { this.renderClassSelect() }
         <AnonymizeStudents setAnonymous={setAnonymous} />
-        <Feedback />
+        {/* Removed for MVP: <Feedback /> */}
         <NumberOfStudentsContainer studentCount={this.props.studentCount} />
         { this.renderStudentSort() }
       </div>

--- a/js/components/portal-dashboard/question-overlay.tsx
+++ b/js/components/portal-dashboard/question-overlay.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Map } from "immutable";
 import { QuestionNavigator } from "./question-navigator";
-import { ClassResponse } from "./overlay-class-response";
+// Removed for MVP: import { ClassResponse } from "./overlay-class-response";
 import { StudentResponse } from "./overlay-student-response";
 import GroupIcon from "../../../img/svg-icons/group-icon.svg";
 import QuestionPopoutIcon from "../../../img/svg-icons/question-popout-icon.svg";
@@ -28,10 +28,8 @@ export class QuestionOverlay extends React.PureComponent<IProps> {
     }
     return (
       <div className={wrapperClass} data-cy="question-overlay">
-        {
-          currentQuestion && this.renderQuestionDetails()
-        }
-        { currentQuestion && <ClassResponse currentQuestion={currentQuestion}/> }
+        { currentQuestion && this.renderQuestionDetails() }
+        {/* Removed for MVP: { currentQuestion && <ClassResponse currentQuestion={currentQuestion}/> } */}
         { currentQuestion && <StudentResponse students={students} isAnonymous={isAnonymous} currentQuestion={currentQuestion} /> }
         {this.renderFooter()}
       </div>


### PR DESCRIPTION
This PR removes the feedback toggle in the upper left nav area, the feedback button in the student responses popup, and the class response section in the question overlay as we prepare for an MVP version of the new portal dashboard.  Code has been commented out in several cases with a "Removed for MVP" tag so we can more easily add it back in later.   