### PR TITLE
Fix multiple choice question layout

### DIFF
--- a/css/portal-dashboard/questions/multiple-choice-question.less
+++ b/css/portal-dashboard/questions/multiple-choice-question.less
@@ -14,8 +14,8 @@
     object-fit: contain;
     border: 1.5px solid @cc-charcoal-light1;
     background-color: white;
-    margin-left: 19px;
     margin-right: 8px;
+    flex-shrink: 0;
   }
   .correct {
     font-weight: bold;

--- a/js/components/portal-dashboard/questions/multiple-choice-question.tsx
+++ b/js/components/portal-dashboard/questions/multiple-choice-question.tsx
@@ -18,8 +18,7 @@ export const MultipleChoiceQuestion: React.FC<IProps> = (props) => {
       { prompt && renderHTML(prompt) }
       { choices.toArray?.().map( (choices: Map<string, any>, i: number) => {
         const multipleChoiceContent = `${choices.get("content")} ${choices.get("correct") ? "(correct)" : ""}`;
-        const multipleChoiceContentClass = `${css.mcContent} ${choices.get("correct") ? css.correct : ""}`;
-
+        const multipleChoiceContentClass = choices.get("correct") ? css.correct : "";
         return (
           <div className={css.choiceWrapper} key={`choices ${i}`}>
             <div className={css.choiceIcon} />


### PR DESCRIPTION
This PR fixes a bug that caused the multiple choice bubble to display incorrectly when we have long text in the multiple choice question.  Changes include:
- fix bug so bubble displays properly
- reduce margin so we have more space to display question
- remove undefined `mcContent` class that we were adding to the question text

![image](https://user-images.githubusercontent.com/5126913/94184936-8713fd00-fe59-11ea-8e79-a1630f996eba.png)
