### PR TITLE
Improve anonymous tests

### DIFF
--- a/cypress/integration/api-error.spec.js
+++ b/cypress/integration/api-error.spec.js
@@ -1,0 +1,10 @@
+context("Test api error", () => {
+  context("when an invalid offering url is used", () => {
+    before(() => {
+      cy.visit("/?offering=http://example.com");
+    });
+    it('shows an error message to user', () => {
+      cy.contains("network error");
+    });
+  });
+});

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -63,27 +63,21 @@ export function fetchAndObserveData() {
         type: SET_ANONYMOUS_VIEW,
         runKey: runKeyValue
       });
-      // Need to disable network when there is no activity because we are using fake data.
-      // This is normally disabled by fetchPortalDataAndAuthFirestore, but we are bypassing this when there is a runkey
-      if(!activity) {
-        firebase.firestore().disableNetwork();
-      }
+
       firestoreInitialized.then(db => {
         if (activity) {
           watchResourceStructure(db, source, activity, dispatch);
-          watchAnonymousAnswers(db, answerSource, runKeyValue, dispatch);
         }
         else {
+          // Th network will be disabled in this case, see db.ts
+
           // Use fake data.
           dispatch({
             type: RECEIVE_RESOURCE_STRUCTURE,
             response: fakeSequenceStructure,
           });
-          dispatch({
-            type: RECEIVE_ANSWERS,
-            response: fakeAnswers,
-          });
         }
+        watchAnonymousAnswers(db, answerSource, runKeyValue, dispatch);
       });
     };
   } else {

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -20,6 +20,8 @@ export default store => next => action => {
     callApi(type, data, state)
       .then(response => successAction && next(successAction(response)))
       .catch(error => {
+        // Log this error to the console in addtion to dispatching the errorAction
+        console.error(`error calling API: ${type} error object:\n`, error);
         if (error instanceof APIError && errorAction) {
           return next(errorAction(error.response));
         }

--- a/js/api.ts
+++ b/js/api.ts
@@ -152,14 +152,6 @@ function fakeUserType(): "teacher" | "learner" {
 }
 
 export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
-  if (!getPortalBaseUrl()) {
-    // disable the network when we don't have a portal url. This way the demo report will not update
-    // data in firestore, and any tests running against it will be repeatable.
-    // Even if this doesn't work and data does go to firestore, the data will be stored
-    // in a seperate 'fake.portal' location
-    firebase.firestore().disableNetwork();
-  }
-
   const offeringPromise = fetchOfferingData();
   const classPromise = fetchClassData();
   return classPromise.then((classData: any) => {

--- a/js/db.ts
+++ b/js/db.ts
@@ -59,8 +59,21 @@ async function initializeDB(name: string) {
     await firebase.firestore().enablePersistence({ synchronizeTabs: true });
   }
 
-  // The disableNetwork call happens in the api.ts fetchPortalDataAndAuthFirestore
-  // it is currently disabled whenever fake data is being used
+  if(!(urlParam("class") || urlParam("offering") || urlParam("activity"))){
+    // The report was not provided any params to load in the activity structure
+    // In this case we are going to be using fake activity or sequence structure
+    // This might be because we are running an automated test, or because the report is being
+    // manually demo'd
+    // In either case we don't want to make network connections to server.
+    await firebase.firestore().disableNetwork();
+
+    // Note: We could load the database with the fake data at this point, so then
+    // the code in actions/index.ts would be more simple.
+    // We would be loading in the fake sequence and activity structure under the
+    // fake.authoring.system source.
+    // And load in the fake answers which match with it.
+    // Which fake structure and fake answers to load could be specified in URL params
+  }
 
   return firebase.firestore();
 }

--- a/js/reducers/data-reducer.ts
+++ b/js/reducers/data-reducer.ts
@@ -7,11 +7,12 @@ import {
 
 export interface IDataState {
   isFetching: boolean;
-  error?: any;
+  error: any;
 }
 
 const INITIAL_DATA_STATE = RecordFactory<IDataState>({
   isFetching: true,
+  error: null
 });
 
 export class DataState extends INITIAL_DATA_STATE implements IDataState {
@@ -19,7 +20,7 @@ export class DataState extends INITIAL_DATA_STATE implements IDataState {
     super(config);
   }
   isFetching: boolean;
-  error?: any;
+  error: any;
 }
 
 export default function data(state = new DataState({}), action: any) {


### PR DESCRIPTION
This changes the 'fake' mode for runKey based testing of the report.
It now tries to load the answer documents for real.  This way the tests exercise more of the code.
It does mean when a runKey is specified, then no answers are shown, however if the point of the test is to work with the answers then it should just leave off the runKey param.

It also moves the disableNetwork into db.ts This seems like a more natural place to put this. 

Additionally, it adds a test for the showing of network errors. This uncovered a bug in the code where the Immutable Record was being initialized without a `error` property. And as far as I understand Immutable Records need to be initialized with all possible properties. It doesn't allow `set(..)` calls unless the properties are defined. So the code was throwing an error while trying to render an error.