### PR TITLE
Update all responses button in question overlay

### DIFF
--- a/css/portal-dashboard/question-overlay.less
+++ b/css/portal-dashboard/question-overlay.less
@@ -27,6 +27,7 @@
     flex: 0 0 50px;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     width: 100%;
     height: 50px;
     background-color: @cc-teal;
@@ -35,17 +36,71 @@
     cursor: pointer;
     user-select: none;
 
-    &:hover {
-      background-color: @cc-teal-light1;
-    }
-    &:active {
-      background-color: @cc-teal-light2;
-    }
-
     .icon {
       width: 32px;
       height: 32px;
-      padding: 0 8px 0 20px;
+      margin-right: 8px;
+    }
+
+    .questionDetailButton {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 40px;
+      width: 160px;
+      margin-left: 10px;
+      padding: 0 10px;
+      border-radius: 4px;
+
+      &:hover {
+        background-color: @cc-teal-light1;
+      }
+
+      &:active {
+        background-color: @cc-teal-light2;
+      }
+
+    }
+
+    .openPopupButton {
+      display: flex;
+      flex-flow: row;
+      text-align: center;
+      align-items: center;
+      justify-content: center;
+      width: 179px;
+      height: 30px;
+      border-radius: 4px;
+      border: 1.5px solid @cc-charcoal-light1;
+      margin-right: 20px;
+      background-color: @cc-orange-light4B;
+      color: @cc-charcoal;
+      cursor: pointer;
+
+      .icon {
+        fill: @cc-orange;
+        width: 20px;
+        height: 20px;
+        margin-right: 5px;
+        padding: 0;
+      }
+      span {
+        font-weight: bold;
+        white-space: nowrap;
+      }
+      &:hover {
+        background-color: @cc-orange-light3
+      }
+      &:active {
+        background-color: @cc-orange;
+        border-color: white;
+        .icon{
+          fill: white;
+        }
+        span {
+          color: white;
+        }
+      }
     }
   }
   .questionTextArea {
@@ -54,52 +109,4 @@
     }
   }
 
-  .footer {
-    flex: 0 0 50px;
-    width: 100%;
-    height: 50px;
-    background-color: @cc-teal-light5;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-      .openPopupButton {
-        width: 239px;
-        height: 30px;
-        border-radius: 4px;
-        border: 1.5px solid @cc-charcoal-light1;
-        display: flex;
-        flex-flow: row;
-        text-align: center;
-        align-items: center;
-        justify-content: center;
-        position: absolute;
-        left: 89px;
-        cursor: pointer;
-
-        .icon {
-          fill: @cc-teal;
-          width: 20px;
-          height: 20px;
-          margin-right: 5px;
-        }
-        span {
-          font-weight: bold;
-          white-space: nowrap;
-        }
-        &:hover {
-          background-color: @cc-teal-light3
-        }
-        &:active {
-          background-color: @cc-teal;
-          border-color: white;
-          .icon{
-            fill: white;
-          }
-          span {
-            color: white;
-          }
-        }
-      }
-  }
 }

--- a/css/portal-dashboard/variables.less
+++ b/css/portal-dashboard/variables.less
@@ -25,6 +25,7 @@
 @cc-orange-light2: #ffc18a;
 @cc-orange-light3: #ffcea1;
 @cc-orange-light4: #ffe6d0;
+@cc-orange-light4B: #ffeddc;
 @cc-orange-light5: #fff2e7;
 @cc-orange-light6: #fff9f3;
 @score-green: #19e549;

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -20,7 +20,7 @@ context("Portal Dashboard Question Details Panel", () => {
     });
 
     it('verify we can click to close the question details panel', () => {
-      cy.get('[data-cy=question-overlay-header]').first().click();
+      cy.get('[data-cy=question-overlay-header-button]').first().click();
       cy.get('[data-cy=question-overlay-header]').should('not.be.visible');
     });
   });

--- a/js/components/portal-dashboard/question-overlay.tsx
+++ b/js/components/portal-dashboard/question-overlay.tsx
@@ -39,7 +39,6 @@ export class QuestionOverlay extends React.PureComponent<IProps> {
             currentStudentId={currentStudentId}
           />
         }
-        {this.renderFooter()}
       </div>
     );
   }
@@ -48,9 +47,12 @@ export class QuestionOverlay extends React.PureComponent<IProps> {
     const { currentActivity, currentQuestion, questions, sortedQuestionIds, toggleCurrentQuestion, setCurrentActivity, hasTeacherEdition } = this.props;
     return (
       <React.Fragment>
-        <div className={css.header} onClick={this.dismissCurrentQuestion} data-cy="question-overlay-header">
-          <QuestionPopoutIcon className={css.icon} />
-          <div>Question Detail View</div>
+        <div className={css.header} data-cy="question-overlay-header">
+          <div className={css.questionDetailButton} onClick={this.dismissCurrentQuestion}>
+            <QuestionPopoutIcon className={css.icon} />
+            <div>Question Details</div>
+          </div>
+          {this.renderAllResponsesButton()}
         </div>
         <QuestionNavigator
           currentActivity={currentActivity}
@@ -70,6 +72,15 @@ export class QuestionOverlay extends React.PureComponent<IProps> {
     if (this.props.currentQuestion) {
       this.props.toggleCurrentQuestion(this.props.currentQuestion.get("id"));
     }
+  }
+
+  private renderAllResponsesButton = () => {
+    return (
+      <div className={css.openPopupButton} data-cy="view-all-student-responses-button" onClick={this.handleShowAllResponsesButtonClick}>
+        <GroupIcon className={css.icon} />
+        <span>View All Responses</span>
+      </div>
+    );
   }
 
   private renderFooter = () => {

--- a/js/components/portal-dashboard/question-overlay.tsx
+++ b/js/components/portal-dashboard/question-overlay.tsx
@@ -48,7 +48,7 @@ export class QuestionOverlay extends React.PureComponent<IProps> {
     return (
       <React.Fragment>
         <div className={css.header} data-cy="question-overlay-header">
-          <div className={css.questionDetailButton} onClick={this.dismissCurrentQuestion}>
+          <div className={css.questionDetailButton} onClick={this.dismissCurrentQuestion} data-cy="question-overlay-header-button">
             <QuestionPopoutIcon className={css.icon} />
             <div>Question Details</div>
           </div>


### PR DESCRIPTION
Update the all responses button in the question overlay to match the UI spec.  Changes includes:
- move all responses button to question detail header
- remove all responses button from footer (entire footer should be removed)
- update colors in all responses button (button state colors should change from teal to orange)
- update related text. "View All Student Responses" becomes "View All Responses" and "Question Detail View" becomes "Question Details".

<img width="426" alt="Screen Shot 2020-12-03 at 9 00 47 PM" src="https://user-images.githubusercontent.com/5126913/101120479-fcfbb980-35aa-11eb-9951-f541f7853f7c.png">
