### PR TITLE
Fix handling of scroll state when scrollLeft is 0

### DIFF
--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -204,7 +204,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
 
   private handleScroll = (e: React.UIEvent<HTMLElement>) => {
     const element = e.target as HTMLElement;
-    if (element && element.scrollLeft !== undefined) {
+    if (element && element.scrollLeft != null) {
       this.setState({ scrollLeft: -1 * element.scrollLeft });
     }
   }

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -204,7 +204,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
 
   private handleScroll = (e: React.UIEvent<HTMLElement>) => {
     const element = e.target as HTMLElement;
-    if (element && element.scrollLeft) {
+    if (element && element.scrollLeft !== undefined) {
       this.setState({ scrollLeft: -1 * element.scrollLeft });
     }
   }


### PR DESCRIPTION
This PR fixes a bug in the handling of the scroll state.  When the horizontal scroll offset was 0, we were not saving the state due to a faulty comparison.   Instead explicitly test against undefined so that we save the scroll offset when it is 0.