### PR TITLE
Use ellipsis when level viewer activity text is expanded and overflows

### DIFF
--- a/css/portal-dashboard/level-viewer.less
+++ b/css/portal-dashboard/level-viewer.less
@@ -174,7 +174,9 @@
 
         .activityTitle {
           padding: 0 10px;
+          overflow: hidden;
           text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
         &:hover {


### PR DESCRIPTION
Use ellipsis when the level viewer activity text is expanded and overflows. There are probably other places in the app where this is needed, but this gives us a starting point.
![image](https://user-images.githubusercontent.com/5126913/92679007-21ae0100-f2dc-11ea-8f69-776beb8651bb.png)

