### PR TITLE
Update stored spotlight state to use student ids and not student map

### DIFF
--- a/js/components/portal-dashboard/all-responses-popup/popup-student-response-list.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-student-response-list.tsx
@@ -8,22 +8,22 @@ import css from "../../../../css/portal-dashboard/all-responses-popup/popup-stud
 interface IProps {
   currentQuestion?: Map<string, any>;
   isAnonymous: boolean;
-  onStudentSelect: (student: Map<any, any>) => void;
-  selectedStudents: Map<any, any>[];
+  onStudentSelect: (studentId: string) => void;
+  selectedStudentIds: string[];
   students: Map<any, any>;
 }
 
 export class PopupStudentResponseList extends React.PureComponent<IProps> {
   render() {
-    const { students, isAnonymous, currentQuestion, selectedStudents } = this.props;
+    const { students, isAnonymous, currentQuestion, selectedStudentIds } = this.props;
     return (
       <div className={css.responseTable} data-cy="popup-response-table">
         { students?.map((student: Map<any, any>, i: number) => {
           const formattedName = getFormattedStudentName(isAnonymous, student);
-          const isSelected = selectedStudents.findIndex((s: Map<any, any>) => s.get("id") === student.get("id")) >= 0;
+          const isSelected = selectedStudentIds.findIndex((sId) => sId === student.get("id")) >= 0;
           return (
             <div className={css.studentRow} key={`student ${i}`} data-cy="student-row">
-              {this.renderStudentNameWrapper(student, formattedName, isSelected)}
+              {this.renderStudentNameWrapper(student.get("id"), formattedName, isSelected)}
               <div className={css.studentResponse} data-cy="student-response">
                 <Answer question={currentQuestion} student={student} responsive={false} studentName={formattedName} />
               </div>
@@ -34,10 +34,10 @@ export class PopupStudentResponseList extends React.PureComponent<IProps> {
     );
   }
 
-  private renderStudentNameWrapper(student: Map<any, any>, formattedName: string, selected: boolean) {
+  private renderStudentNameWrapper(studentId: string, formattedName: string, selected: boolean) {
     return (
       <div className={css.studentWrapper}>
-        <div onClick={this.handleSelect(student)} className={css.spotlightSelectionCheckbox} data-cy="spotlight-selection-checkbox">
+        <div onClick={this.handleSelect(studentId)} className={css.spotlightSelectionCheckbox} data-cy="spotlight-selection-checkbox">
           <div className={`${css.check} ${selected ? css.selected : ""}`} />
         </div>
         <div className={css.studentName} data-cy="student-name">{formattedName}</div>
@@ -45,7 +45,7 @@ export class PopupStudentResponseList extends React.PureComponent<IProps> {
     );
   }
 
-  private handleSelect = (student: Map<any, any>) => () => {
-    this.props.onStudentSelect(student);
+  private handleSelect = (studentId: string) => () => {
+    this.props.onStudentSelect(studentId);
   }
 }

--- a/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
@@ -17,9 +17,10 @@ interface IProps {
   currentQuestion?: Map<string, any>;
   isAnonymous: boolean;
   onCloseDialog: (show: boolean) => void;
-  onStudentSelect: (student: Map<any, any>) => void;
-  selectedStudents: Map<any, any>[];
+  onStudentSelect: (studentId: string) => void;
+  selectedStudentIds: string[];
   setAnonymous: (value: boolean) => void;
+  students: Map<any, any>;
 }
 export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
   render() {
@@ -78,28 +79,30 @@ export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
   }
 
   private renderStudentAnswers = () => {
-    const { selectedStudents, isAnonymous, currentQuestion } = this.props;
+    const { currentQuestion, isAnonymous, selectedStudentIds, students } = this.props;
     return (
       <div className={css.selectedStudentResponseTable} data-cy="popup-response-table">
-        { selectedStudents?.map((student: Map<any, any>, i: number) => {
-          const formattedName = getFormattedStudentName(isAnonymous, student);
-          return (
-            <div className={css.studentRow} key={`student ${i}`} data-cy="student-row">
-              {this.renderStudentNameWrapper(student, formattedName)}
-              <div className={css.studentResponse} data-cy="student-response">
-                <Answer question={currentQuestion} student={student} responsive={false} />
+        { students?.filter((student: Map<any, any>) => selectedStudentIds.findIndex((id: string) => id === student.get("id")) >= 0)
+                   .map((student: Map<any, any>, i: number) => {
+            const formattedName = getFormattedStudentName(isAnonymous, student);
+            return (
+              <div className={css.studentRow} key={`student ${i}`} data-cy="student-row">
+                {this.renderStudentNameWrapper(student.get("id"), formattedName)}
+                <div className={css.studentResponse} data-cy="student-response">
+                  <Answer question={currentQuestion} student={student} responsive={false} />
+                </div>
               </div>
-            </div>
-          );
-        }) }
+            );
+          })
+        }
       </div>
     );
   }
 
-  private renderStudentNameWrapper(student: Map<any, any>, formattedName: string) {
+  private renderStudentNameWrapper(studentId: string, formattedName: string) {
     return (
       <div className={css.studentWrapper}>
-        <div onClick={this.handleSelect(student)} className={css.spotlightSelectionCheckbox} data-cy="spotlight-selection-checkbox">
+        <div onClick={this.handleSelect(studentId)} className={css.spotlightSelectionCheckbox} data-cy="spotlight-selection-checkbox">
           <div className={css.check} />
         </div>
         <div className={css.spotlightBadge}>
@@ -110,8 +113,8 @@ export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
     );
   }
 
-  private handleSelect = (student: Map<any, any>) => () => {
-    this.props.onStudentSelect(student);
+  private handleSelect = (studentId: string) => () => {
+    this.props.onStudentSelect(studentId);
   }
 
 }

--- a/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
@@ -27,7 +27,7 @@ interface IProps {
   trackEvent: (category: string, action: string, label: string) => void;
 }
 interface IState {
-  selectedStudents: Map<any, any>[];
+  selectedStudentIds: string[];
   showSpotlightDialog: boolean;
   showSpotlightListDialog: boolean;
 }
@@ -35,7 +35,7 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      selectedStudents: [],
+      selectedStudentIds: [],
       showSpotlightDialog: false,
       showSpotlightListDialog: false
     };
@@ -44,19 +44,19 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
     const { anonymous, currentActivity, currentQuestion, hasTeacherEdition, isAnonymous, onClose, questions,
             setAnonymous, setCurrentActivity, setStudentFilter, sortedQuestionIds, studentCount, students,
             toggleCurrentQuestion, trackEvent } = this.props;
-    const { selectedStudents, showSpotlightDialog, showSpotlightListDialog } = this.state;
+    const { selectedStudentIds, showSpotlightDialog, showSpotlightListDialog } = this.state;
     return (
       <div className={css.popup} data-cy="all-responses-popup-view">
         <PopupHeader currentActivity={currentActivity} onCloseSelect={onClose} />
         <div className={css.tableHeader}>
           <PopupClassNav
             anonymous={anonymous}
-            isSpotlightOn={selectedStudents.length > 0}
+            isSpotlightOn={selectedStudentIds.length > 0}
             studentCount={studentCount}
             setAnonymous={setAnonymous}
             setStudentFilter={setStudentFilter}
             trackEvent={trackEvent}
-            onShowDialog={selectedStudents.length > 0 ? this.setShowSpotlightListDialog : this.setShowSpotlightDialog}
+            onShowDialog={selectedStudentIds.length > 0 ? this.setShowSpotlightListDialog : this.setShowSpotlightDialog}
           />
           <div className={`${css.questionArea} ${css.column}`} data-cy="questionArea">
             <QuestionNavigator
@@ -74,7 +74,7 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
           currentQuestion={currentQuestion}
           isAnonymous={isAnonymous}
           onStudentSelect={this.toggleSelectedStudent}
-          selectedStudents={selectedStudents}
+          selectedStudentIds={selectedStudentIds}
           students={students}
         />
         { showSpotlightListDialog &&
@@ -85,8 +85,9 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
             isAnonymous={isAnonymous}
             onCloseDialog={this.setShowSpotlightListDialog}
             onStudentSelect={this.toggleSelectedStudent}
-            selectedStudents={selectedStudents}
+            selectedStudentIds={selectedStudentIds}
             setAnonymous={setAnonymous}
+            students={students}
           />
         }
         { showSpotlightDialog &&
@@ -105,15 +106,15 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
     this.setState({ showSpotlightDialog: show });
   }
 
-  private toggleSelectedStudent = (student: Map<any, any> ) => {
-    const { selectedStudents } = this.state;
-    const studentIndex = selectedStudents.findIndex((s: Map<any, any>) => s.get("id") === student.get("id"));
-    const updatedSelectedStudents = [...selectedStudents];
-    if (studentIndex >= 0) {
-      updatedSelectedStudents.splice(studentIndex, 1);
+  private toggleSelectedStudent = (studentId: string ) => {
+    const { selectedStudentIds } = this.state;
+    const index = selectedStudentIds.findIndex((s: string) => s === studentId);
+    const updatedSelectedStudentIds = [...selectedStudentIds];
+    if (index >= 0) {
+      updatedSelectedStudentIds.splice(index, 1);
     } else {
-      updatedSelectedStudents.push(student);
+      updatedSelectedStudentIds.push(studentId);
     }
-    this.setState({ selectedStudents: updatedSelectedStudents });
+    this.setState({ selectedStudentIds: updatedSelectedStudentIds });
   }
 }


### PR DESCRIPTION
This PR changes how we store the currently selected set of spotlight students in the `StudentResponsePopup` component state.  Previously we stored  an array of students (where students was an immutable JS map, the same way that students are stored in the Redux state).  These changes make it so that we now store an array of student id strings in the component state.

It wasn't immediately obvious why this change was needed, but there was a bug in the anonymized name that appeared in the student spotlight.  This made it clear that our previous component state model was incorrect.  Previously, when a student was selected for spotlight, we grabbed a copy of the student (again, an immutable JS map) from the Redux state and stored that in our component state.  However, after the student state in Redux is initially built, it does NOT remain static.  Anonymizing the list of students, actually changes the students in the Redux state (student name is updated).  However, if we've already built a local array of students in the `StudentResponsePopup` component, we don't have access to any student state changes on the Redux state.  The safer approach is to just have the `StudentResponsePopup` store student ids in component state.  The ids can be used to access students from the Redux state.  Then if properties of the student change in the Redux state (like when we anonymize the names), we can use our student id to access a student out of the Redux state and ensure that our set of selected spotlight students is always up to date (instead of having some potentially obsolete copy). 