### PR TITLE
Set min-size and add vertical scrolling to answer component

### DIFF
--- a/css/portal-dashboard/answer.less
+++ b/css/portal-dashboard/answer.less
@@ -3,6 +3,7 @@
 .answer {
   width: 100%;
   height: 100%;
+  min-height: 150px;
 
   .noAnswer {
     display: flex;

--- a/css/portal-dashboard/overlay-student-response.less
+++ b/css/portal-dashboard/overlay-student-response.less
@@ -73,6 +73,7 @@
 
   .responseArea {
     height: calc(100% - 80px);
-    margin: 15px 20px 15px 20px;
+    padding: 15px 20px 15px 20px;
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
Add a minimum size to the answer component and add scroll bars when needed so content is always displayed in question overlay panel.
![resize](https://user-images.githubusercontent.com/5126913/92552504-a71aae00-f215-11ea-8058-b1200046e369.gif)
