### PR TITLE
Set portal dashboard tab title

### DIFF
--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -72,6 +72,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   componentDidMount() {
     const { fetchAndObserveData } = this.props;
     fetchAndObserveData();
+    document.title = "Class Dashboard";
   }
 
   componentDidUpdate(prevProps: IProps) {


### PR DESCRIPTION
Set the tab title to "Class Dashboard" when the new portal dashboard is launched.