### PR TITLE
Fix interactive load error when navigating from one interactive to another

### DIFF
--- a/js/containers/portal-dashboard/answer.tsx
+++ b/js/containers/portal-dashboard/answer.tsx
@@ -16,16 +16,16 @@ class Answer extends React.PureComponent<AnswerProps> {
   }
 
   render() {
-    const { answer, question } = this.props;
+    const { answer, question, student } = this.props;
     const atype = answer && answer.get("type");
     const qtype = question && question.get("type");
     const scored = question && question.get("scored");
     const questionType = QuestionTypes.find(qt => qt.type === qtype && qt.scored === scored);
     const answerType = getAnswerType(answer, question);
     const iconId = getAnswerIconId(answerType);
-
+    const key = `student-${student ? student.get("id") : "NA"}-question-${question ? question.get("id") : "NA"}`;
     return (
-      <div className={css.answer} data-cy="student-answer">
+      <div className={css.answer} data-cy="student-answer" key={key}>
         {answer && (!question.get("required") || answer.get("submitted"))
           ? this.renderAnswer(atype)
           : this.renderNoAnswer(questionType?.icon, iconId)


### PR DESCRIPTION
This PR adds unique keys to the answer containers in the question overlay.  This should guarantee that when navigating to a new student or question, React will flush the answer node and creates a new component where we can properly initialize the interactive iframe.  This is hard to verify without the new mock data.  However, barring any obvious issues, I suggest that we merge this and then rebase the mock data branch onto master where we can confirm the fix. 