### PR TITLE
Change show feeback to hide feedback, fix menu options

### DIFF
--- a/css/portal-dashboard/header.less
+++ b/css/portal-dashboard/header.less
@@ -147,7 +147,7 @@
 
   .menuList {
     width: 210px;
-    height: 90px;
+    padding-bottom: 5px;
     border-radius: 0 0 4px 4px;
     position: absolute;
     margin-top: 10px;

--- a/js/actions/dashboard.js
+++ b/js/actions/dashboard.js
@@ -18,7 +18,7 @@ export const SET_QUESTION_EXPANDED = "SET_QUESTION_EXPANDED";
 export const SELECT_QUESTION = "SELECT_QUESTION";
 
 export const SET_COMPACT_REPORT = "SET_COMPACT_REPORT";
-export const SET_SHOW_FEEDBACK_BADGES = "SET_SHOW_FEEDBACK_BADGES";
+export const SET_HIDE_FEEDBACK_BADGES = "SET_HIDE_FEEDBACK_BADGES";
 
 export const TRACK_EVENT = "TRACK_EVENT";
 
@@ -143,9 +143,9 @@ export function setCompactReport(isCompact) {
   };
 }
 
-export function setShowFeedbackBadges(showFeedbackBadges) {
+export function setHideFeedbackBadges(hideFeedbackBadges) {
   return {
-    type: SET_SHOW_FEEDBACK_BADGES,
-    value: showFeedbackBadges,
+    type: SET_HIDE_FEEDBACK_BADGES,
+    value: hideFeedbackBadges,
   };
 }

--- a/js/components/portal-dashboard/header-menu.tsx
+++ b/js/components/portal-dashboard/header-menu.tsx
@@ -17,8 +17,8 @@ interface IState {
 }
 
 interface IProps {
-  setCompact: (value: boolean) => void;
-  setShowFeedbackBadges: (value: boolean) => void;
+  setCompact?: (value: boolean) => void;
+  setHideFeedbackBadges?: (value: boolean) => void;
   colorTheme?: ColorTheme;
 }
 
@@ -95,29 +95,17 @@ export class HeaderMenuContainer extends React.PureComponent<IProps, IState> {
   private renderMenuItems = () => {
     const { colorTheme } = this.props;
     const colorClass = colorTheme ? css[colorTheme] : "";
-    const itemsWithState: MenuItemWithState[] = [
-      {
-        name: "Compact student list",
-        onSelect: this.props.setCompact,
-        dataCy: "compact-menu-item"
-      },
-      // TODO: FEEDBACK
-      /*
-      {
-        name: "Show feedback badges",
-        onSelect: this.props.setShowFeedbackBadges,
-        dataCy: "feedback-menu-item"
-      },
-      */
-    ];
+    const itemsWithState: MenuItemWithState[] = [];
+    this.props.setCompact && itemsWithState.push(
+      { name: "Compact student list", onSelect: this.props.setCompact, dataCy: "compact-menu-item" });
+    this.props.setHideFeedbackBadges && itemsWithState.push(
+      { name: "Hide feedback badges", onSelect: this.props.setHideFeedbackBadges, dataCy: "feedback-menu-item" });
     return (
       <div className={`${css.menuList} ${(this.state.showMenuItems ? css.show : "")}`} data-cy="menu-list">
         <div className={css.topMenu}>
-          {itemsWithState && itemsWithState.map((item: MenuItemWithState, i: number) => {
-            return (
-              <HeaderMenuItem key={`item ${i}`} menuItem={item} colorTheme={colorTheme} />
-            );
-          })}
+          {itemsWithState && itemsWithState.map((item: MenuItemWithState, i: number) =>
+            <HeaderMenuItem key={`item ${i}`} menuItem={item} colorTheme={colorTheme} />
+          )}
         </div>
         {items && items.map((item, i) => {
           return (

--- a/js/components/portal-dashboard/header.tsx
+++ b/js/components/portal-dashboard/header.tsx
@@ -14,8 +14,8 @@ import css from "../../../css/portal-dashboard/header.less";
 interface IProps {
   userName: string;
   assignmentName: string;
-  setCompact: (value: boolean) => void;
-  setShowFeedbackBadges: (value: boolean) => void;
+  setCompact?: (value: boolean) => void;
+  setHideFeedbackBadges?: (value: boolean) => void;
   trackEvent: (category: string, action: string, label: string) => void;
   setDashboardViewMode: (mode: DashboardViewMode) => void;
   viewMode: DashboardViewMode;
@@ -24,7 +24,7 @@ interface IProps {
 
 export class Header extends React.PureComponent<IProps> {
   render() {
-    const { colorTheme, userName, setCompact, setShowFeedbackBadges } = this.props;
+    const { colorTheme, userName, setCompact, setHideFeedbackBadges } = this.props;
     const colorClass = colorTheme ? css[colorTheme] : "";
     return (
       <div className={`${css.dashboardHeader} ${colorClass}`} data-cy="dashboard-header">
@@ -42,7 +42,7 @@ export class Header extends React.PureComponent<IProps> {
           <AccountOwnerDiv userName={userName} colorTheme={colorTheme} />
           <HeaderMenuContainer
             setCompact={setCompact}
-            setShowFeedbackBadges={setShowFeedbackBadges}
+            setHideFeedbackBadges={setHideFeedbackBadges}
             colorTheme={colorTheme}
           />
         </div>

--- a/js/components/portal-dashboard/student-answers.tsx
+++ b/js/components/portal-dashboard/student-answers.tsx
@@ -13,7 +13,7 @@ interface IProps {
   expandedActivities: Map<any, any>;
   isCompact: boolean;
   questionFeedbacks?: Map<any, any>;
-  showFeedbackBadges: boolean;
+  hideFeedbackBadges: boolean;
   students: Map<any, any>;
   studentProgress: Map<any, any>;
   setCurrentActivity: (activityId: string) => void;
@@ -77,8 +77,8 @@ export class StudentAnswers extends React.PureComponent<IProps> {
                               currentQuestionId === questionId &&
                               currentStudentId === studentId);
             // TODO: FEEDBACK
-            // get questionFeedbacks and showFeedbackBadges from props
-            // if showFeedbackBadges is true,
+            // get questionFeedbacks and hideFeedbackBadges from props
+            // if hideFeedbackBadges is false,
             // search questionFeedbacks for entry that has student id and question id
             // that match studentId and questionId and then
             // optionally display feedback icon component if we found matching feedback

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import { connect } from "react-redux";
 import { fetchAndObserveData, trackEvent, setAnonymous } from "../../actions/index";
 import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getCurrentStudentId,
-         getStudentProgress, getCompactReport, getAnonymous, getDashboardSortBy, getShowFeedbackBadges
+         getStudentProgress, getCompactReport, getAnonymous, getDashboardSortBy, getHideFeedbackBadges
         } from "../../selectors/dashboard-selectors";
 import { Header } from "../../components/portal-dashboard/header";
 import { ClassNav } from "../../components/portal-dashboard/class-nav";
@@ -15,7 +15,7 @@ import DataFetchError from "../../components/report/data-fetch-error";
 import { getSequenceTree, getAnswersByQuestion } from "../../selectors/report-tree";
 import { IResponse } from "../../api";
 import { setStudentSort, setCurrentActivity, setCurrentQuestion, setCurrentStudent,
-         toggleCurrentActivity, toggleCurrentQuestion, setCompactReport, setShowFeedbackBadges } from "../../actions/dashboard";
+         toggleCurrentActivity, toggleCurrentQuestion, setCompactReport, setHideFeedbackBadges } from "../../actions/dashboard";
 import { RootState } from "../../reducers";
 import { QuestionOverlay } from "../../components/portal-dashboard/question-overlay";
 import { ResponseDetails } from "../../components/portal-dashboard/response-details/response-details";
@@ -41,7 +41,7 @@ interface IProps {
   questionFeedbacks: Map<any, any>;
   report: any;
   sequenceTree: Map<any, any>;
-  showFeedbackBadges: boolean;
+  hideFeedbackBadges: boolean;
   sortByMethod: string;
   studentCount: number;
   studentProgress: Map<any, any>;
@@ -51,7 +51,7 @@ interface IProps {
   fetchAndObserveData: () => void;
   setAnonymous: (value: boolean) => void;
   setCompactReport: (value: boolean) => void;
-  setShowFeedbackBadges: (value: boolean) => void;
+  setHideFeedbackBadges: (value: boolean) => void;
   setStudentSort: (value: string) => void;
   setCurrentActivity: (activityId: string) => void;
   setCurrentQuestion: (questionId: string) => void;
@@ -96,7 +96,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
     const { anonymous, answers, clazzName, compactReport, currentActivity, currentQuestion, currentStudentId, error, report,
       sequenceTree, setAnonymous, setStudentSort, studentProgress, students, sortedQuestionIds, questions, expandedActivities,
       setCurrentActivity, setCurrentQuestion, setCurrentStudent, sortByMethod, toggleCurrentActivity, toggleCurrentQuestion,
-      trackEvent, hasTeacherEdition, questionFeedbacks, showFeedbackBadges } = this.props;
+      trackEvent, hasTeacherEdition, questionFeedbacks, hideFeedbackBadges } = this.props;
     const { initialLoading, viewMode } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
@@ -111,7 +111,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
     }
     return (
       <div className={css.portalDashboardApp}>
-        {sequenceTree && this.renderHeader(assignmentName, "progress")}
+        {sequenceTree && this.renderHeader(assignmentName, "ProgressDashboard" )}
         {activityTrees &&
           <div>
             <div className={css.navigation}>
@@ -148,7 +148,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                 currentStudentId={currentStudentId}
                 expandedActivities={expandedActivities}
                 isCompact={compactReport}
-                showFeedbackBadges={showFeedbackBadges}
+                hideFeedbackBadges={hideFeedbackBadges}
                 questionFeedbacks={questionFeedbacks}
                 setCurrentActivity={setCurrentActivity}
                 setCurrentQuestion={setCurrentQuestion}
@@ -175,7 +175,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
               {viewMode !== "ProgressDashboard" &&
                 <CSSTransition classNames={"responseDetails"} timeout={500}>
                   <div className={css.responseDetails} data-cy="response-details-container">
-                    {this.renderHeader(assignmentName, viewMode === "ResponseDetails" ? "response" : "feedback")}
+                    {this.renderHeader(assignmentName, viewMode)}
                     <ResponseDetails
                       activities={activityTrees}
                       anonymous={anonymous}
@@ -207,14 +207,17 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
     );
   }
 
-  private renderHeader = (assignmentName: any, color: ColorTheme) => {
-    const { userName, setCompactReport, setShowFeedbackBadges, trackEvent } = this.props;
+  private renderHeader = (assignmentName: string, headerViewMode: DashboardViewMode) => {
+    const { userName, setCompactReport, setHideFeedbackBadges, trackEvent } = this.props;
     const { viewMode} = this.state;
+    const color: ColorTheme = headerViewMode === "ProgressDashboard"
+      ? "progress"
+      : headerViewMode === "ResponseDetails" ? "response" : "feedback";
     return (
       <Header
         userName={userName}
-        setCompact={setCompactReport}
-        setShowFeedbackBadges={setShowFeedbackBadges}
+        setCompact={headerViewMode === "ProgressDashboard" ? setCompactReport : undefined}
+        setHideFeedbackBadges={headerViewMode === "ProgressDashboard" ? setHideFeedbackBadges : undefined}
         assignmentName={assignmentName}
         trackEvent={trackEvent}
         setDashboardViewMode={this.setDashboardViewMode}
@@ -274,7 +277,7 @@ function mapStateToProps(state: RootState): Partial<IProps> {
     questions,
     report: dataDownloaded && reportState,
     sequenceTree: dataDownloaded && getSequenceTree(state),
-    showFeedbackBadges: getShowFeedbackBadges(state),
+    hideFeedbackBadges: getHideFeedbackBadges(state),
     sortByMethod: getDashboardSortBy(state),
     sortedQuestionIds,
     students: dataDownloaded && getSortedStudents(state),
@@ -288,7 +291,7 @@ const mapDispatchToProps = (dispatch: any, ownProps: any): Partial<IProps> => {
     fetchAndObserveData: () => dispatch(fetchAndObserveData()),
     setAnonymous: (value: boolean) => dispatch(setAnonymous(value)),
     setCompactReport: (value: boolean) => dispatch(setCompactReport(value)),
-    setShowFeedbackBadges: (value: boolean) => dispatch(setShowFeedbackBadges(value)),
+    setHideFeedbackBadges: (value: boolean) => dispatch(setHideFeedbackBadges(value)),
     setStudentSort: (value: string) => dispatch(setStudentSort(value)),
     setCurrentActivity: (activityId: string) => dispatch(setCurrentActivity(activityId)),
     setCurrentStudent: (studentId: string) => dispatch(setCurrentStudent(studentId)),

--- a/js/reducers/dashboard-reducer.ts
+++ b/js/reducers/dashboard-reducer.ts
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import {
   SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, SET_CURRENT_QUESTION, SET_CURRENT_STUDENT,
   TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION,
-  SET_STUDENT_EXPANDED, SET_STUDENTS_EXPANDED, SET_STUDENT_SORT, SET_COMPACT_REPORT, SET_SHOW_FEEDBACK_BADGES,
+  SET_STUDENT_EXPANDED, SET_STUDENTS_EXPANDED, SET_STUDENT_SORT, SET_COMPACT_REPORT, SET_HIDE_FEEDBACK_BADGES,
   SORT_BY_NAME, SET_QUESTION_EXPANDED,
   SELECT_QUESTION,
   SORT_BY_MOST_PROGRESS,
@@ -24,7 +24,7 @@ export interface IDashboardState {
   currentQuestionId: string | null;
   currentStudentId: string | null;
   compactReport: boolean;
-  showFeedbackBadges: boolean;
+  hideFeedbackBadges: boolean;
 }
 
 const INITIAL_DASHBOARD_STATE = RecordFactory<IDashboardState>({
@@ -37,7 +37,7 @@ const INITIAL_DASHBOARD_STATE = RecordFactory<IDashboardState>({
   currentQuestionId: null,
   currentStudentId: null,
   compactReport: false,
-  showFeedbackBadges: false,
+  hideFeedbackBadges: false,
 });
 
 export class DashboardState extends INITIAL_DASHBOARD_STATE implements IDashboardState {
@@ -53,7 +53,7 @@ export class DashboardState extends INITIAL_DASHBOARD_STATE implements IDashboar
   currentQuestionId: string | null;
   currentStudentId: string | null;
   compactReport: boolean;
-  showFeedbackBadges: boolean;
+  hideFeedbackBadges: boolean;
 }
 
 export default function dashboard(state = new DashboardState({}), action: any) {
@@ -93,8 +93,8 @@ export default function dashboard(state = new DashboardState({}), action: any) {
       }
     case SET_COMPACT_REPORT:
       return state.set("compactReport", action.value);
-    case SET_SHOW_FEEDBACK_BADGES:
-      return state.set("showFeedbackBadges", action.value);
+    case SET_HIDE_FEEDBACK_BADGES:
+      return state.set("hideFeedbackBadges", action.value);
     default:
       return state;
   }

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -15,7 +15,7 @@ const getStudents = state => state.getIn(["report", "students"]);
 export const getDashboardSortBy = state => state.getIn(["dashboard", "sortBy"]);
 const getSeletedQuestionId = state => state.getIn(["dashboard", "selectedQuestion"]);
 export const getCompactReport = state => state.getIn(["dashboard", "compactReport"]);
-export const getShowFeedbackBadges = state => state.getIn(["dashboard", "showFeedbackBadges"]);
+export const getHideFeedbackBadges = state => state.getIn(["dashboard", "hideFeedbackBadges"]);
 
 // When a user selects a to display question details by
 // Clicking on the question column expand icon.

--- a/test/reducers/dashboard-reducer_spec.js
+++ b/test/reducers/dashboard-reducer_spec.js
@@ -13,7 +13,7 @@ describe("dashboard reducer", () => {
       currentQuestionId: null,
       currentStudentId: null,
       compactReport: false,
-      showFeedbackBadges: false,
+      hideFeedbackBadges: false,
     });
   });
 


### PR DESCRIPTION
This PR makes adjustments to the upper right menu:
- change show feedback badges to hide feedback badges (needed to change underlying state as well)
- turn on the feedback badges menu item (will be needed when we implement feedback)
- hid feedback badges and compact menu items if we are on any view other than the progress view