### PR TITLE
174915493 student sort

### DIFF
--- a/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
@@ -17,6 +17,7 @@ interface IProps {
   onShowDialog: (show: boolean) => void;
   setAnonymous: (value: boolean) => void;
   setStudentSort: (value: string) => void;
+  sortByMethod: string;
   studentCount: number;
   trackEvent: (category: string, action: string, label: string) => void;
 }
@@ -51,15 +52,16 @@ export class PopupClassNav extends React.PureComponent<IProps, IState>{
     const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
                                  { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
                                  { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
-    const { setStudentSort, trackEvent } = this.props;
+    const { setStudentSort, sortByMethod, trackEvent } = this.props;
     return (
       <div className={cssClassNav.studentSort}>
         <CustomSelect
+          dataCy={"sort-students"}
+          HeaderIcon={SortIcon}
           items={items}
           onSelectItem={setStudentSort}
+          selectState={sortByMethod}
           trackEvent={trackEvent}
-          HeaderIcon={SortIcon}
-          dataCy={"sort-students"}
         />
       </div>
     );

--- a/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { AnonymizeStudents } from "../anonymize-students";
 import { CustomSelect, SelectItem } from "../custom-select";
 import { NumberOfStudentsContainer } from "../num-students-container";
-import { SORT_BY_NAME } from "../../../actions/dashboard";
+import { SORT_BY_NAME, SORT_BY_MOST_PROGRESS, SORT_BY_LEAST_PROGRESS } from "../../../actions/dashboard";
 import SortIcon from "../../../../img/svg-icons/sort-icon.svg";
 import StudentViewIcon from "../../../../img/svg-icons/student-view-icon.svg";
 import QuestionViewIcon from "../../../../img/svg-icons/question-view-icon.svg";
@@ -16,7 +16,7 @@ interface IProps {
   isSpotlightOn: boolean;
   onShowDialog: (show: boolean) => void;
   setAnonymous: (value: boolean) => void;
-  setStudentFilter: (value: string) => void;
+  setStudentSort: (value: string) => void;
   studentCount: number;
   trackEvent: (category: string, action: string, label: string) => void;
 }
@@ -48,17 +48,18 @@ export class PopupClassNav extends React.PureComponent<IProps, IState>{
   }
 
   private renderStudentFilter = () => {
-    const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "All Students" }];
-    const { setStudentFilter, trackEvent } = this.props;
+    const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
+                                 { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
+                                 { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
+    const { setStudentSort, trackEvent } = this.props;
     return (
       <div className={cssClassNav.studentSort}>
         <CustomSelect
           items={items}
-          onSelectItem={setStudentFilter}
+          onSelectItem={setStudentSort}
           trackEvent={trackEvent}
           HeaderIcon={SortIcon}
           dataCy={"sort-students"}
-          disableDropdown={true}
         />
       </div>
     );

--- a/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-class-nav.tsx
@@ -49,9 +49,9 @@ export class PopupClassNav extends React.PureComponent<IProps, IState>{
   }
 
   private renderStudentFilter = () => {
-    const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
-                                 { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
-                                 { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
+    const items: SelectItem[] = [{ value: SORT_BY_NAME, label: "Student Name" },
+                                 { value: SORT_BY_MOST_PROGRESS, label: "Most Progress" } ,
+                                 { value: SORT_BY_LEAST_PROGRESS, label: "Least Progress" }];
     const { setStudentSort, sortByMethod, trackEvent } = this.props;
     return (
       <div className={cssClassNav.studentSort}>
@@ -59,9 +59,9 @@ export class PopupClassNav extends React.PureComponent<IProps, IState>{
           dataCy={"sort-students"}
           HeaderIcon={SortIcon}
           items={items}
-          onSelectItem={setStudentSort}
-          selectState={sortByMethod}
+          onChange={setStudentSort}
           trackEvent={trackEvent}
+          value={sortByMethod}
         />
       </div>
     );

--- a/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
@@ -20,6 +20,7 @@ interface IProps {
   setAnonymous: (value: boolean) => void;
   setCurrentActivity: (activityId: string) => void;
   setStudentFilter: (value: string) => void;
+  sortByMethod: string;
   sortedQuestionIds?: string[];
   studentCount: number;
   students: any;
@@ -42,7 +43,7 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
   }
   render() {
     const { anonymous, currentActivity, currentQuestion, hasTeacherEdition, isAnonymous, onClose, questions,
-            setAnonymous, setCurrentActivity, setStudentFilter, sortedQuestionIds, studentCount, students,
+            setAnonymous, setCurrentActivity, setStudentFilter, sortByMethod, sortedQuestionIds, studentCount, students,
             toggleCurrentQuestion, trackEvent } = this.props;
     const { selectedStudentIds, showSpotlightDialog, showSpotlightListDialog } = this.state;
     return (
@@ -55,6 +56,7 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
             studentCount={studentCount}
             setAnonymous={setAnonymous}
             setStudentSort={setStudentFilter}
+            sortByMethod={sortByMethod}
             trackEvent={trackEvent}
             onShowDialog={selectedStudentIds.length > 0 ? this.setShowSpotlightListDialog : this.setShowSpotlightDialog}
           />

--- a/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/student-responses-popup.tsx
@@ -54,7 +54,7 @@ export class StudentResponsePopup extends React.PureComponent<IProps, IState> {
             isSpotlightOn={selectedStudentIds.length > 0}
             studentCount={studentCount}
             setAnonymous={setAnonymous}
-            setStudentFilter={setStudentFilter}
+            setStudentSort={setStudentFilter}
             trackEvent={trackEvent}
             onShowDialog={selectedStudentIds.length > 0 ? this.setShowSpotlightListDialog : this.setShowSpotlightDialog}
           />

--- a/js/components/portal-dashboard/class-nav.tsx
+++ b/js/components/portal-dashboard/class-nav.tsx
@@ -41,8 +41,8 @@ export class ClassNav extends React.PureComponent<IProps> {
           dataCy={"choose-class"}
           disableDropdown={true}
           HeaderIcon={ClassIcon}
-          items={[{action: "", name: clazzName}]}
-          onSelectItem={(() => {})}
+          items={[{value: "", label: clazzName}]}
+          onChange={(() => {})}
           trackEvent={trackEvent}
         />
       </div>
@@ -50,9 +50,9 @@ export class ClassNav extends React.PureComponent<IProps> {
   }
 
   private renderStudentSort = () => {
-    const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
-                                 { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
-                                 { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
+    const items: SelectItem[] = [{ value: SORT_BY_NAME, label: "Student Name" },
+                                 { value: SORT_BY_MOST_PROGRESS, label: "Most Progress" } ,
+                                 { value: SORT_BY_LEAST_PROGRESS, label: "Least Progress" }];
     const { setStudentSort, sortByMethod, trackEvent } = this.props;
     return (
       <div className={css.studentSort}>
@@ -60,9 +60,9 @@ export class ClassNav extends React.PureComponent<IProps> {
           dataCy={"sort-students"}
           HeaderIcon={SortIcon}
           items={items}
-          onSelectItem={setStudentSort}
-          selectState={sortByMethod}
+          onChange={setStudentSort}
           trackEvent={trackEvent}
+          value={sortByMethod}
         />
       </div>
     );

--- a/js/components/portal-dashboard/class-nav.tsx
+++ b/js/components/portal-dashboard/class-nav.tsx
@@ -14,6 +14,7 @@ interface IProps {
   clazzName: string;
   setAnonymous: (value: boolean) => void;
   setStudentSort: (value: string) => void;
+  sortByMethod: string;
   studentCount: number;
   trackEvent: (category: string, action: string, label: string) => void;
 }
@@ -37,12 +38,12 @@ export class ClassNav extends React.PureComponent<IProps> {
     return (
       <div className={css.chooseClass}>
         <CustomSelect
+          dataCy={"choose-class"}
+          disableDropdown={true}
+          HeaderIcon={ClassIcon}
           items={[{action: "", name: clazzName}]}
           onSelectItem={(() => {})}
           trackEvent={trackEvent}
-          HeaderIcon={ClassIcon}
-          dataCy={"choose-class"}
-          disableDropdown={true}
         />
       </div>
     );
@@ -52,15 +53,16 @@ export class ClassNav extends React.PureComponent<IProps> {
     const items: SelectItem[] = [{ action: SORT_BY_NAME, name: "Student Name" },
                                  { action: SORT_BY_MOST_PROGRESS, name: "Most Progress" } ,
                                  { action: SORT_BY_LEAST_PROGRESS, name: "Least Progress" }];
-    const { setStudentSort, trackEvent } = this.props;
+    const { setStudentSort, sortByMethod, trackEvent } = this.props;
     return (
       <div className={css.studentSort}>
         <CustomSelect
+          dataCy={"sort-students"}
+          HeaderIcon={SortIcon}
           items={items}
           onSelectItem={setStudentSort}
+          selectState={sortByMethod}
           trackEvent={trackEvent}
-          HeaderIcon={SortIcon}
-          dataCy={"sort-students"}
         />
       </div>
     );

--- a/js/components/portal-dashboard/custom-select.tsx
+++ b/js/components/portal-dashboard/custom-select.tsx
@@ -6,17 +6,18 @@ import { SvgIcon } from "../../util/svg-icon";
 import css from "../../../css/portal-dashboard/custom-select.less";
 
 interface IProps {
+  dataCy: string;
+  disableDropdown?: boolean;
+  HeaderIcon: SvgIcon;
+  isHeader?: boolean;
   items: SelectItem[];
   onSelectItem: (value: string) => void;
+  selectState?: string;
   trackEvent: (category: string, action: string, label: string) => void;
-  HeaderIcon: SvgIcon;
-  dataCy: string;
-  isHeader?: boolean;
-  disableDropdown?: boolean;
 }
 
 interface IState {
-  current: string;
+  selected: string;
   showList: boolean;
 }
 
@@ -30,7 +31,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      current: props.items[0].action,
+      selected: props.items[0].action,
       showList: false
     };
   }
@@ -53,8 +54,9 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   }
 
   private renderHeader = () => {
-    const { items, HeaderIcon } = this.props;
-    const currentItem = items.find(i => i.action === this.state.current);
+    const { items, HeaderIcon, selectState } = this.props;
+    const selectedItem = selectState ? selectState : this.state.selected;
+    const currentItem = items.find(i => i.action === selectedItem);
     const showListClass = this.state.showList ? css.showList : "";
     const useHeader = this.props.isHeader ? css.topHeader : "";
     const disabled = this.props.disableDropdown ? css.disabled : "";
@@ -68,12 +70,13 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   }
 
   private renderList = () => {
-    const { items } = this.props;
+    const { items, selectState } = this.props;
+    const selectedItem = selectState ? selectState : this.state.selected;
     const useHeader = this.props.isHeader ? css.topHeader : "";
     return (
       <div className={`${css.list} ${useHeader} ${(this.state.showList ? css.show : "")}`}>
         { items && items.map((item: SelectItem, i: number) => {
-          const currentClass = this.state.current === item.action ? css.selected : "";
+          const currentClass = selectedItem === item.action ? css.selected : "";
           return (
             <div
               key={`item ${i}`}
@@ -104,11 +107,11 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
     });
   }
 
-  private handleListClick = (current: string) => () => {
-    this.props.onSelectItem(current);
-    this.props.trackEvent("Portal-Dashboard", "Dropdown", current);
+  private handleListClick = (selected: string) => () => {
+    this.props.onSelectItem(selected);
+    this.props.trackEvent("Portal-Dashboard", "Dropdown", selected);
     this.setState({
-      current,
+      selected,
       showList: false
     });
   }

--- a/js/components/portal-dashboard/custom-select.tsx
+++ b/js/components/portal-dashboard/custom-select.tsx
@@ -63,7 +63,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
     return (
       <div className={`${css.header} ${useHeader} ${showListClass} ${disabled}`} onClick={this.handleHeaderClick}>
         { <HeaderIcon className={`${css.icon} ${showListClass}`} /> }
-        <div className={css.current}>{currentItem && currentItem.label}</div>
+        <div className={css.current}>{currentItem?.label}</div>
         { <ArrowIcon className={`${css.arrow} ${showListClass} ${disabled}`} /> }
       </div>
     );

--- a/js/components/portal-dashboard/custom-select.tsx
+++ b/js/components/portal-dashboard/custom-select.tsx
@@ -11,19 +11,19 @@ interface IProps {
   HeaderIcon: SvgIcon;
   isHeader?: boolean;
   items: SelectItem[];
-  onSelectItem: (value: string) => void;
-  selectState?: string;
+  onChange: (value: string) => void;
+  value?: string;
   trackEvent: (category: string, action: string, label: string) => void;
 }
 
 interface IState {
-  selected: string;
+  value: string;
   showList: boolean;
 }
 
 export interface SelectItem {
-  action: string;
-  name: string;
+  value: string;
+  label: string;
 }
 
 export class CustomSelect extends React.PureComponent<IProps, IState> {
@@ -31,7 +31,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      selected: props.items[0].action,
+      value: props.value || props.items[0].value,
       showList: false
     };
   }
@@ -54,38 +54,38 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   }
 
   private renderHeader = () => {
-    const { items, HeaderIcon, selectState } = this.props;
-    const selectedItem = selectState ? selectState : this.state.selected;
-    const currentItem = items.find(i => i.action === selectedItem);
+    const { items, HeaderIcon, value } = this.props;
+    const currentValue = value || this.state.value;
+    const currentItem = items.find(i => i.value === currentValue);
     const showListClass = this.state.showList ? css.showList : "";
     const useHeader = this.props.isHeader ? css.topHeader : "";
     const disabled = this.props.disableDropdown ? css.disabled : "";
     return (
       <div className={`${css.header} ${useHeader} ${showListClass} ${disabled}`} onClick={this.handleHeaderClick}>
         { <HeaderIcon className={`${css.icon} ${showListClass}`} /> }
-        <div className={css.current}>{currentItem && currentItem.name}</div>
+        <div className={css.current}>{currentItem && currentItem.label}</div>
         { <ArrowIcon className={`${css.arrow} ${showListClass} ${disabled}`} /> }
       </div>
     );
   }
 
   private renderList = () => {
-    const { items, selectState } = this.props;
-    const selectedItem = selectState ? selectState : this.state.selected;
+    const { items, value } = this.props;
+    const currentValue = value || this.state.value;
     const useHeader = this.props.isHeader ? css.topHeader : "";
     return (
       <div className={`${css.list} ${useHeader} ${(this.state.showList ? css.show : "")}`}>
         { items && items.map((item: SelectItem, i: number) => {
-          const currentClass = selectedItem === item.action ? css.selected : "";
+          const currentClass = currentValue === item.value ? css.selected : "";
           return (
             <div
               key={`item ${i}`}
               className={`${css.listItem} ${currentClass}`}
-              onClick={this.handleListClick(item.action)}
-              data-cy={`list-item-${item.name.toLowerCase().replace(/\ /g, "-")}`}
+              onClick={this.handleChange(item.value)}
+              data-cy={`list-item-${item.label.toLowerCase().replace(/\ /g, "-")}`}
             >
               <CheckIcon className={`${css.check} ${currentClass}`} />
-              <div>{item.name}</div>
+              <div>{item.label}</div>
             </div>
           );
         }) }
@@ -107,11 +107,11 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
     });
   }
 
-  private handleListClick = (selected: string) => () => {
-    this.props.onSelectItem(selected);
-    this.props.trackEvent("Portal-Dashboard", "Dropdown", selected);
+  private handleChange = (value: string) => () => {
+    this.props.onChange(value);
+    this.props.trackEvent("Portal-Dashboard", "Dropdown", value);
     this.setState({
-      selected,
+      value,
       showList: false
     });
   }

--- a/js/components/portal-dashboard/header.tsx
+++ b/js/components/portal-dashboard/header.tsx
@@ -41,8 +41,8 @@ export class Header extends React.PureComponent<IProps> {
     const { assignmentName, trackEvent } = this.props;
     return (
         <CustomSelect
-          items={[{ action: "", name: assignmentName }]}
-          onSelectItem={(() => { })}
+          items={[{ value: "", label: assignmentName }]}
+          onChange={(() => { })}
           trackEvent={trackEvent}
           HeaderIcon={AssignmentIcon}
           dataCy={"choose-assignment"}

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import { connect } from "react-redux";
 import { fetchAndObserveData, trackEvent, setAnonymous } from "../../actions/index";
 import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getCurrentStudentId,
-         getStudentProgress, getCompactReport, getAnonymous } from "../../selectors/dashboard-selectors";
+         getStudentProgress, getCompactReport, getAnonymous, getDashboardSortBy } from "../../selectors/dashboard-selectors";
 import { Header } from "../../components/portal-dashboard/header";
 import { ClassNav } from "../../components/portal-dashboard/class-nav";
 import { LevelViewer } from "../../components/portal-dashboard/level-viewer";
@@ -33,15 +33,16 @@ interface IProps {
   currentStudentId: string | null;
   error: IResponse;
   expandedActivities: Map<any, any>;
+  hasTeacherEdition: boolean;
   isFetching: boolean;
   questions?: Map<string, any>;
   report: any;
   sequenceTree: Map<any, any>;
+  sortByMethod: string;
   studentCount: number;
   studentProgress: Map<any, any>;
   students: any;
   sortedQuestionIds?: string[];
-  hasTeacherEdition: boolean;
   // from mapDispatchToProps
   fetchAndObserveData: () => void;
   setAnonymous: (value: boolean) => void;
@@ -89,8 +90,8 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   render() {
     const { anonymous, answers, clazzName, compactReport, currentActivity, currentQuestion, currentStudentId, error, report,
       sequenceTree, setAnonymous, setCompactReport, setStudentSort, studentProgress, students, sortedQuestionIds, questions,
-      expandedActivities, setCurrentActivity, setCurrentQuestion, setCurrentStudent, toggleCurrentActivity, toggleCurrentQuestion,
-      trackEvent, userName, hasTeacherEdition } = this.props;
+      expandedActivities, setCurrentActivity, setCurrentQuestion, setCurrentStudent, sortByMethod, toggleCurrentActivity,
+      toggleCurrentQuestion, trackEvent, userName, hasTeacherEdition } = this.props;
     const { initialLoading, showAllResponsesPopup } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
@@ -119,10 +120,11 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
               <ClassNav
                 anonymous={anonymous}
                 clazzName={clazzName}
-                setStudentSort={setStudentSort}
-                trackEvent={trackEvent}
-                studentCount={students.size}
                 setAnonymous={setAnonymous}
+                setStudentSort={setStudentSort}
+                sortByMethod={sortByMethod}
+                studentCount={students.size}
+                trackEvent={trackEvent}
               />
               <LevelViewer
                 activities={activityTrees}
@@ -174,20 +176,21 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 <CSSTransition classNames={"popup"} timeout={500}>
                   <StudentResponsePopup
                     anonymous={anonymous}
-                    students={students}
-                    isAnonymous={isAnonymous}
-                    setAnonymous={setAnonymous}
-                    studentCount={students.size}
-                    setStudentFilter={setStudentSort}
                     currentActivity={currentActivity}
                     currentQuestion={currentQuestion}
-                    questions={questions}
-                    sortedQuestionIds={sortedQuestionIds}
-                    toggleCurrentQuestion={toggleCurrentQuestion}
-                    setCurrentActivity={setCurrentActivity}
-                    trackEvent={trackEvent}
                     hasTeacherEdition={hasTeacherEdition}
+                    isAnonymous={isAnonymous}
+                    questions={questions}
                     onClose={this.setShowAllResponsesPopup}
+                    setAnonymous={setAnonymous}
+                    setCurrentActivity={setCurrentActivity}
+                    setStudentFilter={setStudentSort}
+                    sortByMethod={sortByMethod}
+                    sortedQuestionIds={sortedQuestionIds}
+                    studentCount={students.size}
+                    students={students}
+                    toggleCurrentQuestion={toggleCurrentQuestion}
+                    trackEvent={trackEvent}
                   />
                 </CSSTransition>
               }
@@ -245,15 +248,16 @@ function mapStateToProps(state: RootState): Partial<IProps> {
     currentStudentId: getCurrentStudentId(state),
     error,
     expandedActivities: state.getIn(["dashboard", "expandedActivities"]),
+    hasTeacherEdition: dataDownloaded ? state.getIn(["report", "hasTeacherEdition"]) : undefined,
     isFetching: data.get("isFetching"),
+    questions,
     report: dataDownloaded && reportState,
     sequenceTree: dataDownloaded && getSequenceTree(state),
+    sortByMethod: getDashboardSortBy(state),
+    sortedQuestionIds,
     students: dataDownloaded && getSortedStudents(state),
     studentProgress: dataDownloaded && getStudentProgress(state),
     userName: dataDownloaded ? state.getIn(["report", "platformUserName"]) : undefined,
-    questions,
-    sortedQuestionIds,
-    hasTeacherEdition: dataDownloaded ? state.getIn(["report", "hasTeacherEdition"]) : undefined,
   };
 }
 

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -12,7 +12,7 @@ const getQuestions = state => state.getIn(["report", "questions"]);
 const getCurrentQuestionId = state => state.getIn(["dashboard", "currentQuestionId"]);
 export const getCurrentStudentId = state => state.getIn(["dashboard", "currentStudentId"]);
 const getStudents = state => state.getIn(["report", "students"]);
-const getDashboardSortBy = state => state.getIn(["dashboard", "sortBy"]);
+export const getDashboardSortBy = state => state.getIn(["dashboard", "sortBy"]);
 const getSeletedQuestionId = state => state.getIn(["dashboard", "selectedQuestion"]);
 export const getCompactReport = state => state.getIn(["dashboard", "compactReport"]);
 


### PR DESCRIPTION
This PR syncs the state of the two student sort `CustomSelect` component instances within the app.  Unlike other occurrences of the `CustomSelect` where the selected item is managed by the component's local state, if the current sort method is changed in one `CustomSelect`, it must also be changed in the other instance (this is similar to what we needed to do with the 3(!) anonymize toggles in the app - they all have to have a synchronized state).  To do this, we obtain the current student sort method from the Redux component and pass it to the `CustomSelect`.  This allows the `CustomSelect` to use or override its internal component state management based on the absence or presence of an optional prop.

There is also some minor refactoring of component props lists.  As the props lists grow on these components (a side effect of an early choice to grab the Redux state in the main app component and then pass it down as needed to child components), I'm finding it helpful to have them in alphabetical order.