### PR TITLE
Fix crash in spotlight

### DIFF
--- a/css/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.less
+++ b/css/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.less
@@ -11,6 +11,8 @@
   bottom: 25px;
   z-index: 1000;
   box-shadow: 0 0 0 8000px rgba(0,0,0,0.35);
+  display: flex;
+  flex-direction: column;
 
   .spotlightListHeader {
     height: 50px;
@@ -133,7 +135,6 @@
 
   .selectedStudentResponseTable {
     margin-top: 3px;
-    height: calc(100vh - 250px - @header-height);
     overflow-y: auto;
     font-weight: normal;
 

--- a/css/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.less
+++ b/css/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.less
@@ -1,5 +1,8 @@
 @import "../variables";
 
+@anonymize-container-width: 270px;
+@anonymize-container-margin: 3px;
+
 .spotlightListDialog {
   border-radius: 8px;
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.35);
@@ -103,7 +106,7 @@
 
     .anonymizeContainer {
       width: 270px;
-      margin-right: 3px;
+      margin-right: @anonymize-container-margin;
       background-color: @cc-teal-light6;
       height: 100%;
       display: flex;
@@ -115,13 +118,14 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      width: 100%;
+      width: calc(100% - @anonymize-container-margin - @anonymize-container-width);
       background-color: @cc-teal-light6;
       height: 100%;
 
       .icon {
         fill: @cc-teal;
         margin-left: 15px;
+        flex-shrink: 0;
       }
       .questionPromptText {
         margin-left: 3px;

--- a/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
@@ -61,7 +61,7 @@ export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
     const type = currentQuestion?.get("type");
     const questionType = QuestionTypes.find(qt => qt.type === type);
     const QuestionIcon = questionType?.icon;
-    const typeText = type && type.replace(/_/gm, ' ');
+    const typeText = type?.replace(/_/gm, ' ');
     const interactiveName = type === "iframe_interactive" ? currentQuestion?.get("name") : typeText;
     const prompt = currentQuestion?.get("prompt");
     const prompText = prompt ? striptags(prompt.replace(/&nbsp;/g, ' ')) : interactiveName;

--- a/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/spotlight-student-list-dialog.tsx
@@ -61,7 +61,10 @@ export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
     const type = currentQuestion?.get("type");
     const questionType = QuestionTypes.find(qt => qt.type === type);
     const QuestionIcon = questionType?.icon;
-    const prompt = currentQuestion ? striptags((currentQuestion.get("prompt")).replace(/&nbsp;/g, ' ')) : "";
+    const typeText = type && type.replace(/_/gm, ' ');
+    const interactiveName = type === "iframe_interactive" ? currentQuestion?.get("name") : typeText;
+    const prompt = currentQuestion?.get("prompt");
+    const prompText = prompt ? striptags(prompt.replace(/&nbsp;/g, ' ')) : interactiveName;
 
     return (
       <div className={css.spotlightColumnHeaders} data-cy="select-student-header">
@@ -71,7 +74,7 @@ export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
         <div className={css.questionPrompt} data-cy="question-prompt">
           <QuestionIcon className={`${css.icon} ${css.questionTypeIcon}`} />
           <span className={css.questionPromptText} data-cy="question-prompt-text">
-            {prompt}
+            {prompText}
           </span>
         </div>
       </div>

--- a/js/components/portal-dashboard/question-area.tsx
+++ b/js/components/portal-dashboard/question-area.tsx
@@ -21,12 +21,11 @@ export class QuestionArea extends React.PureComponent<IProps>{
     const teacherEditionBadge = css.teacherEditionBadge;
     const type = currentQuestion?.get("type");
     const scored = currentQuestion?.get("scored");
-    const typeText = type && type.replace(/_/gm, ' ');
+    const typeText = type?.replace(/_/gm, ' ');
     const interactiveName = type === "iframe_interactive" && currentQuestion?.get("name");
     const questionType = QuestionTypes.find(qt => qt.type === type && qt.scored === scored);
     const QuestionIcon = questionType?.icon;
     const activityURL = currentActivity?.get("url");
-
     return (
       <div className={`${css.questionArea} ${hideQuestion ? css.hidden : ""}`}>
         <div className={css.questionTypeHeader}>


### PR DESCRIPTION
This PR fixes two bugs in the spotlight view:

- The app crashed when opening an interactive question in the spotlight.  This was caused by an empty prompt in the question.  I expanded the checks for what text to display for the question in the spotlight, but @eireland you did much of the work that decides which question text to display in which context.  You might want to confirm my text choices.
- The vertical size of the content container in the spotlight view was incorrect.  It didn't fill the entire space of the spotlight view.  As a side note, I would avoid using the CSS `calc` with the viewport height/width (`vh` and `vw`) unless absolutely needed.  It tends to lock us into complex calculations that depend upon other component sizing when simple flex containers can often do the work (and then you often don't need to worry about future changes to the calculation).

![image](https://user-images.githubusercontent.com/5126913/94181708-bb38ef00-fe54-11ea-8837-32ec1653f6af.png)
