### PR TITLE
Improve handling of spotlight dialogs

### DIFF
--- a/css/portal-dashboard/all-responses-popup/popup-class-nav.less
+++ b/css/portal-dashboard/all-responses-popup/popup-class-nav.less
@@ -110,6 +110,12 @@
         }
         &.spotlightOn {
           background-color: @hi-yellow-light3;
+          &:hover {
+            background-color: @hi-yellow-light1;
+          }
+          &:active {
+            background-color: @cc-teal;
+          }
         }
 
         .spotlightIcon {

--- a/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
@@ -14,7 +14,7 @@ import cssClassNav from "../../../../css/portal-dashboard/class-nav.less";
 interface IProps {
   anonymous: boolean;
   isSpotlightOn: boolean;
-  onShowDialog: () => void;
+  onShowDialog: (show: boolean) => void;
   setAnonymous: (value: boolean) => void;
   setStudentFilter: (value: string) => void;
   studentCount: number;
@@ -86,7 +86,7 @@ export class PopupClassNav extends React.PureComponent<IProps, IState>{
   private renderSpotlightToggle() {
     const spotLightContainerClasses = `${css.spotlightContainer} ${this.props.isSpotlightOn ? css.spotlightOn : ""}`;
     return (
-      <div className={css.spotlightToggle} onClick={this.props.onShowDialog} data-cy="spotlight-toggle">
+      <div className={css.spotlightToggle} onClick={() => this.props.onShowDialog(true)} data-cy="spotlight-toggle">
         <div className={spotLightContainerClasses}>
           <SpotlightIcon className={css.spotlightIcon} />
         </div>

--- a/js/components/portal-dashboard/all-responses-popup/spotlight-message-dialog.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/spotlight-message-dialog.tsx
@@ -4,7 +4,7 @@ import SpotlightIcon from "../../../../img/svg-icons/spotlight-icon.svg";
 import css from "../../../../css/portal-dashboard/all-responses-popup/spotlight-message-dialog.less";
 
 interface IProps {
-  onCloseDialog: () => void;
+  onCloseDialog: (show: boolean) => void;
 }
 export class SpotlightMessageDialog extends React.PureComponent<IProps>{
   render() {
@@ -25,7 +25,7 @@ export class SpotlightMessageDialog extends React.PureComponent<IProps>{
           <div className={css.dialogText}>
             Use this feature to highlight and share student work in your classroom.
           </div>
-          <div className={css.dismissDialogButton} onClick={this.props.onCloseDialog} data-cy="spotlight-dialog-close-button">
+          <div className={css.dismissDialogButton} onClick={() => this.props.onCloseDialog(false)} data-cy="spotlight-dialog-close-button">
             Got it
           </div>
         </div>

--- a/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
@@ -16,7 +16,7 @@ interface IProps {
   currentActivity?: Map<string, any>;
   currentQuestion?: Map<string, any>;
   isAnonymous: boolean;
-  onCloseDialog: () => void;
+  onCloseDialog: (show: boolean) => void;
   onStudentSelect: (student: Map<any, any>) => void;
   selectedStudents: Map<any, any>[];
   setAnonymous: (value: boolean) => void;
@@ -47,7 +47,7 @@ export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
           </div>
         </div>
         <div className={css.headerRight}>
-          <div className={css.closeIcon} data-cy="close-popup-button" onClick={onCloseDialog}>
+          <div className={css.closeIcon} data-cy="close-popup-button" onClick={() => onCloseDialog(false)}>
             <SmallCloseIcon className={css.closeIconSVG} />
           </div>
         </div>

--- a/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
@@ -56,7 +56,7 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
             setAnonymous={setAnonymous}
             setStudentFilter={setStudentFilter}
             trackEvent={trackEvent}
-            onShowDialog={selectedStudents.length > 0 ? this.setShowSpotlightListDialog(true) : this.setShowSpotlightDialog(true)}
+            onShowDialog={selectedStudents.length > 0 ? this.setShowSpotlightListDialog : this.setShowSpotlightDialog}
           />
           <div className={`${css.questionArea} ${css.column}`} data-cy="questionArea">
             <QuestionNavigator
@@ -83,7 +83,7 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
             currentActivity={currentActivity}
             currentQuestion={currentQuestion}
             isAnonymous={isAnonymous}
-            onCloseDialog={this.setShowSpotlightListDialog(false)}
+            onCloseDialog={this.setShowSpotlightListDialog}
             onStudentSelect={this.toggleSelectedStudent}
             selectedStudents={selectedStudents}
             setAnonymous={setAnonymous}
@@ -91,17 +91,17 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
         }
         { showSpotlightDialog &&
           <SpotlightMessageDialog
-            onCloseDialog={this.setShowSpotlightDialog(false)}
+            onCloseDialog={this.setShowSpotlightDialog}
           />
         }
       </div>
     );
   }
 
-  private setShowSpotlightListDialog = (show: boolean) => () => {
+  private setShowSpotlightListDialog = (show: boolean) => {
     this.setState({ showSpotlightListDialog: show });
   }
-  private setShowSpotlightDialog = (show: boolean) => () => {
+  private setShowSpotlightDialog = (show: boolean) => {
     this.setState({ showSpotlightDialog: show });
   }
 

--- a/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
@@ -29,32 +29,34 @@ interface IProps {
 interface IState {
   selectedStudents: Map<any, any>[];
   showSpotlightDialog: boolean;
+  showSpotlightListDialog: boolean;
 }
 export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
       selectedStudents: [],
-      showSpotlightDialog: false
+      showSpotlightDialog: false,
+      showSpotlightListDialog: false
     };
   }
   render() {
     const { anonymous, currentActivity, currentQuestion, hasTeacherEdition, isAnonymous, onClose, questions,
             setAnonymous, setCurrentActivity, setStudentFilter, sortedQuestionIds, studentCount, students,
             toggleCurrentQuestion, trackEvent } = this.props;
-    const { selectedStudents, showSpotlightDialog } = this.state;
+    const { selectedStudents, showSpotlightDialog, showSpotlightListDialog } = this.state;
     return (
       <div className={css.popup} data-cy="all-responses-popup-view">
         <PopupHeader currentActivity={currentActivity} onCloseSelect={onClose} />
         <div className={css.tableHeader}>
           <PopupClassNav
             anonymous={anonymous}
-            isSpotlightOn={showSpotlightDialog && selectedStudents.length > 0}
+            isSpotlightOn={selectedStudents.length > 0}
             studentCount={studentCount}
             setAnonymous={setAnonymous}
             setStudentFilter={setStudentFilter}
             trackEvent={trackEvent}
-            onShowDialog={this.showSpotlightDialog(true)}
+            onShowDialog={selectedStudents.length > 0 ? this.setShowSpotlightListDialog(true) : this.setShowSpotlightDialog(true)}
           />
           <div className={`${css.questionArea} ${css.column}`} data-cy="questionArea">
             <QuestionNavigator
@@ -75,26 +77,31 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
           selectedStudents={selectedStudents}
           students={students}
         />
-        { showSpotlightDialog && (selectedStudents.length > 0
-          ? <SpotlightStudentListDialog
-              anonymous={anonymous}
-              currentActivity={currentActivity}
-              currentQuestion={currentQuestion}
-              isAnonymous={isAnonymous}
-              onCloseDialog={this.showSpotlightDialog(false)}
-              onStudentSelect={this.toggleSelectedStudent}
-              selectedStudents={selectedStudents}
-              setAnonymous={setAnonymous}
-            />
-          : <SpotlightMessageDialog
-              onCloseDialog={this.showSpotlightDialog(false)}
-            />)
+        { showSpotlightListDialog &&
+          <SpotlightStudentListDialog
+            anonymous={anonymous}
+            currentActivity={currentActivity}
+            currentQuestion={currentQuestion}
+            isAnonymous={isAnonymous}
+            onCloseDialog={this.setShowSpotlightListDialog(false)}
+            onStudentSelect={this.toggleSelectedStudent}
+            selectedStudents={selectedStudents}
+            setAnonymous={setAnonymous}
+          />
+        }
+        { showSpotlightDialog &&
+          <SpotlightMessageDialog
+            onCloseDialog={this.setShowSpotlightDialog(false)}
+          />
         }
       </div>
     );
   }
 
-  private showSpotlightDialog = (show: boolean) => () => {
+  private setShowSpotlightListDialog = (show: boolean) => () => {
+    this.setState({ showSpotlightListDialog: show });
+  }
+  private setShowSpotlightDialog = (show: boolean) => () => {
     this.setState({ showSpotlightDialog: show });
   }
 


### PR DESCRIPTION
Adds more sophisticated state management of the spotlight dialog.  We previously assumed that if the number of selected students was 0, that we could always show the spotlight message dialog.  This is incorrect, a user can remove all of the selected students inside the spotlight list dialog itself which then keeps the spotlight list dialog up but with no student showing.  I wasn't eager to introduce another state variable, but I think this is the most straightforward way to handle this other than merging the dialogs into a single component.