### PR TITLE
Toggle current activity and close question overlay when click activity in level viewer

### DIFF
--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -189,6 +189,7 @@ export class LevelViewer extends React.PureComponent<IProps> {
   }
 
   private handleActivityButtonClick = (activityId: string) => () => {
+    this.props.toggleCurrentQuestion(this.props.currentQuestion?.get("id"));
     this.props.toggleCurrentActivity(activityId);
   }
 

--- a/js/components/portal-dashboard/question-overlay.tsx
+++ b/js/components/portal-dashboard/question-overlay.tsx
@@ -25,9 +25,9 @@ interface IProps {
 
 export class QuestionOverlay extends React.PureComponent<IProps> {
   render() {
-    const { students, currentQuestion, isAnonymous, setCurrentStudent, currentStudentId } = this.props;
+    const { students, currentActivity, currentQuestion, isAnonymous, setCurrentStudent, currentStudentId } = this.props;
     return (
-      <div className={`${css.questionOverlay} ${(currentQuestion ? css.visible : "")}`} data-cy="question-overlay">
+      <div className={`${css.questionOverlay} ${(currentQuestion && currentActivity ? css.visible : "")}`} data-cy="question-overlay">
         { currentQuestion && this.renderQuestionDetails() }
         {/* Removed for MVP: { currentQuestion && <ClassResponse currentQuestion={currentQuestion}/> } */}
         { currentQuestion &&


### PR DESCRIPTION
This PR makes changes so that after clicking on an activity button in the Level Viewer, we clear the current selected question and hide the Question Overlay.  This adheres to the Dash Prototype (https://hav7ta.axshare.com/#id=nkd8s4&p=portal_dashboard___reports_v3_4), and fixes some of the odd states that a user can get into in the app.  Without this fix, the following can happen:
- User has activity1: question1 showing in Question Overlay.  User clicks on activity2 in the Level Viewer.  We still display activity1: question1 in the Question Overlay even though the user has selected activity2.  
![image](https://user-images.githubusercontent.com/5126913/94205097-5f339200-fe77-11ea-90e5-9a9f97e09a06.png)

- User has Question Overlay showing.  User clicks activity button in Level Viewer to collapse the current activity (now NO activity is selected).  User now presses the Show All Students buttons.  Window appears but there is no activity title shown, because no activity is selected. @eireland we saw this the other day while pairing.
![image](https://user-images.githubusercontent.com/5126913/94205180-95711180-fe77-11ea-918c-6eb335ca7b68.png)
