### PR TITLE
Fix arrow button states

### DIFF
--- a/css/portal-dashboard/question-navigator.less
+++ b/css/portal-dashboard/question-navigator.less
@@ -64,21 +64,36 @@
     color: @cc-charcoal;
   }
 
-  .arrow {
-    height: 24px;
-    width: 24px;
-    margin: 0 20px 0 5px;
-    fill: @cc-teal;
-    transition-property: transform;
-    transition-duration: .25s;
-
-    &.hideQuestion {
-      fill: white;
-      transform: rotate(180deg);
-    }
-  }
-
   .showHideButton {
+    height: 32px;
+    width: 32px;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 20px 0 0;
     cursor: pointer;
+    &:hover {
+      background-color: @cc-teal-light3;
+    }
+    &:active {
+      background-color: @cc-teal;
+      .arrow {
+        fill: white;
+      }
+    }
+    .arrow {
+      height: 24px;
+      width: 24px;
+      fill: @cc-teal;
+      transform: rotate(180deg);
+      transition-property: transform;
+      transition-duration: .25s;
+
+      &.hideQuestion {
+        transform: rotate(0deg);
+      }
+    }
+
   }
 }

--- a/js/components/portal-dashboard/question-navigator.tsx
+++ b/js/components/portal-dashboard/question-navigator.tsx
@@ -28,8 +28,6 @@ export class QuestionNavigator extends React.PureComponent<IProps, IState> {
   }
   render() {
     const { currentQuestion, inOverlay } = this.props;
-    const chevronClass = this.state.hideQuestion ? `${css.arrow}  ${css.hideQuestion}` : `${css.arrow}`;
-
     return (
       <React.Fragment>
         <div className={css.titleWrapper}>
@@ -46,7 +44,7 @@ export class QuestionNavigator extends React.PureComponent<IProps, IState> {
           <div className={css.title} data-cy="question-overlay-title">
             Question #{currentQuestion ? currentQuestion.get("questionNumber") : ""}
           </div>
-          {inOverlay && this.renderChevron(chevronClass)}
+          {inOverlay && this.renderChevron()}
         </div>
         <QuestionArea currentQuestion={currentQuestion} hideQuestion={this.state.hideQuestion} useMinHeight={inOverlay} />
       </React.Fragment>
@@ -67,26 +65,20 @@ export class QuestionNavigator extends React.PureComponent<IProps, IState> {
     const { sortedQuestionIds, currentQuestion } = this.props;
     if (!sortedQuestionIds || !currentQuestion) return false;
     const idx = sortedQuestionIds.indexOf(currentQuestion.get("id"));
-    if (idx > 0) {
-      return sortedQuestionIds[idx - 1];
-    }
-    return false;
+    return idx > 0 ? sortedQuestionIds[idx - 1] : false;
   }
 
   private get nextQuestion() {
     const { sortedQuestionIds, currentQuestion } = this.props;
     if (!sortedQuestionIds || !currentQuestion) return false;
     const idx = sortedQuestionIds.indexOf(currentQuestion.get("id"));
-    if (idx < sortedQuestionIds.length - 1) {
-      return sortedQuestionIds[idx + 1];
-    }
-    return false;
+    return idx < sortedQuestionIds.length - 1 ? sortedQuestionIds[idx + 1] : false;
   }
 
-  private renderChevron = (cssClass: string) => {
+  private renderChevron = () => {
     return (
       <div className={css.showHideButton} onClick={this.handleChevronClick} data-cy="show-hide-question-button">
-        <ArrowIcon className={cssClass} />
+        <ArrowIcon className={`${css.arrow} ${this.state.hideQuestion ? css.hideQuestion : ""}`} />
       </div>
     );
   }


### PR DESCRIPTION
This PR fixes the UI of the show//hide question arrow button in the question overlay so that it matches the UI spec.  Changes include:
- proper arrow orientation.  Arrow points up when question is shown, points down when question is hidden
- arrow has correct color when question is hidden
- arrow has hover states defined in UI spec

See spec for more details:
https://app.zeplin.io/project/5e96f4b8527afa7d28bb1468/screen/5ed4f976e9fe2773c0bd3a33

![image](https://user-images.githubusercontent.com/5126913/93506801-9e8b3d00-f8d1-11ea-8450-df782d742b6b.png)
