### PR TITLE
174390484 interactive iframe

### DIFF
--- a/css/portal-dashboard/all-responses-popup/popup-class-nav.less
+++ b/css/portal-dashboard/all-responses-popup/popup-class-nav.less
@@ -8,6 +8,7 @@
 .popupClassNav {
   width: 240px;
   font-weight: normal;
+  background-color: @cc-teal-light6;
 
   .icon {
     width: 20px;

--- a/css/portal-dashboard/all-responses-popup/popup-student-response-list.less
+++ b/css/portal-dashboard/all-responses-popup/popup-student-response-list.less
@@ -3,7 +3,7 @@
 .responseTable {
   margin-top: 3px;
   height: calc(100vh - 250px - @header-height );
-  overflow-y: scroll;
+  overflow-y: auto;
   font-weight: normal;
 
   .studentRow {
@@ -14,6 +14,7 @@
     min-height: 55px;
 
     .studentWrapper{
+      flex-shrink: 0;
       display: flex;
       flex-direction: row;
       align-items: flex-start;

--- a/css/portal-dashboard/answer.less
+++ b/css/portal-dashboard/answer.less
@@ -3,7 +3,6 @@
 .answer {
   width: 100%;
   height: 100%;
-  min-height: 150px;
 
   .noAnswer {
     display: flex;

--- a/css/portal-dashboard/answers/image-answer.less
+++ b/css/portal-dashboard/answers/image-answer.less
@@ -6,7 +6,7 @@
 
   .contentContainer {
     flex: 1;
-    min-height: 0;
+    min-height: 150px;
     &.center {
       display: flex;
       justify-content: center;

--- a/css/report/iframe-answer.less
+++ b/css/report/iframe-answer.less
@@ -1,4 +1,26 @@
 .iframe-answer {
+
+  &.responsive {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .iframe-answer-header {
+    &.responsive {
+      flex-basis: auto;
+    }
+  }
+  .iframe-answer-content {
+    &.responsive {
+      flex: 1;
+      iframe {
+        height: 100%;
+        width: 100%;
+      }
+    }
+  }
   a {
     color: #479492;
     text-decoration: none;

--- a/cypress/integration/portal-dashboard/portal-dashboard-all-responses-popup.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-all-responses-popup.spec.js
@@ -91,9 +91,9 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=student-name]').eq(5).should("contain", "Wu, Jerome");
     });
     it('verify responses',()=>{
-      cy.get('[data-cy="all-responses-popup-view"] [data-cy=question-navigator-next-button]').click().click().click();
+      cy.get('[data-cy="all-responses-popup-view"] [data-cy=question-navigator-next-button]').click().click().click().click().click();
 
-      cy.get('[data-cy=student-response] [data-cy=student-answer] > div > a').should('have.attr','href');
+      cy.get('[data-cy=student-response] [data-cy=student-answer] > div > div > a').should('have.attr','href');
     });
     //TODO add tests for filtering when implemented
   });

--- a/js/components/portal-dashboard/all-responses-popup/popup-student-response-list.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-student-response-list.tsx
@@ -23,7 +23,7 @@ export class PopupStudentResponseList extends React.PureComponent<IProps> {
             <div className={css.studentRow} key={`student ${i}`} data-cy="student-row">
               {this.renderStudentNameWrapper(formattedName)}
               <div className={`${css.studentResponse}`} data-cy="student-response">
-                <Answer question={currentQuestion} student={student} staticSize={true} />
+                <Answer question={currentQuestion} student={student} responsive={false} />
               </div>
             </div>
           );

--- a/js/components/portal-dashboard/answers/image-answer.tsx
+++ b/js/components/portal-dashboard/answers/image-answer.tsx
@@ -7,7 +7,7 @@ import css from "../../../../css/portal-dashboard/answers/image-answer.less";
 
 interface IProps {
   answer: Map<any, any>;
-  staticSize?: boolean;
+  responsive?: boolean;
   question?: Map<any, any>;
   studentName: string;
 }
@@ -16,7 +16,7 @@ const kStaticHeight = 250;
 const kStaticWidth = 250;
 
 export const ImageAnswer: React.FC<IProps> = (props) => {
-  const { answer, staticSize, question, studentName } = props;
+  const { answer, responsive, question, studentName } = props;
   const imgAnswer = answer.get("answer");
 
   const [modalOpen, setModalOpen] = useState(false);
@@ -48,8 +48,8 @@ export const ImageAnswer: React.FC<IProps> = (props) => {
   const divSize: DOMRect | DOMRectReadOnly = useSize(divTarget);
 
   // get the container size - can be static or dynamic
-  const containerHeight: number = staticSize ? kStaticHeight: divSize?.height;
-  const containerWidth: number = staticSize ? kStaticWidth : divSize?.width;
+  const containerHeight: number = responsive ? divSize?.height : kStaticHeight;
+  const containerWidth: number = responsive ? divSize?.width : kStaticWidth;
 
   // compute final image size from the container size and image aspect ratio
   const constrainX = naturalWidth / containerWidth >= naturalHeight / containerHeight;
@@ -59,7 +59,7 @@ export const ImageAnswer: React.FC<IProps> = (props) => {
   return (
     <React.Fragment>
       <div className={css.imageAnswer}>
-        <div className={`${css.contentContainer} ${!staticSize ? css.center : ""}`} ref={divTarget}>
+        <div className={`${css.contentContainer} ${responsive ? css.center : ""}`} ref={divTarget}>
           <div className={css.imageContainer} style={{height: imgHeight, width: imgWidth}}>
             <img src={imgAnswer.get("imageUrl")} data-cy="answer-image" onLoad={onImgLoad} />
             <MagnifyIcon onClick={handleShowModal(true)} />

--- a/js/components/portal-dashboard/overlay-student-response.tsx
+++ b/js/components/portal-dashboard/overlay-student-response.tsx
@@ -42,7 +42,7 @@ export class StudentResponse extends React.PureComponent<IProps, IState> {
           </div>
         </div>
         <div className={css.responseArea}>
-          <Answer question={currentQuestion} student={students.get(currentStudentIndex)} studentName={studentName}/>
+          <Answer question={currentQuestion} student={students.get(currentStudentIndex)} responsive={true} studentName={studentName}/>
         </div>
       </div>
     );

--- a/js/components/report/iframe-answer.js
+++ b/js/components/report/iframe-answer.js
@@ -74,7 +74,7 @@ export default class IframeAnswer extends PureComponent {
   }
 
   renderIframe() {
-    const { answer, question } = this.props;
+    const { answer, question, responsive } = this.props;
     let url;
     let state;
     // There are two supported answer types handled by iframe question: simple link or interactive state.
@@ -89,7 +89,7 @@ export default class IframeAnswer extends PureComponent {
       state = answer.get("answer");
     }
     return (
-      <div>
+      <div className={`iframe-answer-content ${responsive ? "responsive" : ""}`}>
         <InteractiveIframe src={url} state={state} width={question.get("width")} height={question.get("height")} />
       </div>
     );
@@ -107,12 +107,14 @@ export default class IframeAnswer extends PureComponent {
   }
 
   render() {
-    const { alwaysOpen, answer } = this.props;
+    const { alwaysOpen, answer, responsive } = this.props;
     const answerText = answer.get("answerText");
     return (
-      <div className="iframe-answer" data-cy="iframe-answer">
-        { answerText && <div>{ answerText }</div> }
-        {!alwaysOpen && this.renderLink()}
+      <div className={`iframe-answer ${responsive ? "responsive" : ""}`} data-cy="iframe-answer">
+        <div className={`iframe-answer-header ${responsive ? "responsive" : ""}`}>
+          { answerText && <div>{ answerText }</div> }
+          { !alwaysOpen && this.renderLink() }
+        </div>
         {this.shouldRenderIframe() && this.renderIframe()}
       </div>
     );

--- a/js/containers/portal-dashboard/answer.tsx
+++ b/js/containers/portal-dashboard/answer.tsx
@@ -6,7 +6,6 @@ import { QuestionTypes } from "../../util/question-utils";
 import MultipleChoiceAnswer from "../../components/portal-dashboard/multiple-choice-answer";
 import OpenResponseAnswer from "../../components/dashboard/open-response-answer";
 import { ImageAnswer } from "../../components/portal-dashboard/answers/image-answer";
-import ExternalLinkAnswer from "../../components/portal-dashboard/external-link-answer";
 import IframeAnswer from "../../components/report/iframe-answer";
 
 import css from "../../../css/portal-dashboard/answer.less";
@@ -51,7 +50,7 @@ class Answer extends React.PureComponent<AnswerProps> {
       "multiple_choice_answer": MultipleChoiceAnswer,
       "open_response_answer": OpenResponseAnswer,
       "image_question_answer": ImageAnswer,
-      "external_link": ExternalLinkAnswer,
+      "external_link": IframeAnswer,
       "interactive_state": IframeAnswer,
     };
     const AComponent = (answer && (!question.get("required") || answer.get("submitted"))) ? AnswerComponent[type] : undefined;

--- a/js/containers/portal-dashboard/answer.tsx
+++ b/js/containers/portal-dashboard/answer.tsx
@@ -46,7 +46,7 @@ class Answer extends React.PureComponent<AnswerProps> {
   }
 
   renderAnswer = (type: string) => {
-    const { answer, question, staticSize, studentName } = this.props;
+    const { answer, question, responsive, studentName } = this.props;
     const AnswerComponent: any = {
       "multiple_choice_answer": MultipleChoiceAnswer,
       "open_response_answer": OpenResponseAnswer,
@@ -62,7 +62,7 @@ class Answer extends React.PureComponent<AnswerProps> {
     }
     else {
       return (
-        <AComponent answer={answer} question={question} showFullAnswer={true} staticSize={staticSize} studentName={studentName}/>
+        <AComponent answer={answer} question={question} showFullAnswer={true} responsive={responsive} studentName={studentName}/>
       );
     }
   }

--- a/js/util/answer-utils.ts
+++ b/js/util/answer-utils.ts
@@ -23,7 +23,7 @@ export interface AnswerProps {
   answer: Map<any, any>;
   question: Map<string, any>;
   student: Map<any, any>;
-  staticSize?: boolean;
+  responsive?: boolean;
   studentName?: string;
 }
 


### PR DESCRIPTION
This PR makes fixes to the handling of the interactive iframe answers and some small UI improvements to the all student responses overlay.  Changes include: 
- Correctly determine if interactive can be opened with "View Work" link or only with "View work in new tab" link.
- Better handling of interactive sizing in question overlay (improvements to both the image answer and the interactive answer).
- Fix the min height of answers in the all student responses overlay (min height was being applied at all times which was adding lots of unneeded whitespace).
- Fix background color in upper left nav in all student responses (fixes the white band that sometimes appeared at bottom of nav component).
- Fix student name column width in all student responses (the column width did not line up with the upper left nav component).
