### PR TITLE
174870014 animate student popup v2

### DIFF
--- a/css/portal-dashboard/all-responses-popup/student-responses-popup.less
+++ b/css/portal-dashboard/all-responses-popup/student-responses-popup.less
@@ -2,8 +2,7 @@
 
 .popup {
   position: fixed;
-  bottom: 0;
-  right: 0;
+  top: 0;
   padding: 0;
   box-sizing: border-box;
   box-shadow: -1px 1px 4px 0px rgba(0, 0, 0, 0.35);
@@ -15,7 +14,7 @@
   z-index: 1;
 
   &.hidden {
-    right: 100%;
+    top: 100%;
   }
 
   .tableHeader {

--- a/css/portal-dashboard/all-responses-popup/student-responses-popup.less
+++ b/css/portal-dashboard/all-responses-popup/student-responses-popup.less
@@ -3,6 +3,7 @@
 .popup {
   position: fixed;
   bottom: 0;
+  right: 0;
   padding: 0;
   box-sizing: border-box;
   box-shadow: -1px 1px 4px 0px rgba(0, 0, 0, 0.35);
@@ -12,6 +13,10 @@
   height: 100%;
   font-weight: bold;
   z-index: 1;
+
+  &.hidden {
+    right: 100%;
+  }
 
   .tableHeader {
     display: flex;

--- a/cypress/integration/portal-dashboard/portal-dashboard-anonymize.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-anonymize.spec.js
@@ -13,7 +13,7 @@ context("Portal Dashboard Anonymous Mode",() =>{
     });
 
     it('verify we enter anonymous mode',()=>{
-      cy.get('[data-cy=anonymize-students]').within(() => {
+      cy.get('[data-cy=anonymize-students]').eq(0).within(() => {
         cy.get('[data-cy=toggle-control]').click();
       });
       cy.get('[data-cy=student-name]')
@@ -23,7 +23,7 @@ context("Portal Dashboard Anonymous Mode",() =>{
     });
 
     it('verify we return to normal mode',()=>{
-      cy.get('[data-cy=anonymize-students]').within(() => {
+      cy.get('[data-cy=anonymize-students]').eq(0).within(() => {
         cy.get('[data-cy=toggle-control]').click();
       });
       cy.get('[data-cy=student-name]').eq(0).should("contain", "Armstrong, Jenna");

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -30,21 +30,21 @@ context("Portal Dashboard Question Details Panel", () => {
       // cy.get('[data-cy=collapsed-activity-button]').first().click();
       cy.get('[data-cy=activity-question-button]').first().click();
       cy.get('[data-cy=question-navigator-previous-button]').should('be.visible');
-      cy.get('[data-cy=question-navigator-next-button]').should('be.visible');
+      cy.get('[data-cy=question-navigator-next-button]').eq(0).should('be.visible');
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
-      cy.get('[data-cy=question-navigator-previous-button]').click();
+      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
     });
 
     it('verify we can page to the second question', () => {
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
-      cy.get('[data-cy=question-navigator-next-button]').click();
+      cy.get('[data-cy=question-navigator-next-button]').eq(0).click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #2");
     });
 
     it('verify we can page back to the first question', () => {
       cy.get('[data-cy=question-overlay]').should("contain", "Question #2");
-      cy.get('[data-cy=question-navigator-previous-button]').click();
+      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
     });
 
@@ -52,7 +52,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 1: Report Test Activity 1");
       cy.get('[data-cy=activity-question-button]').eq(6).click({ force: true });
       cy.get('[data-cy=question-overlay]').should("contain", "Question #7");
-      cy.get('[data-cy=question-navigator-next-button]').click();
+      cy.get('[data-cy=question-navigator-next-button]').eq(0).click();
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
     });
@@ -61,7 +61,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=activity-question-button]').eq(7).click({ force: true });
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #8");
-      cy.get('[data-cy=question-navigator-next-button]').click();
+      cy.get('[data-cy=question-navigator-next-button]').eq(0).click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #8");
     });
 
@@ -69,7 +69,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=activity-question-button]').eq(0).click({ force: true });
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
-      cy.get('[data-cy=question-navigator-previous-button]').click();
+      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click();
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 1: Report Test Activity 1");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #7");
     });
@@ -81,7 +81,7 @@ context("Portal Dashboard Question Details Panel", () => {
   });
   describe('Question area', () => {
     before(() => {
-      cy.get('[data-cy=question-navigator-previous-button]').click().click().click();
+      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click().click().click();
     });
     it('verify question area is visible', () => {
       cy.get('[data-cy=question-overlay] [data-cy=question-title]').should('be.visible');
@@ -137,9 +137,9 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=overlay-student-name]').should('contain','Wu, Jerome');
     });
     it('verify student name is anonymize when toggle is on and vice versa',()=>{
-      cy.get('[data-cy="anonymize-students"] [data-cy=toggle-control]').click();
+      cy.get('[data-cy="anonymize-students"] [data-cy=toggle-control]').eq(0).click();
       cy.get('[data-cy=overlay-student-name]').should('contain','Student 6');
-      cy.get('[data-cy="anonymize-students"] [data-cy=toggle-control]').click();
+      cy.get('[data-cy="anonymize-students"] [data-cy=toggle-control]').eq(0).click();
       cy.get('[data-cy=overlay-student-name]').should('contain','Wu, Jerome');
     });
     it('verify multiple choice choice texts are visible',()=>{
@@ -151,7 +151,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy="answer-image"]').should('be.visible');
     });
     it('verify image lightbox of image answer', ()=>{
-      cy.get('[data-cy="magnify-answer"]').should('be.visible').click();
+      cy.get('[data-cy="magnify-answer"]').should('be.visible').eq(0).click();
       cy.get('[data-cy="answer-lightbox"]').should('be.visible');
       cy.get('[data-cy="modal-header"]').should('contain', "Wu, Jerome");
       cy.get('[data-cy="answer-lightbox"] [data-cy="answer-image"]').should('be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -30,21 +30,21 @@ context("Portal Dashboard Question Details Panel", () => {
       // cy.get('[data-cy=collapsed-activity-button]').first().click();
       cy.get('[data-cy=activity-question-button]').first().click();
       cy.get('[data-cy=question-navigator-previous-button]').should('be.visible');
-      cy.get('[data-cy=question-navigator-next-button]').eq(0).should('be.visible');
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-next-button]').should('be.visible');
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
-      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click();
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-previous-button]').click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
     });
 
     it('verify we can page to the second question', () => {
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
-      cy.get('[data-cy=question-navigator-next-button]').eq(0).click();
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-next-button]').click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #2");
     });
 
     it('verify we can page back to the first question', () => {
       cy.get('[data-cy=question-overlay]').should("contain", "Question #2");
-      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click();
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-previous-button]').click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
     });
 
@@ -52,7 +52,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 1: Report Test Activity 1");
       cy.get('[data-cy=activity-question-button]').eq(6).click({ force: true });
       cy.get('[data-cy=question-overlay]').should("contain", "Question #7");
-      cy.get('[data-cy=question-navigator-next-button]').eq(0).click();
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-next-button]').click();
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
     });
@@ -61,7 +61,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=activity-question-button]').eq(7).click({ force: true });
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #8");
-      cy.get('[data-cy=question-navigator-next-button]').eq(0).click();
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-next-button]').click();
       cy.get('[data-cy=question-overlay]').should("contain", "Question #8");
     });
 
@@ -69,7 +69,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=activity-question-button]').eq(0).click({ force: true });
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");
-      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click();
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-previous-button]').click();
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 1: Report Test Activity 1");
       cy.get('[data-cy=question-overlay]').should("contain", "Question #7");
     });
@@ -81,7 +81,7 @@ context("Portal Dashboard Question Details Panel", () => {
   });
   describe('Question area', () => {
     before(() => {
-      cy.get('[data-cy=question-navigator-previous-button]').eq(0).click().click().click();
+      cy.get('[data-cy="question-overlay"] [data-cy=question-navigator-previous-button]').click().click().click();
     });
     it('verify question area is visible', () => {
       cy.get('[data-cy=question-overlay] [data-cy=question-title]').should('be.visible');
@@ -151,7 +151,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy="answer-image"]').should('be.visible');
     });
     it('verify image lightbox of image answer', ()=>{
-      cy.get('[data-cy="magnify-answer"]').should('be.visible').eq(0).click();
+      cy.get('[data-cy="question-overlay"] [data-cy="magnify-answer"]').should('be.visible').click();
       cy.get('[data-cy="answer-lightbox"]').should('be.visible');
       cy.get('[data-cy="modal-header"]').should('contain', "Wu, Jerome");
       cy.get('[data-cy="answer-lightbox"] [data-cy="answer-image"]').should('be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
@@ -13,7 +13,7 @@ context("Portal Dashboard Student Sort",() =>{
     });
 
     it('verify we sort by most progress',()=>{
-      cy.get('[data-cy=sort-students]').click();
+      cy.get('[data-cy=sort-students]').eq(0).click();
       cy.get('[data-cy="list-item-most-progress"]').should('be.visible').click();
       cy.get('[data-cy=student-name]').eq(0).should("contain", "Jenkins, John");
       cy.get('[data-cy=student-name]').eq(1).should("contain", "Wu, Jerome");
@@ -24,7 +24,7 @@ context("Portal Dashboard Student Sort",() =>{
     });
 
     it('verify we sort by least progress',()=>{
-      cy.get('[data-cy=sort-students]').click();
+      cy.get('[data-cy=sort-students]').eq(0).click();
       cy.get('[data-cy="list-item-least-progress"]').should('be.visible').click();
       cy.get('[data-cy=student-name]').eq(0).should("contain", "Crosby, Kate");
       cy.get('[data-cy=student-name]').eq(1).should("contain", "Galloway, Amy");

--- a/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
@@ -12,6 +12,7 @@ interface IProps {
   currentQuestion?: Map<string, any>;
   handleCloseAllResponsesPopup: (show: boolean) => void;
   isAnonymous: boolean;
+  isHidden?: boolean;
   questions?: Map<string, any>;
   setAnonymous: (value: boolean) => void;
   setCurrentActivity: (activityId: string) => void;
@@ -24,19 +25,20 @@ interface IProps {
 }
 export class StudentResponsePopup extends React.PureComponent<IProps> {
   render() {
-    const { anonymous, students, isAnonymous, studentCount, setAnonymous, setStudentFilter, trackEvent,
-      currentQuestion, questions, sortedQuestionIds, toggleCurrentQuestion, setCurrentActivity } = this.props;
+    const { anonymous, currentQuestion, isAnonymous, isHidden, questions, setCurrentActivity, setAnonymous,
+            setStudentFilter, sortedQuestionIds, studentCount, students, toggleCurrentQuestion, trackEvent } = this.props;
     return (
-      <div className={css.popup} data-cy="all-responses-popup-view">
+      <div className={`${css.popup} ${isHidden ? css.hidden : ""}`} data-cy="all-responses-popup-view">
         <PopupHeader handleCloseAllResponsesPopup={this.props.handleCloseAllResponsesPopup} />
         <div className={css.tableHeader}>
-          <PopupClassNav
-            anonymous={anonymous}
-            studentCount={studentCount}
-            setAnonymous={setAnonymous}
-            setStudentFilter={setStudentFilter}
-            trackEvent={trackEvent} />
-          <div className={css.questionArea} data-cy="questionArea">
+        <PopupClassNav
+          anonymous={anonymous}
+          studentCount={studentCount}
+          setAnonymous={setAnonymous}
+          setStudentFilter={setStudentFilter}
+          trackEvent={trackEvent} />
+        <div className={css.questionArea} data-cy="questionArea">
+          { currentQuestion &&
             <QuestionNavigator
               currentQuestion={currentQuestion}
               questions={questions}
@@ -44,13 +46,16 @@ export class StudentResponsePopup extends React.PureComponent<IProps> {
               toggleCurrentQuestion={toggleCurrentQuestion}
               setCurrentActivity={setCurrentActivity}
             />
-          </div>
+          }
         </div>
-        <PopupStudentResponseList
-          students={students}
-          isAnonymous={isAnonymous}
-          currentQuestion={currentQuestion}
-        />
+        </div>
+        { currentQuestion &&
+          <PopupStudentResponseList
+            students={students}
+            isAnonymous={isAnonymous}
+            currentQuestion={currentQuestion}
+          />
+        }
       </div>
     );
   }

--- a/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
@@ -31,23 +31,23 @@ export class StudentResponsePopup extends React.PureComponent<IProps> {
       <div className={`${css.popup} ${isHidden ? css.hidden : ""}`} data-cy="all-responses-popup-view">
         <PopupHeader handleCloseAllResponsesPopup={this.props.handleCloseAllResponsesPopup} />
         <div className={css.tableHeader}>
-        <PopupClassNav
-          anonymous={anonymous}
-          studentCount={studentCount}
-          setAnonymous={setAnonymous}
-          setStudentFilter={setStudentFilter}
-          trackEvent={trackEvent} />
-        <div className={css.questionArea} data-cy="questionArea">
-          { currentQuestion &&
-            <QuestionNavigator
-              currentQuestion={currentQuestion}
-              questions={questions}
-              sortedQuestionIds={sortedQuestionIds}
-              toggleCurrentQuestion={toggleCurrentQuestion}
-              setCurrentActivity={setCurrentActivity}
-            />
-          }
-        </div>
+          <PopupClassNav
+            anonymous={anonymous}
+            studentCount={studentCount}
+            setAnonymous={setAnonymous}
+            setStudentFilter={setStudentFilter}
+            trackEvent={trackEvent} />
+          <div className={css.questionArea} data-cy="questionArea">
+            { currentQuestion &&
+              <QuestionNavigator
+                currentQuestion={currentQuestion}
+                questions={questions}
+                sortedQuestionIds={sortedQuestionIds}
+                toggleCurrentQuestion={toggleCurrentQuestion}
+                setCurrentActivity={setCurrentActivity}
+              />
+            }
+          </div>
         </div>
         { currentQuestion &&
           <PopupStudentResponseList

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -165,23 +165,22 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
               students={students}
               toggleCurrentQuestion={toggleCurrentQuestion}
             />
-            {showAllResponsesPopup &&
-              <StudentResponsePopup
-                anonymous={anonymous}
-                students={students}
-                isAnonymous={isAnonymous}
-                setAnonymous={setAnonymous}
-                studentCount={students.size}
-                setStudentFilter={setStudentSort}
-                currentQuestion={currentQuestion}
-                questions={questions}
-                sortedQuestionIds={sortedQuestionIds}
-                toggleCurrentQuestion={toggleCurrentQuestion}
-                setCurrentActivity={setCurrentActivity}
-                trackEvent={trackEvent}
-                handleCloseAllResponsesPopup={this.setShowAllResponsesPopup}
-              />
-            }
+            <StudentResponsePopup
+              anonymous={anonymous}
+              currentQuestion={currentQuestion}
+              handleCloseAllResponsesPopup={this.setShowAllResponsesPopup}
+              isAnonymous={isAnonymous}
+              isHidden={!showAllResponsesPopup}
+              questions={questions}
+              setAnonymous={setAnonymous}
+              setCurrentActivity={setCurrentActivity}
+              setStudentFilter={setStudentSort}
+              sortedQuestionIds={sortedQuestionIds}
+              studentCount={students.size}
+              students={students}
+              toggleCurrentQuestion={toggleCurrentQuestion}
+              trackEvent={trackEvent}
+            />
           </div>
         }
         {error && <DataFetchError error={error} />}


### PR DESCRIPTION
This PR adds a slide in animation to the `StudentResponsePopup` component.  

Note that in doing so, I needed to adjust several Cypress tests that previously assumed that there was a single instance of a component.  Several components (like the anonymize toggle) are children of the `StudentResponsePopup` component and hence now have an additional instance because the `StudentResponsePopup` is ALWAYS rendered offscreen in preparation for the animation (previously it was conditionally rendered).  This PR also required additional handling of undefined component props which can cause exceptions (again caused by the `StudentResponsePopup` now being rendered when the app loads and before a user has had a chance to select a student, a question, etc.).

I also put together an alternate animation approach here using `react-transition-group`:
https://github.com/concord-consortium/portal-report/compare/174870014-animate-student-popup
This approach does NOT require the component to be rendered until we actually need it (and hence doesn't require Cypress test changes or adding extra handling of undefined props values).  However, I was not entirely satisfied with this approach.  To use  `react-transition-group` we need to have a statically named CSS base class and several statically named transition classes that are used used during the animation stages.  The base class name is passed to the `CSSTransition` component.  However, this does not work with our CSS modules styling approach where class names in the `.less` files are renamed by Webpack.  To get around this, I simply imported the class names that I needed in a simple CSS module so they wouldn't be mutated by Webpack.  I wasn't happy with this approach though.  I think it's confusing and potentially difficult to manage the CSS when it is split between `.less` and `.css` files.

All of that to say... I think it's worth looking at the two implementations.  
- The approach on this branch and in this PR has the advantage of placing all of the CSS in a single module and letting the Webpack import of the `.less` files work its magic without complaint.  However, as explained above, it also requires rendering the component at ALL times which forces us to add complexity to our Cypress tests and and requires us to build in extra logic around various props that previously were never undefined but now can be because the component is being rendered at points where certain values haven't yet been defined based on user navigation.
- The alternate `react-transition-group` approach has the advantage of only rendering the component when needed and not causing headaches with the Cypress tests or requiring extra error checking.  However, it splits the CSS import into multiple modules which can be confusing, is less unified, and might cause issues long term if we need to work on the CSS for this component.  Again, the `react-transition-group` approach is found here: 
https://github.com/concord-consortium/portal-report/tree/174870014-animate-student-popup

Anyway, I at least wanted someone else to look at these two approaches.  Maybe one is obviously better than the other, and I'm just not seeing it?

![animate](https://user-images.githubusercontent.com/5126913/93659443-f2914100-f9f9-11ea-902d-28bd73aa8c5e.gif)
