### PR TITLE
Response table selection

### DIFF
--- a/css/portal-dashboard/answer-compact.less
+++ b/css/portal-dashboard/answer-compact.less
@@ -28,7 +28,7 @@
     &:hover {
       background-color: @cc-orange-light3;
     }
-    &:active {
+    &.selected, &:active {
       background-color: @cc-orange;
     }
   }

--- a/css/portal-dashboard/answer-compact.less
+++ b/css/portal-dashboard/answer-compact.less
@@ -21,8 +21,6 @@
 
     &.noAnswer {
       background-color: white;
-      pointer-events: none;
-      cursor: auto;
     }
 
     &:hover {

--- a/css/portal-dashboard/overlay-student-response.less
+++ b/css/portal-dashboard/overlay-student-response.less
@@ -66,6 +66,7 @@
         &.disabled {
           cursor: auto;
           opacity: 0.35;
+          pointer-events: none;
         }
       }
     }
@@ -75,5 +76,10 @@
     height: calc(100% - 80px);
     padding: 15px 20px 15px 20px;
     overflow-y: auto;
+
+    .selectMessage {
+      font-style: italic;
+      text-align: center;
+    }
   }
 }

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -113,6 +113,8 @@ context("Portal Dashboard Question Details Panel", () => {
   });
   describe('Student Response area', () => {
     it('verify student response area is visible', () => {
+      cy.get('[data-cy=open-response-completed]').eq(0).click();
+      cy.get('[data-cy=previous-student-button]').click().click();
       cy.get('[data-cy=overlay-student-response-area]').should('be.visible');
       cy.get('[data-cy=overlay-student-response-area] [data-cy=student-answer]').should('be.visible').and('contain', "No response");
     });

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -120,7 +120,7 @@ context("Portal Dashboard Question Details Panel", () => {
     });
     it('verify previous student button is disabled if first student',()=>{
       cy.get('[data-cy=overlay-student-name]').should('contain','Armstrong, Jenna');
-      cy.get('[data-cy=previous-student-button]').click(); //Can't verify if button is disabled
+      cy.get('[data-cy=previous-student-button]').click({force: true}); //Can't verify if button is disabled
       cy.get('[data-cy=overlay-student-name]').should('contain','Armstrong, Jenna');
     });
     it('verify changing students', () => {
@@ -128,12 +128,12 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=overlay-student-name').should('contain','Crosby, Kate');
       cy.get('[data-cy=next-student-button]').click().click();
       cy.get('[data-cy=overlay-student-name]').should('contain','Jenkins, John');
-      cy.get('[data-cy=overlay-student-response-area] [data-cy=student-answer]').should('be.visible').and('contain', "test required answer 2");
+      cy.get('[data-cy=overlay-student-response-area] [data-cy=student-answer]').should('be.visible').and('contain', "test answer 1");
     });
     it('verify next button is disabled when end of list is reached',()=>{
       cy.get('[data-cy=next-student-button]').click().click();
       cy.get('[data-cy=overlay-student-name]').should('contain','Wu, Jerome');
-      cy.get('[data-cy=next-student-button]').click();//Can't verify if button is disabled
+      cy.get('[data-cy=next-student-button]').click({force: true});//Can't verify if button is disabled
       cy.get('[data-cy=overlay-student-name]').should('contain','Wu, Jerome');
     });
     it('verify student name is anonymize when toggle is on and vice versa',()=>{

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
@@ -50,11 +50,18 @@ context("Portal Dashboard Response Table",()=>{
       .get('[data-cy=student-answer]')
       .eq(4)
       .get('[data-cy=interactive-completed]').should('be.visible');
-
     cy.get('[data-cy=student-answers-row]')
       .eq(5)
       .get('[data-cy=student-answer]')
       .eq(2)
       .get('[data-cy=multiple-choice-scored-correct]').should('be.visible');
+  });
+  it('verify click on response icon opens question detail for student', ()=>{
+    cy.get('[data-cy=open-response-completed]').eq(2).click();
+    cy.get('[data-cy=openResponseText]').should('be.visible').and('contain', "test required answer 2");
+    cy.get('[data-cy=overlay-student-name').should('contain', 'Jenkins, John');
+    cy.get('[data-cy=multiple-choice-nonscored-completed]').eq(2).click();
+    cy.get('[data-cy=multiple-choice-answers]').should('be.visible');
+    cy.get('[data-cy=overlay-student-name').should('contain', 'Wu, Jerome');
   });
 });

--- a/js/actions/dashboard.js
+++ b/js/actions/dashboard.js
@@ -5,7 +5,7 @@ export const SET_STUDENT_SORT = "SET_STUDENT_SORT";
 
 export const SET_CURRENT_ACTIVITY = "SET_CURRENT_ACTIVITY";
 export const SET_CURRENT_QUESTION = "SET_CURRENT_QUESTION";
-export const SET_CURRENT_STUDENT_INDEX = "SET_CURRENT_STUDENT_INDEX";
+export const SET_CURRENT_STUDENT = "SET_CURRENT_STUDENT";
 export const TOGGLE_CURRENT_ACTIVITY = "TOGGLE_CURRENT_ACTIVITY";
 export const TOGGLE_CURRENT_QUESTION = "TOGGLE_CURRENT_QUESTION";
 export const TOGGLE_ALL_RESPONSES_TO_CURRENT_QUESTION = "TOGGLE_ALL_RESPONSES_TO_CURRENT_QUESTION";
@@ -114,10 +114,10 @@ export function setCurrentQuestion(questionId) {
   };
 }
 
-export function setCurrentStudentIndex(studentIndex) {
+export function setCurrentStudent(studentId) {
   return {
-    type: SET_CURRENT_STUDENT_INDEX,
-    value: studentIndex,
+    type: SET_CURRENT_STUDENT,
+    value: studentId,
   };
 }
 

--- a/js/actions/dashboard.js
+++ b/js/actions/dashboard.js
@@ -4,6 +4,7 @@ export const SET_STUDENTS_EXPANDED = "SET_STUDENTS_EXPANDED";
 export const SET_STUDENT_SORT = "SET_STUDENT_SORT";
 
 export const SET_CURRENT_ACTIVITY = "SET_CURRENT_ACTIVITY";
+export const SET_CURRENT_QUESTION = "SET_CURRENT_QUESTION";
 export const TOGGLE_CURRENT_ACTIVITY = "TOGGLE_CURRENT_ACTIVITY";
 export const TOGGLE_CURRENT_QUESTION = "TOGGLE_CURRENT_QUESTION";
 export const TOGGLE_ALL_RESPONSES_TO_CURRENT_QUESTION = "TOGGLE_ALL_RESPONSES_TO_CURRENT_QUESTION";
@@ -102,6 +103,13 @@ export function setCurrentActivity(activityId) {
   return {
     type: SET_CURRENT_ACTIVITY,
     value: activityId,
+  };
+}
+
+export function setCurrentQuestion(questionId) {
+  return {
+    type: SET_CURRENT_QUESTION,
+    value: questionId,
   };
 }
 

--- a/js/actions/dashboard.js
+++ b/js/actions/dashboard.js
@@ -5,6 +5,7 @@ export const SET_STUDENT_SORT = "SET_STUDENT_SORT";
 
 export const SET_CURRENT_ACTIVITY = "SET_CURRENT_ACTIVITY";
 export const SET_CURRENT_QUESTION = "SET_CURRENT_QUESTION";
+export const SET_CURRENT_STUDENT_INDEX = "SET_CURRENT_STUDENT_INDEX";
 export const TOGGLE_CURRENT_ACTIVITY = "TOGGLE_CURRENT_ACTIVITY";
 export const TOGGLE_CURRENT_QUESTION = "TOGGLE_CURRENT_QUESTION";
 export const TOGGLE_ALL_RESPONSES_TO_CURRENT_QUESTION = "TOGGLE_ALL_RESPONSES_TO_CURRENT_QUESTION";
@@ -110,6 +111,13 @@ export function setCurrentQuestion(questionId) {
   return {
     type: SET_CURRENT_QUESTION,
     value: questionId,
+  };
+}
+
+export function setCurrentStudentIndex(studentIndex) {
+  return {
+    type: SET_CURRENT_STUDENT_INDEX,
+    value: studentIndex,
   };
 }
 

--- a/js/components/portal-dashboard/overlay-student-response.tsx
+++ b/js/components/portal-dashboard/overlay-student-response.tsx
@@ -16,7 +16,7 @@ interface IProps {
 
 export class StudentResponse extends React.PureComponent<IProps> {
   render() {
-    const { currentQuestion, students, isAnonymous, currentStudentId } = this.props;
+    const { students, isAnonymous, currentStudentId } = this.props;
     const currentStudentIndex = students.findIndex((s: any) => s.get("id") === currentStudentId );
     const studentSelected = currentStudentIndex >= 0;
     const studentName = studentSelected
@@ -24,25 +24,41 @@ export class StudentResponse extends React.PureComponent<IProps> {
                         : "Student Response";
     return (
       <div className={css.studentResponse} data-cy="overlay-student-response-area">
-        <div className={css.responseHeader}>
-          <div className={css.title} data-cy='overlay-student-name'>{studentName}</div>
-          <div className={css.nextStudentButtons}>
-            <div className={`${css.button} ${(studentSelected && currentStudentIndex > 0) ? "" : css.disabled}`}
-              data-cy="previous-student-button" onClick={this.changeCurrentStudent(currentStudentIndex - 1)}>
-              <ArrowLeftIcon className={css.icon} />
-            </div>
-            <div className={`${css.button} ${(studentSelected && currentStudentIndex < students.size - 1) ? "" : css.disabled}`}
-              data-cy="next-student-button" onClick={this.changeCurrentStudent(currentStudentIndex + 1)}>
-              <ArrowLeftIcon className={css.icon} />
-            </div>
+        {this.renderResponseHeader(currentStudentIndex, studentName)}
+        {this.renderResponseArea(currentStudentIndex, studentName)}
+      </div>
+    );
+  }
+
+  private renderResponseHeader = (currentStudentIndex: any, studentName: string) => {
+    const { students } = this.props;
+    const studentSelected = currentStudentIndex >= 0;
+    return (
+      <div className={css.responseHeader}>
+        <div className={css.title} data-cy='overlay-student-name'>{studentName}</div>
+        <div className={css.nextStudentButtons}>
+          <div className={`${css.button} ${(studentSelected && currentStudentIndex > 0) ? "" : css.disabled}`}
+            data-cy="previous-student-button" onClick={this.changeCurrentStudent(currentStudentIndex - 1)}>
+            <ArrowLeftIcon className={css.icon} />
+          </div>
+          <div className={`${css.button} ${(studentSelected && currentStudentIndex < students.size - 1) ? "" : css.disabled}`}
+            data-cy="next-student-button" onClick={this.changeCurrentStudent(currentStudentIndex + 1)}>
+            <ArrowLeftIcon className={css.icon} />
           </div>
         </div>
-        <div className={css.responseArea}>
-          { studentSelected
-            ? <Answer question={currentQuestion} student={students.get(currentStudentIndex)} responsive={true} studentName={studentName}/>
-            : <div className={css.selectMessage}>Select a student’s answer in the dashboard to view their response.</div>
-          }
-        </div>
+      </div>
+    );
+  }
+
+  private renderResponseArea = (currentStudentIndex: number, studentName: string) => {
+    const { currentQuestion, students } = this.props;
+    const studentSelected = currentStudentIndex >= 0;
+    return (
+      <div className={css.responseArea}>
+        { studentSelected
+          ? <Answer question={currentQuestion} student={students.get(currentStudentIndex)} responsive={true} studentName={studentName}/>
+          : <div className={css.selectMessage}>Select a student’s answer in the dashboard to view their response.</div>
+        }
       </div>
     );
   }

--- a/js/components/portal-dashboard/overlay-student-response.tsx
+++ b/js/components/portal-dashboard/overlay-student-response.tsx
@@ -10,21 +10,13 @@ interface IProps {
   students: any;
   isAnonymous: boolean;
   currentQuestion?: Map<string, any>;
-}
-interface IState {
+  setCurrentStudent: (studentIndex: number) => void;
   currentStudentIndex: number;
 }
 
-export class StudentResponse extends React.PureComponent<IProps, IState> {
-  constructor(props: IProps) {
-    super(props);
-    this.state = {
-      currentStudentIndex: 0
-    };
-  }
+export class StudentResponse extends React.PureComponent<IProps> {
   render() {
-    const { currentQuestion, students, isAnonymous } = this.props;
-    const { currentStudentIndex } = this.state;
+    const { currentQuestion, currentStudentIndex, students, isAnonymous } = this.props;
     const studentName = getFormattedStudentName(isAnonymous, students.get(currentStudentIndex));
     return (
       <div className={css.studentResponse} data-cy="overlay-student-response-area">
@@ -50,6 +42,6 @@ export class StudentResponse extends React.PureComponent<IProps, IState> {
 
   private changeCurrentStudent = (index: number) => () => {
     const newIndex = Math.min(Math.max(0, index), this.props.students.size - 1);
-      this.setState({ currentStudentIndex: newIndex });
+    this.props.setCurrentStudent(newIndex);
   }
 }

--- a/js/components/portal-dashboard/overlay-student-response.tsx
+++ b/js/components/portal-dashboard/overlay-student-response.tsx
@@ -17,24 +17,30 @@ interface IProps {
 export class StudentResponse extends React.PureComponent<IProps> {
   render() {
     const { currentQuestion, currentStudentIndex, students, isAnonymous } = this.props;
-    const studentName = getFormattedStudentName(isAnonymous, students.get(currentStudentIndex));
+    const studentSelected = currentStudentIndex >= 0;
+    const studentName = studentSelected
+                        ? getFormattedStudentName(isAnonymous, students.get(currentStudentIndex))
+                        : "Student Response";
     return (
       <div className={css.studentResponse} data-cy="overlay-student-response-area">
         <div className={css.responseHeader}>
-          <div className={css.title} data-cy='overlay-student-name'>{getFormattedStudentName(isAnonymous, students.get(currentStudentIndex))}</div>
+          <div className={css.title} data-cy='overlay-student-name'>{studentName}</div>
           <div className={css.nextStudentButtons}>
-            <div className={css.button + (currentStudentIndex > 0 ? "" : " " + css.disabled) }
+            <div className={`${css.button} ${(studentSelected && currentStudentIndex > 0) ? "" : css.disabled}`}
               data-cy="previous-student-button" onClick={this.changeCurrentStudent(currentStudentIndex - 1)}>
               <ArrowLeftIcon className={css.icon} />
             </div>
-            <div className={css.button + (currentStudentIndex < students.size - 1 ? "" : " " + css.disabled )}
+            <div className={`${css.button} ${(studentSelected && currentStudentIndex < students.size - 1) ? "" : css.disabled}`}
               data-cy="next-student-button" onClick={this.changeCurrentStudent(currentStudentIndex + 1)}>
               <ArrowLeftIcon className={css.icon} />
             </div>
           </div>
         </div>
         <div className={css.responseArea}>
-          <Answer question={currentQuestion} student={students.get(currentStudentIndex)} responsive={true} studentName={studentName}/>
+          { studentSelected
+            ? <Answer question={currentQuestion} student={students.get(currentStudentIndex)} responsive={true} studentName={studentName}/>
+            : <div className={css.selectMessage}>Select a student’s answer in the dashboard to view their response.</div>
+          }
         </div>
       </div>
     );
@@ -42,6 +48,8 @@ export class StudentResponse extends React.PureComponent<IProps> {
 
   private changeCurrentStudent = (index: number) => () => {
     const newIndex = Math.min(Math.max(0, index), this.props.students.size - 1);
-    this.props.setCurrentStudent(newIndex);
+    if (this.props.currentStudentIndex !== newIndex) {
+      this.props.setCurrentStudent(newIndex);
+    }
   }
 }

--- a/js/components/portal-dashboard/overlay-student-response.tsx
+++ b/js/components/portal-dashboard/overlay-student-response.tsx
@@ -10,13 +10,14 @@ interface IProps {
   students: any;
   isAnonymous: boolean;
   currentQuestion?: Map<string, any>;
-  setCurrentStudent: (studentIndex: number) => void;
-  currentStudentIndex: number;
+  setCurrentStudent: (studentId: string | null) => void;
+  currentStudentId: string | null;
 }
 
 export class StudentResponse extends React.PureComponent<IProps> {
   render() {
-    const { currentQuestion, currentStudentIndex, students, isAnonymous } = this.props;
+    const { currentQuestion, students, isAnonymous, currentStudentId } = this.props;
+    const currentStudentIndex = students.findIndex((s: any) => s.get("id") === currentStudentId );
     const studentSelected = currentStudentIndex >= 0;
     const studentName = studentSelected
                         ? getFormattedStudentName(isAnonymous, students.get(currentStudentIndex))
@@ -47,9 +48,12 @@ export class StudentResponse extends React.PureComponent<IProps> {
   }
 
   private changeCurrentStudent = (index: number) => () => {
+    const { currentStudentId, students } = this.props;
     const newIndex = Math.min(Math.max(0, index), this.props.students.size - 1);
-    if (this.props.currentStudentIndex !== newIndex) {
-      this.props.setCurrentStudent(newIndex);
+    const currentStudentIndex = students.findIndex((s: any) => s.get("id") === currentStudentId );
+    if (currentStudentIndex !== newIndex) {
+      const newId = students.get(newIndex).get("id");
+      this.props.setCurrentStudent(newId);
     }
   }
 }

--- a/js/components/portal-dashboard/question-overlay.tsx
+++ b/js/components/portal-dashboard/question-overlay.tsx
@@ -9,21 +9,21 @@ import QuestionPopoutIcon from "../../../img/svg-icons/question-popout-icon.svg"
 import css from "../../../css/portal-dashboard/question-overlay.less";
 
 interface IProps {
-  students: any;
-  isAnonymous: boolean;
   currentQuestion?: Map<string, any>;
-  questions?: Map<string, any>;
-  sortedQuestionIds?: string[];
-  toggleCurrentQuestion: (questionId: string) => void;
-  setCurrentActivity: (activityId: string) => void;
+  currentStudentId: string | null;
   handleShowAllResponsesPopup: (show: boolean) => void;
-  setCurrentStudent: (studentIndex: number) => void;
-  currentStudentIndex: number;
+  isAnonymous: boolean;
+  questions?: Map<string, any>;
+  setCurrentActivity: (activityId: string) => void;
+  setCurrentStudent: (studentId: string | null) => void;
+  sortedQuestionIds?: string[];
+  students: any;
+  toggleCurrentQuestion: (questionId: string) => void;
 }
 
 export class QuestionOverlay extends React.PureComponent<IProps> {
   render() {
-    const { students, currentQuestion, isAnonymous, setCurrentStudent, currentStudentIndex } = this.props;
+    const { students, currentQuestion, isAnonymous, setCurrentStudent, currentStudentId } = this.props;
     return (
       <div className={`${css.questionOverlay} ${(currentQuestion ? css.visible : "")}`} data-cy="question-overlay">
         { currentQuestion && this.renderQuestionDetails() }
@@ -34,7 +34,7 @@ export class QuestionOverlay extends React.PureComponent<IProps> {
             isAnonymous={isAnonymous}
             currentQuestion={currentQuestion}
             setCurrentStudent={setCurrentStudent}
-            currentStudentIndex={currentStudentIndex}
+            currentStudentId={currentStudentId}
           />
         }
         {this.renderFooter()}

--- a/js/components/portal-dashboard/question-overlay.tsx
+++ b/js/components/portal-dashboard/question-overlay.tsx
@@ -17,16 +17,26 @@ interface IProps {
   toggleCurrentQuestion: (questionId: string) => void;
   setCurrentActivity: (activityId: string) => void;
   handleShowAllResponsesPopup: (show: boolean) => void;
+  setCurrentStudent: (studentIndex: number) => void;
+  currentStudentIndex: number;
 }
 
 export class QuestionOverlay extends React.PureComponent<IProps> {
   render() {
-    const { students, currentQuestion, isAnonymous } = this.props;
+    const { students, currentQuestion, isAnonymous, setCurrentStudent, currentStudentIndex } = this.props;
     return (
       <div className={`${css.questionOverlay} ${(currentQuestion ? css.visible : "")}`} data-cy="question-overlay">
         { currentQuestion && this.renderQuestionDetails() }
         {/* Removed for MVP: { currentQuestion && <ClassResponse currentQuestion={currentQuestion}/> } */}
-        { currentQuestion && <StudentResponse students={students} isAnonymous={isAnonymous} currentQuestion={currentQuestion} /> }
+        { currentQuestion &&
+          <StudentResponse
+            students={students}
+            isAnonymous={isAnonymous}
+            currentQuestion={currentQuestion}
+            setCurrentStudent={setCurrentStudent}
+            currentStudentIndex={currentStudentIndex}
+          />
+        }
         {this.renderFooter()}
       </div>
     );

--- a/js/components/portal-dashboard/student-answers.tsx
+++ b/js/components/portal-dashboard/student-answers.tsx
@@ -6,6 +6,8 @@ import css from "../../../css/portal-dashboard/student-answers.less";
 interface IProps {
   activities: any;
   currentActivity: any;
+  currentQuestion: any;
+  currentStudentIndex: number;
   expandedActivities: any;
   isCompact: boolean;
   students: any;
@@ -13,6 +15,7 @@ interface IProps {
   setCurrentActivity: (activityId: string) => void;
   setCurrentQuestion: (questionId: string) => void;
   setCurrentStudent: (studentIndex: number) => void;
+
 }
 
 export class StudentAnswers extends React.PureComponent<IProps> {
@@ -58,24 +61,30 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     // const visibleQuestions = activity.get("questions", []).filter((q: any) => q.get("visible"));
     return (
       <div className={css.activityAnswers} key={activity.get("id")}>
-        { pages.map((page: any) => this.renderActivityPage(page, student, studentIndex)) }
+        { pages.map((page: any) => this.renderActivityPage(activity, page, student, studentIndex)) }
         { this.renderScore(activity, student) }
       </div>
     );
   }
 
-  private renderActivityPage = (page: any, student: any, studentIndex: number) => {
-    const activityId = this.props.currentActivity.get("id");
+  private renderActivityPage = (activity: any, page: any, student: any, studentIndex: number) => {
+    const currentActivityId = this.props.currentActivity.get("id");
+    const currentQuestionId = this.props.currentQuestion?.get("id");
+    const currentStudentIndex = this.props.currentStudentIndex;
     return (
       <div className={css.activityPage} key={page.get("id")}>
         { page.get("children").map((question: any) => {
             const questionId = question.get("id");
+            const selected = (currentActivityId === activity.get("id") &&
+                              currentQuestionId === questionId &&
+                              currentStudentIndex === studentIndex);
             return (
               <AnswerCompact
                 key={questionId}
                 question={question}
                 student={student}
-                onAnswerSelect={this.handleAnswerSelect(activityId, questionId, studentIndex)}
+                onAnswerSelect={this.handleAnswerSelect(currentActivityId, questionId, studentIndex)}
+                selected={selected}
                />
             );
           })
@@ -85,9 +94,13 @@ export class StudentAnswers extends React.PureComponent<IProps> {
   }
 
   private handleAnswerSelect = (activityId: string, questionId: string, studentIndex: number) => () => {
+    const currentActivityId = this.props.currentActivity.get("id");
+    const currentQuestionId = this.props.currentQuestion?.get("id");
+    const currentStudentIndex = this.props.currentStudentIndex;
+    const unselectStudent = currentActivityId === activityId && currentQuestionId === questionId && currentStudentIndex === studentIndex;
     this.props.setCurrentActivity(activityId);
     this.props.setCurrentQuestion(questionId);
-    this.props.setCurrentStudent(studentIndex);
+    this.props.setCurrentStudent(unselectStudent? -1 : studentIndex);
   }
 
   private renderScore = (activity: any, student: any) => {

--- a/js/components/portal-dashboard/student-answers.tsx
+++ b/js/components/portal-dashboard/student-answers.tsx
@@ -10,6 +10,8 @@ interface IProps {
   isCompact: boolean;
   students: any;
   studentProgress: any;
+  setCurrentActivity: (activityId: string) => void;
+  setCurrentQuestion: (questionId: string) => void;
 }
 
 export class StudentAnswers extends React.PureComponent<IProps> {
@@ -62,16 +64,28 @@ export class StudentAnswers extends React.PureComponent<IProps> {
   }
 
   private renderActivityPage = (page: any, student: any) => {
+    const activityId = this.props.currentActivity.get("id");
     return (
       <div className={css.activityPage} key={page.get("id")}>
         { page.get("children").map((question: any) => {
+            const questionId = question.get("id");
             return (
-              <AnswerCompact key={question.get("id")} question={question} student={student} />
+              <AnswerCompact
+                key={questionId}
+                question={question}
+                student={student}
+                onAnswerSelect={this.handleAnswerSelect(activityId, questionId)}
+               />
             );
           })
         }
       </div>
     );
+  }
+
+  private handleAnswerSelect = (activityId: string, questionId: string) => () => {
+    this.props.setCurrentActivity(activityId);
+    this.props.setCurrentQuestion(questionId);
   }
 
   private renderScore = (activity: any, student: any) => {
@@ -113,4 +127,5 @@ export class StudentAnswers extends React.PureComponent<IProps> {
       <div className={`${css.progressIcon} ${cssClass}`}/>
     );
   }
+
 }

--- a/js/components/portal-dashboard/student-answers.tsx
+++ b/js/components/portal-dashboard/student-answers.tsx
@@ -12,6 +12,7 @@ interface IProps {
   studentProgress: any;
   setCurrentActivity: (activityId: string) => void;
   setCurrentQuestion: (questionId: string) => void;
+  setCurrentStudent: (studentIndex: number) => void;
 }
 
 export class StudentAnswers extends React.PureComponent<IProps> {
@@ -24,14 +25,14 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     return (
       <div className={css.studentAnswers} ref={elt => this.studentAnswersRef = elt} data-cy="student-answers" >
       {
-        students.map((s: any) => {
+        students.map((s: any, index: number) => {
           return (
             <div key={s.get("id")} className={`${css.studentAnswersRow} ${compactClass}`} data-cy="student-answers-row">
               {
                 activitiesList.map((a: any) => {
                   return (
                     (currentActivity && a.get("id") === currentActivity.get("id"))
-                    ? this.renderExpandedActivity(a, s)
+                    ? this.renderExpandedActivity(a, s, index)
                     : this.renderProgress(a, s)
                   );
                 })
@@ -48,7 +49,7 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     return this.studentAnswersRef;
   }
 
-  private renderExpandedActivity = (activity: any, student: any) => {
+  private renderExpandedActivity = (activity: any, student: any, studentIndex: number) => {
     const pages: Map<any, any>[] = [];
     activity.get("children").forEach((section: Map<any, any>) => {
       section.get("children").forEach((page: Map<any, any>) => pages.push(page));
@@ -57,13 +58,13 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     // const visibleQuestions = activity.get("questions", []).filter((q: any) => q.get("visible"));
     return (
       <div className={css.activityAnswers} key={activity.get("id")}>
-        { pages.map((page: any) => this.renderActivityPage(page, student)) }
+        { pages.map((page: any) => this.renderActivityPage(page, student, studentIndex)) }
         { this.renderScore(activity, student) }
       </div>
     );
   }
 
-  private renderActivityPage = (page: any, student: any) => {
+  private renderActivityPage = (page: any, student: any, studentIndex: number) => {
     const activityId = this.props.currentActivity.get("id");
     return (
       <div className={css.activityPage} key={page.get("id")}>
@@ -74,7 +75,7 @@ export class StudentAnswers extends React.PureComponent<IProps> {
                 key={questionId}
                 question={question}
                 student={student}
-                onAnswerSelect={this.handleAnswerSelect(activityId, questionId)}
+                onAnswerSelect={this.handleAnswerSelect(activityId, questionId, studentIndex)}
                />
             );
           })
@@ -83,9 +84,10 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     );
   }
 
-  private handleAnswerSelect = (activityId: string, questionId: string) => () => {
+  private handleAnswerSelect = (activityId: string, questionId: string, studentIndex: number) => () => {
     this.props.setCurrentActivity(activityId);
     this.props.setCurrentQuestion(questionId);
+    this.props.setCurrentStudent(studentIndex);
   }
 
   private renderScore = (activity: any, student: any) => {

--- a/js/components/portal-dashboard/student-answers.tsx
+++ b/js/components/portal-dashboard/student-answers.tsx
@@ -7,15 +7,14 @@ interface IProps {
   activities: any;
   currentActivity: any;
   currentQuestion: any;
-  currentStudentIndex: number;
+  currentStudentId: string | null;
   expandedActivities: any;
   isCompact: boolean;
   students: any;
   studentProgress: any;
   setCurrentActivity: (activityId: string) => void;
   setCurrentQuestion: (questionId: string) => void;
-  setCurrentStudent: (studentIndex: number) => void;
-
+  setCurrentStudent: (studentId: string | null) => void;
 }
 
 export class StudentAnswers extends React.PureComponent<IProps> {
@@ -28,14 +27,14 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     return (
       <div className={css.studentAnswers} ref={elt => this.studentAnswersRef = elt} data-cy="student-answers" >
       {
-        students.map((s: any, index: number) => {
+        students.map((s: any) => {
           return (
             <div key={s.get("id")} className={`${css.studentAnswersRow} ${compactClass}`} data-cy="student-answers-row">
               {
                 activitiesList.map((a: any) => {
                   return (
                     (currentActivity && a.get("id") === currentActivity.get("id"))
-                    ? this.renderExpandedActivity(a, s, index)
+                    ? this.renderExpandedActivity(a, s)
                     : this.renderProgress(a, s)
                   );
                 })
@@ -52,7 +51,7 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     return this.studentAnswersRef;
   }
 
-  private renderExpandedActivity = (activity: any, student: any, studentIndex: number) => {
+  private renderExpandedActivity = (activity: any, student: any) => {
     const pages: Map<any, any>[] = [];
     activity.get("children").forEach((section: Map<any, any>) => {
       section.get("children").forEach((page: Map<any, any>) => pages.push(page));
@@ -61,29 +60,29 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     // const visibleQuestions = activity.get("questions", []).filter((q: any) => q.get("visible"));
     return (
       <div className={css.activityAnswers} key={activity.get("id")}>
-        { pages.map((page: any) => this.renderActivityPage(activity, page, student, studentIndex)) }
+        { pages.map((page: any) => this.renderActivityPage(activity, page, student)) }
         { this.renderScore(activity, student) }
       </div>
     );
   }
 
-  private renderActivityPage = (activity: any, page: any, student: any, studentIndex: number) => {
+  private renderActivityPage = (activity: any, page: any, student: any) => {
     const currentActivityId = this.props.currentActivity.get("id");
     const currentQuestionId = this.props.currentQuestion?.get("id");
-    const currentStudentIndex = this.props.currentStudentIndex;
+    const currentStudentId = this.props.currentStudentId;
     return (
       <div className={css.activityPage} key={page.get("id")}>
         { page.get("children").map((question: any) => {
             const questionId = question.get("id");
             const selected = (currentActivityId === activity.get("id") &&
                               currentQuestionId === questionId &&
-                              currentStudentIndex === studentIndex);
+                              currentStudentId === student.get("id"));
             return (
               <AnswerCompact
                 key={questionId}
                 question={question}
                 student={student}
-                onAnswerSelect={this.handleAnswerSelect(currentActivityId, questionId, studentIndex)}
+                onAnswerSelect={this.handleAnswerSelect(currentActivityId, questionId, student.get("id"))}
                 selected={selected}
                />
             );
@@ -93,14 +92,14 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     );
   }
 
-  private handleAnswerSelect = (activityId: string, questionId: string, studentIndex: number) => () => {
+  private handleAnswerSelect = (activityId: string, questionId: string, studentId: string) => () => {
     const currentActivityId = this.props.currentActivity.get("id");
     const currentQuestionId = this.props.currentQuestion?.get("id");
-    const currentStudentIndex = this.props.currentStudentIndex;
-    const unselectStudent = currentActivityId === activityId && currentQuestionId === questionId && currentStudentIndex === studentIndex;
+    const currentStudentId = this.props.currentStudentId;
+    const unselectStudent = currentActivityId === activityId && currentQuestionId === questionId && currentStudentId === studentId;
     this.props.setCurrentActivity(activityId);
     this.props.setCurrentQuestion(questionId);
-    this.props.setCurrentStudent(unselectStudent? -1 : studentIndex);
+    this.props.setCurrentStudent(unselectStudent? null : studentId);
   }
 
   private renderScore = (activity: any, student: any) => {

--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -25,9 +25,10 @@ class AnswerCompact extends React.PureComponent<AnswerProps> {
   }
 
   private renderAnswer = (icon: any, iconId: string) => {
+    const { onAnswerSelect } = this.props;
     const AnswerIcon = icon;
     return (
-      <div className={css.answerContent} data-cy={iconId}>
+      <div className={css.answerContent} data-cy={iconId} onClick={onAnswerSelect}>
         <AnswerIcon />
       </div>
     );

--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -35,8 +35,9 @@ class AnswerCompact extends React.PureComponent<AnswerProps> {
   }
 
   renderNoAnswer = () => {
+    const { onAnswerSelect, selected } = this.props;
     return (
-      <div className={`${css.answerContent} ${css.noAnswer}`} data-cy="no-answer" />
+      <div className={`${css.answerContent} ${css.noAnswer} ${selected ? css.selected : ""}`} data-cy="no-answer" onClick={onAnswerSelect}/>
     );
   }
 

--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -25,10 +25,10 @@ class AnswerCompact extends React.PureComponent<AnswerProps> {
   }
 
   private renderAnswer = (icon: any, iconId: string) => {
-    const { onAnswerSelect } = this.props;
+    const { onAnswerSelect, selected } = this.props;
     const AnswerIcon = icon;
     return (
-      <div className={css.answerContent} data-cy={iconId} onClick={onAnswerSelect}>
+      <div className={`${css.answerContent} ${selected ? css.selected : ""}`} data-cy={iconId} onClick={onAnswerSelect}>
         <AnswerIcon />
       </div>
     );

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -143,6 +143,8 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
               <StudentAnswers
                 activities={activityTrees}
                 currentActivity={currentActivity}
+                currentQuestion={currentQuestion}
+                currentStudentIndex={currentStudentIndex}
                 expandedActivities={expandedActivities}
                 students={students}
                 studentProgress={studentProgress}

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Map } from "immutable";
 import { connect } from "react-redux";
 import { fetchAndObserveData, trackEvent, setAnonymous } from "../../actions/index";
-import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getCurrentStudentIndex,
+import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getCurrentStudentId,
         getStudentProgress, getCompactReport } from "../../selectors/dashboard-selectors";
 import { Header } from "../../components/portal-dashboard/header";
 import { ClassNav } from "../../components/portal-dashboard/class-nav";
@@ -13,7 +13,7 @@ import LoadingIcon from "../../components/report/loading-icon";
 import DataFetchError from "../../components/report/data-fetch-error";
 import { getSequenceTree } from "../../selectors/report-tree";
 import { IResponse } from "../../api";
-import { setStudentSort, setCurrentActivity, setCurrentQuestion, setCurrentStudentIndex,
+import { setStudentSort, setCurrentActivity, setCurrentQuestion, setCurrentStudent,
          toggleCurrentActivity, toggleCurrentQuestion, setCompactReport } from "../../actions/dashboard";
 import { RootState } from "../../reducers";
 import { QuestionOverlay } from "../../components/portal-dashboard/question-overlay";
@@ -27,7 +27,7 @@ interface IProps {
   compactReport: boolean;
   currentActivity?: Map<string, any>;
   currentQuestion?: Map<string, any>;
-  currentStudentIndex: number;
+  currentStudentId: string | null;
   error: IResponse;
   expandedActivities: Map<any, any>;
   isFetching: boolean;
@@ -45,7 +45,7 @@ interface IProps {
   setStudentSort: (value: string) => void;
   setCurrentActivity: (activityId: string) => void;
   setCurrentQuestion: (questionId: string) => void;
-  setCurrentStudentIndex: (studentIndex: number) => void;
+  setCurrentStudent: (studentId: string) => void;
   toggleCurrentActivity: (activityId: string) => void;
   toggleCurrentQuestion: (questionId: string) => void;
   trackEvent: (category: string, action: string, label: string) => void;
@@ -88,9 +88,9 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   }
 
   render() {
-    const { clazzName, compactReport, currentActivity, currentQuestion, currentStudentIndex, error, report,
+    const { clazzName, compactReport, currentActivity, currentQuestion, currentStudentId, error, report,
       sequenceTree, setAnonymous, setCompactReport, setStudentSort, studentProgress, students, sortedQuestionIds, questions,
-      expandedActivities, setCurrentActivity, setCurrentQuestion, setCurrentStudentIndex, toggleCurrentActivity, toggleCurrentQuestion, trackEvent, userName } = this.props;
+      expandedActivities, setCurrentActivity, setCurrentQuestion, setCurrentStudent, toggleCurrentActivity, toggleCurrentQuestion, trackEvent, userName } = this.props;
     const { initialLoading, showAllResponsesPopup } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
@@ -144,7 +144,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 activities={activityTrees}
                 currentActivity={currentActivity}
                 currentQuestion={currentQuestion}
-                currentStudentIndex={currentStudentIndex}
+                currentStudentId={currentStudentId}
                 expandedActivities={expandedActivities}
                 students={students}
                 studentProgress={studentProgress}
@@ -152,20 +152,20 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 isCompact={compactReport}
                 setCurrentActivity={setCurrentActivity}
                 setCurrentQuestion={setCurrentQuestion}
-                setCurrentStudent={setCurrentStudentIndex}
+                setCurrentStudent={setCurrentStudent}
               />
             </div>
             <QuestionOverlay
-              students={students}
-              isAnonymous={isAnonymous}
               currentQuestion={currentQuestion}
-              questions={questions}
-              sortedQuestionIds={sortedQuestionIds}
-              toggleCurrentQuestion={toggleCurrentQuestion}
-              setCurrentActivity={setCurrentActivity}
+              currentStudentId={currentStudentId}
               handleShowAllResponsesPopup={this.setShowAllResponsesPopup}
-              setCurrentStudent={setCurrentStudentIndex}
-              currentStudentIndex={currentStudentIndex}
+              isAnonymous={isAnonymous}
+              questions={questions}
+              setCurrentActivity={setCurrentActivity}
+              setCurrentStudent={setCurrentStudent}
+              sortedQuestionIds={sortedQuestionIds}
+              students={students}
+              toggleCurrentQuestion={toggleCurrentQuestion}
             />
             {showAllResponsesPopup &&
               <StudentResponsePopup
@@ -230,7 +230,7 @@ function mapStateToProps(state: RootState): Partial<IProps> {
     compactReport: getCompactReport(state),
     currentActivity: getCurrentActivity(state),
     currentQuestion: getCurrentQuestion(state),
-    currentStudentIndex: getCurrentStudentIndex(state),
+    currentStudentId: getCurrentStudentId(state),
     error,
     expandedActivities: state.getIn(["dashboard", "expandedActivities"]),
     isFetching: data.get("isFetching"),
@@ -251,7 +251,7 @@ const mapDispatchToProps = (dispatch: any, ownProps: any): Partial<IProps> => {
     setCompactReport: (value: boolean) => dispatch(setCompactReport(value)),
     setStudentSort: (value: string) => dispatch(setStudentSort(value)),
     setCurrentActivity: (activityId: string) => dispatch(setCurrentActivity(activityId)),
-    setCurrentStudentIndex: (studentIndex: number) => dispatch(setCurrentStudentIndex(studentIndex)),
+    setCurrentStudent: (studentId: string) => dispatch(setCurrentStudent(studentId)),
     setCurrentQuestion: (questionId: string) => dispatch(setCurrentQuestion(questionId)),
     toggleCurrentActivity: (activityId: string) => dispatch(toggleCurrentActivity(activityId)),
     toggleCurrentQuestion: (questionId: string) => dispatch(toggleCurrentQuestion(questionId)),

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -12,7 +12,7 @@ import LoadingIcon from "../../components/report/loading-icon";
 import DataFetchError from "../../components/report/data-fetch-error";
 import { getSequenceTree } from "../../selectors/report-tree";
 import { IResponse } from "../../api";
-import { setStudentSort, setCurrentActivity, toggleCurrentActivity, toggleCurrentQuestion, setCompactReport } from "../../actions/dashboard";
+import { setStudentSort, setCurrentActivity, setCurrentQuestion, toggleCurrentActivity, toggleCurrentQuestion, setCompactReport } from "../../actions/dashboard";
 import { RootState } from "../../reducers";
 import { QuestionOverlay } from "../../components/portal-dashboard/question-overlay";
 import { StudentResponsePopup } from "../../components/portal-dashboard/all-responses-popup/student-responses-popup";
@@ -41,6 +41,7 @@ interface IProps {
   setCompactReport: (value: boolean) => void;
   setStudentSort: (value: string) => void;
   setCurrentActivity: (activityId: string) => void;
+  setCurrentQuestion: (questionId: string) => void;
   toggleCurrentActivity: (activityId: string) => void;
   toggleCurrentQuestion: (questionId: string) => void;
   trackEvent: (category: string, action: string, label: string) => void;
@@ -85,7 +86,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   render() {
     const { clazzName, compactReport, currentActivity, currentQuestion, error, report,
       sequenceTree, setAnonymous, setCompactReport, setStudentSort, studentProgress, students, sortedQuestionIds, questions,
-      expandedActivities, setCurrentActivity, toggleCurrentActivity, toggleCurrentQuestion, trackEvent, userName } = this.props;
+      expandedActivities, setCurrentActivity, setCurrentQuestion, toggleCurrentActivity, toggleCurrentQuestion, trackEvent, userName } = this.props;
     const { initialLoading, showAllResponsesPopup } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
@@ -143,6 +144,8 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 studentProgress={studentProgress}
                 ref={elt => this.studentAnswersComponentRef = elt}
                 isCompact={compactReport}
+                setCurrentActivity={setCurrentActivity}
+                setCurrentQuestion={setCurrentQuestion}
               />
             </div>
             <QuestionOverlay
@@ -238,6 +241,7 @@ const mapDispatchToProps = (dispatch: any, ownProps: any): Partial<IProps> => {
     setCompactReport: (value: boolean) => dispatch(setCompactReport(value)),
     setStudentSort: (value: string) => dispatch(setStudentSort(value)),
     setCurrentActivity: (activityId: string) => dispatch(setCurrentActivity(activityId)),
+    setCurrentQuestion: (questionId: string) => dispatch(setCurrentQuestion(questionId)),
     toggleCurrentActivity: (activityId: string) => dispatch(toggleCurrentActivity(activityId)),
     toggleCurrentQuestion: (questionId: string) => dispatch(toggleCurrentQuestion(questionId)),
     trackEvent: (category: string, action: string, label: string) => dispatch(trackEvent(category, action, label)),

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Map } from "immutable";
 import { connect } from "react-redux";
 import { fetchAndObserveData, trackEvent, setAnonymous } from "../../actions/index";
-import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getStudentProgress, getCompactReport } from "../../selectors/dashboard-selectors";
+import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getCurrentStudentIndex,
+        getStudentProgress, getCompactReport } from "../../selectors/dashboard-selectors";
 import { Header } from "../../components/portal-dashboard/header";
 import { ClassNav } from "../../components/portal-dashboard/class-nav";
 import { LevelViewer } from "../../components/portal-dashboard/level-viewer";
@@ -12,7 +13,8 @@ import LoadingIcon from "../../components/report/loading-icon";
 import DataFetchError from "../../components/report/data-fetch-error";
 import { getSequenceTree } from "../../selectors/report-tree";
 import { IResponse } from "../../api";
-import { setStudentSort, setCurrentActivity, setCurrentQuestion, toggleCurrentActivity, toggleCurrentQuestion, setCompactReport } from "../../actions/dashboard";
+import { setStudentSort, setCurrentActivity, setCurrentQuestion, setCurrentStudentIndex,
+         toggleCurrentActivity, toggleCurrentQuestion, setCompactReport } from "../../actions/dashboard";
 import { RootState } from "../../reducers";
 import { QuestionOverlay } from "../../components/portal-dashboard/question-overlay";
 import { StudentResponsePopup } from "../../components/portal-dashboard/all-responses-popup/student-responses-popup";
@@ -25,6 +27,7 @@ interface IProps {
   compactReport: boolean;
   currentActivity?: Map<string, any>;
   currentQuestion?: Map<string, any>;
+  currentStudentIndex: number;
   error: IResponse;
   expandedActivities: Map<any, any>;
   isFetching: boolean;
@@ -42,6 +45,7 @@ interface IProps {
   setStudentSort: (value: string) => void;
   setCurrentActivity: (activityId: string) => void;
   setCurrentQuestion: (questionId: string) => void;
+  setCurrentStudentIndex: (studentIndex: number) => void;
   toggleCurrentActivity: (activityId: string) => void;
   toggleCurrentQuestion: (questionId: string) => void;
   trackEvent: (category: string, action: string, label: string) => void;
@@ -84,9 +88,9 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   }
 
   render() {
-    const { clazzName, compactReport, currentActivity, currentQuestion, error, report,
+    const { clazzName, compactReport, currentActivity, currentQuestion, currentStudentIndex, error, report,
       sequenceTree, setAnonymous, setCompactReport, setStudentSort, studentProgress, students, sortedQuestionIds, questions,
-      expandedActivities, setCurrentActivity, setCurrentQuestion, toggleCurrentActivity, toggleCurrentQuestion, trackEvent, userName } = this.props;
+      expandedActivities, setCurrentActivity, setCurrentQuestion, setCurrentStudentIndex, toggleCurrentActivity, toggleCurrentQuestion, trackEvent, userName } = this.props;
     const { initialLoading, showAllResponsesPopup } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
@@ -146,6 +150,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 isCompact={compactReport}
                 setCurrentActivity={setCurrentActivity}
                 setCurrentQuestion={setCurrentQuestion}
+                setCurrentStudent={setCurrentStudentIndex}
               />
             </div>
             <QuestionOverlay
@@ -157,6 +162,8 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
               toggleCurrentQuestion={toggleCurrentQuestion}
               setCurrentActivity={setCurrentActivity}
               handleShowAllResponsesPopup={this.setShowAllResponsesPopup}
+              setCurrentStudent={setCurrentStudentIndex}
+              currentStudentIndex={currentStudentIndex}
             />
             {showAllResponsesPopup &&
               <StudentResponsePopup
@@ -221,6 +228,7 @@ function mapStateToProps(state: RootState): Partial<IProps> {
     compactReport: getCompactReport(state),
     currentActivity: getCurrentActivity(state),
     currentQuestion: getCurrentQuestion(state),
+    currentStudentIndex: getCurrentStudentIndex(state),
     error,
     expandedActivities: state.getIn(["dashboard", "expandedActivities"]),
     isFetching: data.get("isFetching"),
@@ -241,6 +249,7 @@ const mapDispatchToProps = (dispatch: any, ownProps: any): Partial<IProps> => {
     setCompactReport: (value: boolean) => dispatch(setCompactReport(value)),
     setStudentSort: (value: string) => dispatch(setStudentSort(value)),
     setCurrentActivity: (activityId: string) => dispatch(setCurrentActivity(activityId)),
+    setCurrentStudentIndex: (studentIndex: number) => dispatch(setCurrentStudentIndex(studentIndex)),
     setCurrentQuestion: (questionId: string) => dispatch(setCurrentQuestion(questionId)),
     toggleCurrentActivity: (activityId: string) => dispatch(toggleCurrentActivity(activityId)),
     toggleCurrentQuestion: (questionId: string) => dispatch(toggleCurrentQuestion(questionId)),

--- a/js/reducers/dashboard-reducer.ts
+++ b/js/reducers/dashboard-reducer.ts
@@ -1,7 +1,7 @@
 import { RecordFactory } from "../util/record-factory";
 import { Map } from "immutable";
 import {
-  SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION,
+  SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, SET_CURRENT_QUESTION, TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION,
   SET_STUDENT_EXPANDED, SET_STUDENTS_EXPANDED, SET_STUDENT_SORT, SET_COMPACT_REPORT,
   SORT_BY_NAME, SET_QUESTION_EXPANDED,
   SELECT_QUESTION,
@@ -68,6 +68,8 @@ export default function dashboard(state = new DashboardState({}), action: any) {
       return state.set("selectedQuestion", action.value);
     case SET_CURRENT_ACTIVITY:
       return state.set("currentActivityId", action.value);
+    case SET_CURRENT_QUESTION:
+      return state.set("currentQuestionId", action.value);
     case TOGGLE_CURRENT_ACTIVITY:
       if (state.get("currentActivityId") === action.value) {
         return state.set("currentActivityId", null);

--- a/js/reducers/dashboard-reducer.ts
+++ b/js/reducers/dashboard-reducer.ts
@@ -1,7 +1,7 @@
 import { RecordFactory } from "../util/record-factory";
 import { Map } from "immutable";
 import {
-  SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, SET_CURRENT_QUESTION, SET_CURRENT_STUDENT_INDEX,
+  SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, SET_CURRENT_QUESTION, SET_CURRENT_STUDENT,
   TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION,
   SET_STUDENT_EXPANDED, SET_STUDENTS_EXPANDED, SET_STUDENT_SORT, SET_COMPACT_REPORT,
   SORT_BY_NAME, SET_QUESTION_EXPANDED,
@@ -22,7 +22,7 @@ export interface IDashboardState {
   sortBy: SortType;
   currentActivityId: string | null;
   currentQuestionId: string | null;
-  currentStudentIndex: number;
+  currentStudentId: string | null;
   compactReport: boolean;
 }
 
@@ -34,7 +34,7 @@ const INITIAL_DASHBOARD_STATE = RecordFactory<IDashboardState>({
   selectedQuestion: null,
   currentActivityId: null,
   currentQuestionId: null,
-  currentStudentIndex: -1,
+  currentStudentId: null,
   compactReport: false,
 });
 
@@ -49,7 +49,7 @@ export class DashboardState extends INITIAL_DASHBOARD_STATE implements IDashboar
   selectedQuestion: Map<any, any> | null;
   currentActivityId: string | null;
   currentQuestionId: string | null;
-  currentStudentIndex: number;
+  currentStudentId: string | null;
   compactReport: boolean;
 }
 
@@ -74,8 +74,8 @@ export default function dashboard(state = new DashboardState({}), action: any) {
       return state.set("currentActivityId", action.value);
     case SET_CURRENT_QUESTION:
       return state.set("currentQuestionId", action.value);
-    case SET_CURRENT_STUDENT_INDEX:
-      return state.set("currentStudentIndex", action.value);
+    case SET_CURRENT_STUDENT:
+      return state.set("currentStudentId", action.value);
     case TOGGLE_CURRENT_ACTIVITY:
       if (state.get("currentActivityId") === action.value) {
         return state.set("currentActivityId", null);

--- a/js/reducers/dashboard-reducer.ts
+++ b/js/reducers/dashboard-reducer.ts
@@ -34,7 +34,7 @@ const INITIAL_DASHBOARD_STATE = RecordFactory<IDashboardState>({
   selectedQuestion: null,
   currentActivityId: null,
   currentQuestionId: null,
-  currentStudentIndex: 0,
+  currentStudentIndex: -1,
   compactReport: false,
 });
 

--- a/js/reducers/dashboard-reducer.ts
+++ b/js/reducers/dashboard-reducer.ts
@@ -1,7 +1,8 @@
 import { RecordFactory } from "../util/record-factory";
 import { Map } from "immutable";
 import {
-  SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, SET_CURRENT_QUESTION, TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION,
+  SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, SET_CURRENT_QUESTION, SET_CURRENT_STUDENT_INDEX,
+  TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION,
   SET_STUDENT_EXPANDED, SET_STUDENTS_EXPANDED, SET_STUDENT_SORT, SET_COMPACT_REPORT,
   SORT_BY_NAME, SET_QUESTION_EXPANDED,
   SELECT_QUESTION,
@@ -21,6 +22,7 @@ export interface IDashboardState {
   sortBy: SortType;
   currentActivityId: string | null;
   currentQuestionId: string | null;
+  currentStudentIndex: number;
   compactReport: boolean;
 }
 
@@ -32,6 +34,7 @@ const INITIAL_DASHBOARD_STATE = RecordFactory<IDashboardState>({
   selectedQuestion: null,
   currentActivityId: null,
   currentQuestionId: null,
+  currentStudentIndex: 0,
   compactReport: false,
 });
 
@@ -46,6 +49,7 @@ export class DashboardState extends INITIAL_DASHBOARD_STATE implements IDashboar
   selectedQuestion: Map<any, any> | null;
   currentActivityId: string | null;
   currentQuestionId: string | null;
+  currentStudentIndex: number;
   compactReport: boolean;
 }
 
@@ -70,6 +74,8 @@ export default function dashboard(state = new DashboardState({}), action: any) {
       return state.set("currentActivityId", action.value);
     case SET_CURRENT_QUESTION:
       return state.set("currentQuestionId", action.value);
+    case SET_CURRENT_STUDENT_INDEX:
+      return state.set("currentStudentIndex", action.value);
     case TOGGLE_CURRENT_ACTIVITY:
       if (state.get("currentActivityId") === action.value) {
         return state.set("currentActivityId", null);

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -9,6 +9,7 @@ const getActivities = state => state.getIn(["report", "activities"]);
 const getCurrentActivityId = state => state.getIn(["dashboard", "currentActivityId"]);
 const getQuestions = state => state.getIn(["report", "questions"]);
 const getCurrentQuestionId = state => state.getIn(["dashboard", "currentQuestionId"]);
+export const getCurrentStudentIndex = state => state.getIn(["dashboard", "currentStudentIndex"]);
 const getStudents = state => state.getIn(["report", "students"]);
 const getDashboardSortBy = state => state.getIn(["dashboard", "sortBy"]);
 const getSeletedQuestionId = state => state.getIn(["dashboard", "selectedQuestion"]);

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -9,7 +9,7 @@ const getActivities = state => state.getIn(["report", "activities"]);
 const getCurrentActivityId = state => state.getIn(["dashboard", "currentActivityId"]);
 const getQuestions = state => state.getIn(["report", "questions"]);
 const getCurrentQuestionId = state => state.getIn(["dashboard", "currentQuestionId"]);
-export const getCurrentStudentIndex = state => state.getIn(["dashboard", "currentStudentIndex"]);
+export const getCurrentStudentId = state => state.getIn(["dashboard", "currentStudentId"]);
 const getStudents = state => state.getIn(["report", "students"]);
 const getDashboardSortBy = state => state.getIn(["dashboard", "sortBy"]);
 const getSeletedQuestionId = state => state.getIn(["dashboard", "selectedQuestion"]);

--- a/js/util/answer-utils.ts
+++ b/js/util/answer-utils.ts
@@ -26,6 +26,7 @@ export interface AnswerProps {
   responsive?: boolean;
   studentName?: string;
   onAnswerSelect?: () => void;
+  selected?: boolean;
 }
 
 export const AnswerTypes: AnswerType[] = [

--- a/js/util/answer-utils.ts
+++ b/js/util/answer-utils.ts
@@ -25,6 +25,7 @@ export interface AnswerProps {
   student: Map<any, any>;
   responsive?: boolean;
   studentName?: string;
+  onAnswerSelect?: () => void;
 }
 
 export const AnswerTypes: AnswerType[] = [

--- a/test/reducers/dashboard-reducer_spec.js
+++ b/test/reducers/dashboard-reducer_spec.js
@@ -11,6 +11,7 @@ describe("dashboard reducer", () => {
       selectedQuestion: null,
       currentActivityId: null,
       currentQuestionId: null,
+      currentStudentIndex: 0,
       compactReport: false,
     });
   });

--- a/test/reducers/dashboard-reducer_spec.js
+++ b/test/reducers/dashboard-reducer_spec.js
@@ -11,7 +11,7 @@ describe("dashboard reducer", () => {
       selectedQuestion: null,
       currentActivityId: null,
       currentQuestionId: null,
-      currentStudentIndex: 0,
+      currentStudentId: null,
       compactReport: false,
     });
   });


### PR DESCRIPTION
This PR fixes a bug/unimplemented feature in the response table.  When an response table icon is clicked, the current question and student in the question overlay need to change state to reflect the item that was clicked on.  This PR adds a current student index to the to redux state so that we can access a current student in parallel components.  Otherwise, existing redux state is used to manage clicks in the response table.

![tableclick](https://user-images.githubusercontent.com/5126913/93109191-98deee80-f668-11ea-99a3-6c9c7a4cd51d.gif)

