### PR TITLE
174831493 horizontal scroll improvements

### DIFF
--- a/css/portal-dashboard/header.less
+++ b/css/portal-dashboard/header.less
@@ -7,7 +7,7 @@
   box-sizing: border-box;
   height: @header-height;
   margin-bottom: 3px;
-  padding: 0 20px 0 20px;
+  padding: 0 20px;
   background-color: @cc-teal-light4;
 
   .appInfo {

--- a/css/portal-dashboard/header.less
+++ b/css/portal-dashboard/header.less
@@ -7,6 +7,7 @@
   box-sizing: border-box;
   height: @header-height;
   margin-bottom: 3px;
+  padding: 0 20px 0 20px;
   background-color: @cc-teal-light4;
 
   .appInfo {
@@ -16,7 +17,7 @@
     align-items: center;
     justify-content: flex-start;
     height: @header-height;
-    margin: 0 10px 0 20px;
+    margin: 0 10px 0 0;
   }
 
   .logo {
@@ -38,13 +39,11 @@
 
   .headerCenter {
     display: flex;
+    align-items: center;
+    justify-content: center;
     flex-direction: row;
     flex: 1;
-    justify-content: center;
     margin: 15px 0px 15px 0px;
-    align-items: center;
-    width: 400px;
-    height: 100%;
     font-size: 16px;
 
     .assignmentTitle{
@@ -58,19 +57,18 @@
     align-items: center;
     flex: 1;
     justify-content: flex-end;
-    margin: 0 10px 0 10px;
   }
 
   .icon {
     width: 32px;
     height: 32px;
     object-fit: contain;
+    flex-shrink: 0;
   }
 
   .headerMenu {
     height: 32px;
     width: 32px;
-    padding: 12px;
   }
 
   .menuIcon {

--- a/css/portal-dashboard/level-viewer.less
+++ b/css/portal-dashboard/level-viewer.less
@@ -15,7 +15,7 @@
     height: 44px;
     background-color: white;
     position: absolute;
-    bottom: -46px;
+    bottom: -40px;
   }
 
   .activityButtons {

--- a/css/portal-dashboard/student-answers.less
+++ b/css/portal-dashboard/student-answers.less
@@ -1,15 +1,10 @@
 @import "./variables";
 
 .studentAnswers {
-  display: inline-block;
-  width: 100%;
   background-color: white;
   width: calc(100% - @left-panel-width);
   white-space: nowrap;
-  overflow-x: auto;
-  overflow-y: auto;
   height: fit-content;
-  z-index: 1;
 
   .studentAnswersRow {
     display: flex;
@@ -22,6 +17,7 @@
     border-style: solid;
     border-width: 0 0 1px 0;
     border-color: @cc-charcoal-light2;
+    background-color: white;
     padding: 0 0 0 10px;
 
     &.compact {

--- a/css/portal-dashboard/student-names.less
+++ b/css/portal-dashboard/student-names.less
@@ -3,6 +3,8 @@
 .studentList {
   display: inline-block;
   width: 240px;
+  position: sticky;
+  left: 0;
 
   .studentName {
     display: flex;

--- a/cypress/integration/portal-dashboard/portal-dashboard-scrolling.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-scrolling.spec.js
@@ -8,7 +8,7 @@ context("Portal Dashboard Content Scrolling",() =>{
     cy.get('[data-cy=collapsed-activity-button]').first().click();
     cy.wait(1000);
 
-    cy.get('[data-cy=student-answers]').scrollTo('right');
+    cy.get('[data-cy=progress-table]').scrollTo('right');
 
     cy.get('[data-cy=collapsed-activity-button]').first().should('be.visible');
     cy.get('[data-cy=collapsed-activity-button]').first().should("contain", "2 Report Test Activity 2");

--- a/js/components/portal-dashboard/student-answers.tsx
+++ b/js/components/portal-dashboard/student-answers.tsx
@@ -20,14 +20,12 @@ interface IProps {
 }
 
 export class StudentAnswers extends React.PureComponent<IProps> {
-  private studentAnswersRef: HTMLElement | null;
-
   render() {
     const { students, activities, currentActivity, isCompact } = this.props;
     const activitiesList = activities.toList().filter((activity: any) => activity.get("visible"));
     const compactClass = isCompact ? css.compact : "";
     return (
-      <div className={css.studentAnswers} ref={elt => this.studentAnswersRef = elt} data-cy="student-answers" >
+      <div className={css.studentAnswers} data-cy="student-answers" >
       {
         students.map((s: any) => {
           return (
@@ -47,10 +45,6 @@ export class StudentAnswers extends React.PureComponent<IProps> {
       }
       </div>
     );
-  }
-
-  public getStudentAnswersRef = () => {
-    return this.studentAnswersRef;
   }
 
   private renderExpandedActivity = (activity: any, student: any) => {

--- a/js/components/portal-dashboard/student-answers.tsx
+++ b/js/components/portal-dashboard/student-answers.tsx
@@ -25,7 +25,7 @@ export class StudentAnswers extends React.PureComponent<IProps> {
     const activitiesList = activities.toList().filter((activity: any) => activity.get("visible"));
     const compactClass = isCompact ? css.compact : "";
     return (
-      <div className={css.studentAnswers} data-cy="student-answers" >
+      <div className={css.studentAnswers} data-cy="student-answers">
       {
         students.map((s: any) => {
           return (

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import { connect } from "react-redux";
 import { fetchAndObserveData, trackEvent, setAnonymous } from "../../actions/index";
 import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getCurrentStudentId,
-        getStudentProgress, getCompactReport, getAnonymous } from "../../selectors/dashboard-selectors";
+         getStudentProgress, getCompactReport, getAnonymous } from "../../selectors/dashboard-selectors";
 import { Header } from "../../components/portal-dashboard/header";
 import { ClassNav } from "../../components/portal-dashboard/class-nav";
 import { LevelViewer } from "../../components/portal-dashboard/level-viewer";
@@ -61,7 +61,6 @@ interface IState {
 }
 
 class PortalDashboardApp extends React.PureComponent<IProps, IState> {
-  private responseTableRef: HTMLElement | null;
   constructor(props: IProps) {
     super(props);
     this.state = {
@@ -82,10 +81,6 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
     const { isFetching } = this.props;
     if (initialLoading && !isFetching && prevProps.isFetching) {
       this.setState({ initialLoading: false });
-    }
-
-    if (this.responseTableRef && this.responseTableRef.scrollLeft * -1 !== this.state.scrollLeft) {
-      this.setState({ scrollLeft: this.responseTableRef.scrollLeft * -1 });
     }
   }
 
@@ -137,7 +132,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 toggleCurrentQuestion={toggleCurrentQuestion}
               />
             </div>
-            <div className={css.progressTable} onScroll={this.handleScroll} ref={elt => this.responseTableRef = elt} data-cy="progress-table">
+            <div className={css.progressTable} onScroll={this.handleScroll} data-cy="progress-table">
               <StudentNames
                 students={students}
                 isAnonymous={isAnonymous}

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -197,7 +197,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
 
   private handleScroll = (e: React.UIEvent<HTMLElement>) => {
     const element = e.target as HTMLElement;
-    if (element && element.scrollLeft !== null) {
+    if (element && element.scrollLeft != null) {
       this.setState({ scrollLeft: -1 * element.scrollLeft });
     }
   }

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -137,7 +137,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 toggleCurrentQuestion={toggleCurrentQuestion}
               />
             </div>
-            <div className={css.progressTable} onScroll={this.handleScroll} ref={elt => this.responseTableRef = elt}>
+            <div className={css.progressTable} onScroll={this.handleScroll} ref={elt => this.responseTableRef = elt} data-cy="progress-table">
               <StudentNames
                 students={students}
                 isAnonymous={isAnonymous}

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -61,7 +61,7 @@ interface IState {
 }
 
 class PortalDashboardApp extends React.PureComponent<IProps, IState> {
-  private studentAnswersComponentRef: StudentAnswers | null;
+  private responseTableRef: HTMLElement | null;
   constructor(props: IProps) {
     super(props);
     this.state = {
@@ -84,9 +84,8 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
       this.setState({ initialLoading: false });
     }
 
-    const studentAnswersRef = this.studentAnswersComponentRef?.getStudentAnswersRef();
-    if (studentAnswersRef && this.state.scrollLeft !== studentAnswersRef.scrollLeft * -1) {
-      this.setState({ scrollLeft: studentAnswersRef.scrollLeft * -1 });
+    if (this.responseTableRef && this.responseTableRef.scrollLeft * -1 !== this.state.scrollLeft) {
+      this.setState({ scrollLeft: this.responseTableRef.scrollLeft * -1 });
     }
   }
 
@@ -138,7 +137,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 toggleCurrentQuestion={toggleCurrentQuestion}
               />
             </div>
-            <div className={css.progressTable} onScroll={this.handleScroll}>
+            <div className={css.progressTable} onScroll={this.handleScroll} ref={elt => this.responseTableRef = elt}>
               <StudentNames
                 students={students}
                 isAnonymous={isAnonymous}
@@ -153,7 +152,6 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 expandedActivities={expandedActivities}
                 students={students}
                 studentProgress={studentProgress}
-                ref={elt => this.studentAnswersComponentRef = elt}
                 isCompact={compactReport}
                 setCurrentActivity={setCurrentActivity}
                 setCurrentQuestion={setCurrentQuestion}
@@ -204,7 +202,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
 
   private handleScroll = (e: React.UIEvent<HTMLElement>) => {
     const element = e.target as HTMLElement;
-    if (element && element.scrollLeft) {
+    if (element && element.scrollLeft !== null) {
       this.setState({ scrollLeft: -1 * element.scrollLeft });
     }
   }


### PR DESCRIPTION
This PR makes changes to the display of the horizontal scroll bar for the response table when the app is at a short width.  The primary change being ensuring that the scrollbar is always visible when the content overflows (previously could be hidden if the vertical scrollbar was also present and the user was scrolled to the top of the container).  Changes include:
- Always show the horizontal scrollbar when it is needed
- Improve responsiveness of app header by adjusting the flex layout - this allows the header to behave better when the app width is small
- Improve the display of the vertical scrollbar and top border of first student row (move cover so we do not occlude these controls)
