### PR TITLE
Fix question area height in question overlay and all student responses

### DIFF
--- a/css/portal-dashboard/all-responses-popup/popup-student-response-list.less
+++ b/css/portal-dashboard/all-responses-popup/popup-student-response-list.less
@@ -2,7 +2,6 @@
 
 .responseTable {
   margin-top: 3px;
-  height: calc(100vh - 250px - @header-height);
   overflow-y: auto;
   font-weight: normal;
 

--- a/css/portal-dashboard/all-responses-popup/student-responses-popup.less
+++ b/css/portal-dashboard/all-responses-popup/student-responses-popup.less
@@ -12,6 +12,8 @@
   height: 100%;
   font-weight: bold;
   z-index: 1;
+  display: flex;
+  flex-direction: column;
 
   .tableHeader {
     display: flex;

--- a/css/portal-dashboard/question-area.less
+++ b/css/portal-dashboard/question-area.less
@@ -2,8 +2,6 @@
 
 .questionArea {
   flex-basis: auto;
-  overflow-y: auto;
-  max-height: calc(100vh * .4);
 }
 
 .questionTypeHeader {
@@ -151,6 +149,8 @@
   width: 100%;
   padding-top: 2px;
   padding-bottom: 20px;
+  max-height: calc(100vh * .3);
+  overflow-y: auto;
 
   &.minHeight {
     min-height: 101px;

--- a/css/portal-dashboard/question-area.less
+++ b/css/portal-dashboard/question-area.less
@@ -2,6 +2,8 @@
 
 .questionArea {
   flex-basis: auto;
+  overflow-y: auto;
+  max-height: calc(100vh * .4);
 }
 
 .questionTypeHeader {


### PR DESCRIPTION
Improve handling of long question text in both the question overlay and all student response views.

![image](https://user-images.githubusercontent.com/5126913/94479952-66fe7980-018a-11eb-8928-cbc1360ef7f9.png)
