### PR TITLE
174962304 text overflow

### DIFF
--- a/css/portal-dashboard/level-viewer.less
+++ b/css/portal-dashboard/level-viewer.less
@@ -64,7 +64,7 @@
         cursor: pointer;
 
         .activityTitle {
-          width: 73px;
+          width: 100px;
           height: 50%;
           padding: 6px 10px 0 10px;
           text-overflow: ellipsis;

--- a/cypress/integration/portal-dashboard/portal-dashboard-scrolling.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-scrolling.spec.js
@@ -11,12 +11,13 @@ context("Portal Dashboard Content Scrolling",() =>{
     cy.get('[data-cy=progress-table]').scrollTo('right');
 
     cy.get('[data-cy=collapsed-activity-button]').first().should('be.visible');
-    cy.get('[data-cy=collapsed-activity-button]').first().should("contain", "2 Report Test Activity 2");
+    cy.get('[data-cy=collapsed-activity-button]').first().should("contain", "2 Report Test");
 
     cy.get('[data-cy=collapsed-activity-button]').first().click();
     cy.wait(1000);
+    cy.get('[data-cy=progress-table]').scrollTo('left');
     cy.get('[data-cy=collapsed-activity-button]').first().should('be.visible');
-    cy.get('[data-cy=collapsed-activity-button]').first().should("contain", "1 Report Test Activity 1");
+    cy.get('[data-cy=collapsed-activity-button]').first().should("contain", "1 Report Test");
   });
 
 });

--- a/js/components/portal-dashboard/all-responses-popup/popup-header.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-header.tsx
@@ -4,6 +4,7 @@ import AssignmentIcon from "../../../../img/svg-icons/assignment-icon.svg";
 // Removed for MVP: import FeedbackIcon from "../../../../img/svg-icons/feedback-icon.svg";
 import GroupIcon from "../../../../img/svg-icons/group-icon.svg";
 import SmallCloseIcon from "../../../../img/svg-icons/small-close-icon.svg";
+import LinesEllipsis from "react-lines-ellipsis";
 
 import css from "../../../../css/portal-dashboard/all-responses-popup/popup-header.less";
 
@@ -38,7 +39,14 @@ export class PopupHeader extends React.PureComponent<IProps, IState>{
     return (
       <div className={css.headerLeft} onClick={this.handleCloseAllResponses}>
         <AssignmentIcon className={`${css.assignmentIcon} ${css.icon}`} />
-        <div className={css.title} data-cy="popup-header-title">{activityName}</div>
+        <div className={css.title} data-cy="popup-header-title">
+          <LinesEllipsis
+            text={activityName}
+            maxLine="2"
+            ellipsis="..."
+            basedOn="letters"
+          />
+        </div>
       </div>
     );
   }

--- a/js/components/portal-dashboard/all-responses-popup/popup-header.tsx
+++ b/js/components/portal-dashboard/all-responses-popup/popup-header.tsx
@@ -39,7 +39,7 @@ export class PopupHeader extends React.PureComponent<IProps, IState>{
     return (
       <div className={css.headerLeft} onClick={this.handleCloseAllResponses}>
         <AssignmentIcon className={`${css.assignmentIcon} ${css.icon}`} />
-        <div className={css.title} data-cy="popup-header-title">
+        <div className={css.title} data-cy="popup-header-title" title={activityName}>
           <LinesEllipsis
             text={activityName}
             maxLine="2"

--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -58,7 +58,7 @@ export class LevelViewer extends React.PureComponent<IProps> {
       <div key={activity.get("id")} className={css.animateLevelButton} data-cy="collapsed-activity-button">
         <div className={css.activityButton}>
           <div className={css.activityInnerButton} onClick={this.handleActivityButtonClick(activity.get("id"))}>
-            <div className={css.activityTitle}>
+            <div className={css.activityTitle} title={`${idx + 1} ${activity.get("name")}`}>
               <LinesEllipsis
                 text={`${idx + 1} ${activity.get("name")}`}
                 maxLine="3"
@@ -144,8 +144,13 @@ export class LevelViewer extends React.PureComponent<IProps> {
     if (totalWidth === 0) return;
     return (
       <div className={css.pageWrapper} key={page.get("id")} style={{width: totalWidth}}>
-        <div className={css.page}>
-            P{idx + 1}: {page.get("name")}
+        <div className={css.page} title={`P${idx + 1}: ${page.get("name")}`}>
+          <LinesEllipsis
+            text={`P${idx + 1}: ${page.get("name")}`}
+            maxLine="2"
+            ellipsis="..."
+            basedOn="letters"
+          />
         </div>
         <div className={css.questionsContainer}>
           { questions.map(this.renderQuestion) }

--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -4,6 +4,7 @@ import { ProgressLegendContainer } from "./legend-container";
 import { QuestionTypes } from "../../util/question-utils";
 import CorrectIcon from "../../../img/svg-icons/q-mc-scored-correct-icon.svg";
 import LaunchIcon from "../../../img/svg-icons/launch-icon.svg";
+import LinesEllipsis from "react-lines-ellipsis";
 
 import css from "../../../css/portal-dashboard/level-viewer.less";
 
@@ -58,7 +59,12 @@ export class LevelViewer extends React.PureComponent<IProps> {
         <div className={css.activityButton}>
           <div className={css.activityInnerButton} onClick={this.handleActivityButtonClick(activity.get("id"))}>
             <div className={css.activityTitle}>
-              {idx + 1} {activity.get("name")}
+              <LinesEllipsis
+                text={`${idx + 1} ${activity.get("name")}`}
+                maxLine="3"
+                ellipsis="..."
+                basedOn="letters"
+              />
             </div>
             <div className={`${css.activityImage} ${this.activityColorClass(idx)}`} />
           </div>

--- a/js/global.d.ts
+++ b/js/global.d.ts
@@ -7,3 +7,4 @@ declare module "*.svg" {
   const _: FunctionComponent<SVGProps<SVGSVGElement>>;
   export = _;
 }
+declare module "react-lines-ellipsis";

--- a/package-lock.json
+++ b/package-lock.json
@@ -20293,6 +20293,11 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-lines-ellipsis": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/react-lines-ellipsis/-/react-lines-ellipsis-0.14.1.tgz",
+      "integrity": "sha512-4nEDEzzfXy2bqRhLc00DWYb39FKIpGqaIIh/YT3KdHyM9pqD8cSfDSCdGy657sB12alCdT7cKK48Uk0OsRMvHQ=="
+    },
     "react-mde": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/react-mde/-/react-mde-10.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",
+    "react-lines-ellipsis": "^0.14.1",
     "react-mde": "^10.0.3",
     "react-radio-group": "^3.0.3",
     "react-redux": "^7.2.0",


### PR DESCRIPTION
This PR fixes two cases where long, overflowing text was not being handled properly.  In both cases overflow text should be shown with a set number of lines and with ellipsis as per the UI spec.  Cases include:
- activity names in the buttons in the level viewer
- activity name in the all student responses view
![image](https://user-images.githubusercontent.com/5126913/94226004-55c41d00-feab-11ea-8645-6b2464ec84d9.png)

For anyone interested, I used the library `react-lines-ellipsis` to handle multi-line overflow (which is much trickier than single line overflow with ellipsis).  I also tried `react-clamp-lines` (I couldn't get the sizing and number of clamped lines to work) and `React-clamp` (old, didn't work at all).