### PR TITLE
176082067 activity navigator

### DIFF
--- a/css/portal-dashboard/activity-navigator.less
+++ b/css/portal-dashboard/activity-navigator.less
@@ -1,0 +1,68 @@
+@import "./variables";
+
+.activityNav {
+  background-color: @cc-teal-light6;
+  width: 100%;
+  flex: 0 0 50px;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 50px;
+  background-color: @cc-teal-light5;
+  user-select: none;
+  text-align: center;
+  border-bottom: 1px solid @cc-teal;
+
+  .navButtons {
+    display: flex;
+    align-items: center;
+    margin-left: 20px;
+
+    .button {
+      width: 32px;
+      height: 32px;
+      border-radius: 3px;
+      box-sizing: border-box;
+      border: solid 1.5px @cc-charcoal-light1;
+      background-color: @cc-teal-light5;
+      cursor: pointer;
+
+      &:nth-of-type(2) {
+        margin-left: 13px;
+        transform: rotate(180deg);
+      }
+
+      .icon {
+        width: 32px;
+        height: 32px;
+        margin-top: -2px;
+        margin-left: -2px;
+        fill: @cc-teal;
+      }
+
+      &:not(.disabled) {
+        &:hover {
+          background-color: @cc-teal-light3;
+        }
+        &:active {
+          background-color: @cc-teal;
+          border-color: white;
+
+          .icon {
+            fill: white;
+          }
+        }
+      }
+      &.disabled {
+        cursor: auto;
+        opacity: 0.35;
+      }
+    }
+  }
+
+  .title {
+    width: 78%;
+    font-weight: bold;
+    color: @cc-charcoal;
+  }
+}

--- a/css/portal-dashboard/question-area.less
+++ b/css/portal-dashboard/question-area.less
@@ -149,12 +149,7 @@
   width: 100%;
   padding-top: 2px;
   padding-bottom: 20px;
-  max-height: calc(100vh * .3);
   overflow-y: auto;
-
-  &.minHeight {
-    min-height: 101px;
-  }
 }
 
 .hidden {

--- a/css/portal-dashboard/question-navigator.less
+++ b/css/portal-dashboard/question-navigator.less
@@ -3,7 +3,7 @@
 .questionArea {
   background-color: @cc-teal-light6;
   width: 100%;
-  height: 250px;
+  min-height: 250px;
 
   .titleWrapper {
     flex: 0 0 50px;

--- a/css/portal-dashboard/response-details/response-details.less
+++ b/css/portal-dashboard/response-details/response-details.less
@@ -5,7 +5,14 @@
 
   .responsePanel {
     width: 100%;
-    height: 251px;
     background-color: @cc-orange-light6;
+
+    .contentNavigatorArea {
+      min-height: 250px;
+
+      &.short {
+        min-height: 200px;
+      }
+    }
   }
 }

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
@@ -10,10 +10,6 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=view-all-student-responses-button]').should('be.visible').click();
       cy.get('[data-cy=dashboard-header]').should('be.visible');
     });
-    // after(()=>{
-    //   cy.get('[data-cy=navigation-select]').last().click();
-    //   cy.get('[data-cy="list-item-progress-dashboard"]').last().should('be.visible').click();
-    // });
   });
   context('View List By', () => {
     describe('verify by list by toggles switches views', () => {
@@ -34,9 +30,33 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=spotlight-dialog-close-button]').should('be.visible').click();
       cy.get('[data-cy=spotlight-dialog]').should('not.be.visible');
     });
+  });
+  context('Activity nav area', ()=>{
+    it('verify activity navigation is visible', ()=>{
+      cy.get('[data-cy=activity-navigator]').should('be.visible');
+      cy.get('[data-cy=activity-navigator-previous-button]').should('be.visible');
+      cy.get('[data-cy=activity-navigator-next-button]').should('be.visible');
+      cy.get('[data-cy=activity-title]').should('be.visible');
+    });
+    it('verify activity nav buttons toggle activities', ()=>{
+      cy.get('[data-cy=activity-title]').should('contain', "Activity #1");
+      cy.get('[data-cy=activity-navigator-next-button]').click();
+      cy.get('[data-cy=activity-title]').should('contain', "Activity #2");
+      cy.get('[data-cy=activity-navigator-previous-button]').click();
+      cy.get('[data-cy=activity-title]').should('contain', "Activity #1");
+    });
+    it('verify toggling activity goes to the first question of the activity', ()=>{
+      cy.get('[data-cy=response-panel] [data-cy=question-overlay-title]').should('contain', "Question #1");
+      cy.get('[data-cy=response-panel] [data-cy=question-navigator-next-button]').click();
+      cy.get('[data-cy=response-panel] [data-cy=question-overlay-title]').should('contain', "Question #2");
+      cy.get('[data-cy=activity-navigator-next-button]').click();
+      cy.get('[data-cy=activity-title]').should('contain', "Activity #2");
+      cy.get('[data-cy=response-panel] [data-cy=question-overlay-title]').should('contain', "Question #1");
+    });
     after(()=>{
-      cy.get('[data-cy=navigation-select]').last().click();
-      cy.get('[data-cy="list-item-progress-dashboard"]').last().should('be.visible').click();
+      cy.get('[data-cy=activity-navigator-previous-button]').click();
+      cy.get('[data-cy=navigation-select]').eq(1).should('be.visible').click();
+      cy.get('[data-cy=list-item-progress-dashboard]').eq(1).click();
     });
   });
   context('Question nav area',()=>{

--- a/js/components/portal-dashboard/activity-navigator.tsx
+++ b/js/components/portal-dashboard/activity-navigator.tsx
@@ -39,10 +39,13 @@ export class ActivityNavigator extends React.PureComponent<IProps> {
 
   private handleNavigation  = (activityIndex: number) => () =>{
     const { activities, setCurrentActivity, setCurrentQuestion} = this.props;
-    const newActivityId = activities.toArray()[activityIndex].get("id");
-    const newQuestionId = (activities.toArray()[activityIndex]).get("questions").first().get("id");
-    setCurrentActivity(newActivityId);
-    setCurrentQuestion(newQuestionId);
+    const activitiesArray = activities.toArray();
+    if ( activityIndex >= 0 && activityIndex < activitiesArray.length ) {
+      const newActivityId = activitiesArray[activityIndex].get("id");
+      const newQuestionId = activitiesArray[activityIndex].get("questions").first().get("id");
+      setCurrentActivity(newActivityId);
+      setCurrentQuestion(newQuestionId);
+    }
   }
 
 }

--- a/js/components/portal-dashboard/activity-navigator.tsx
+++ b/js/components/portal-dashboard/activity-navigator.tsx
@@ -18,14 +18,14 @@ export class ActivityNavigator extends React.PureComponent<IProps> {
     const currentActivityId = currentActivity? currentActivity.get("id") : activities.first().get("id");
     const currentActivityIndex = activities.toArray().findIndex((a: any) => a.get("id") === currentActivityId);
     return (
-      <div className={css.activityNav}>
+      <div className={css.activityNav} data-cy="activity-navigator">
           <div className={css.navButtons}>
             <div className={`${css.button} ${currentActivityIndex === 0 ? css.disabled : ""}`}
               onClick={this.handleNavigation(currentActivityIndex - 1)} data-cy="activity-navigator-previous-button">
               <ArrowLeftIcon className={css.icon} />
             </div>
             <div className={`${css.button} ${currentActivityIndex === activities.size-1 ? css.disabled : ""}`}
-              onClick={this.handleNavigation(currentActivityIndex + 1)} data-cy="question-navigator-next-button">
+              onClick={this.handleNavigation(currentActivityIndex + 1)} data-cy="activity-navigator-next-button">
               <ArrowLeftIcon className={css.icon} />
             </div>
           </div>

--- a/js/components/portal-dashboard/activity-navigator.tsx
+++ b/js/components/portal-dashboard/activity-navigator.tsx
@@ -41,7 +41,6 @@ export class ActivityNavigator extends React.PureComponent<IProps> {
     const { activities, setCurrentActivity, setCurrentQuestion} = this.props;
     const newActivityId = activities.toArray()[activityIndex].get("id");
     const newQuestionId = (activities.toArray()[activityIndex]).get("questions").first().get("id");
-    console.log(activityIndex, (activities.toArray()[activityIndex]).get("questions").first().get("id"), "in handleNavigation");
     setCurrentActivity(newActivityId);
     setCurrentQuestion(newQuestionId);
   }

--- a/js/components/portal-dashboard/activity-navigator.tsx
+++ b/js/components/portal-dashboard/activity-navigator.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Map } from "immutable";
+import ArrowLeftIcon from "../../../img/svg-icons/arrow-left-icon.svg";
+
+import css from "../../../css/portal-dashboard/activity-navigator.less";
+
+
+interface IProps {
+  activities: Map<any, any>;
+  currentActivity?: Map<string, any>;
+  setCurrentActivity: (activityId: string) => void;
+  setCurrentQuestion: (questionId: string) => void;
+}
+
+export class ActivityNavigator extends React.PureComponent<IProps> {
+  render() {
+    const { activities, currentActivity } = this.props;
+    const currentActivityId = currentActivity? currentActivity.get("id") : activities.first().get("id");
+    const currentActivityIndex = activities.toArray().findIndex((a: any) => a.get("id") === currentActivityId);
+    return (
+      <div className={css.activityNav}>
+          <div className={css.navButtons}>
+            <div className={`${css.button} ${currentActivityIndex === 0 ? css.disabled : ""}`}
+              onClick={this.handleNavigation(currentActivityIndex - 1)} data-cy="activity-navigator-previous-button">
+              <ArrowLeftIcon className={css.icon} />
+            </div>
+            <div className={`${css.button} ${currentActivityIndex === activities.size-1 ? css.disabled : ""}`}
+              onClick={this.handleNavigation(currentActivityIndex + 1)} data-cy="question-navigator-next-button">
+              <ArrowLeftIcon className={css.icon} />
+            </div>
+          </div>
+          <div className={css.title} data-cy="activity-title">
+            Activity #{currentActivityIndex+1}: {currentActivity ? currentActivity.get("name")
+                                                                 : activities.toArray()[currentActivityIndex].get("name")}
+          </div>
+      </div>
+    );
+  }
+
+  private handleNavigation  = (activityIndex: number) => () =>{
+    const { activities, setCurrentActivity, setCurrentQuestion} = this.props;
+    const newActivityId = activities.toArray()[activityIndex].get("id");
+    const newQuestionId = (activities.toArray()[activityIndex]).get("questions").first().get("id");
+    console.log(activityIndex, (activities.toArray()[activityIndex]).get("questions").first().get("id"), "in handleNavigation");
+    setCurrentActivity(newActivityId);
+    setCurrentQuestion(newQuestionId);
+  }
+
+}

--- a/js/components/portal-dashboard/activity-navigator.tsx
+++ b/js/components/portal-dashboard/activity-navigator.tsx
@@ -30,14 +30,15 @@ export class ActivityNavigator extends React.PureComponent<IProps> {
             </div>
           </div>
           <div className={css.title} data-cy="activity-title">
-            Activity #{currentActivityIndex+1}: {currentActivity ? currentActivity.get("name")
-                                                                 : activities.toArray()[currentActivityIndex].get("name")}
+            Activity #{currentActivityIndex+1}: {currentActivity
+                                                 ? currentActivity.get("name")
+                                                 : activities.toArray()[currentActivityIndex].get("name")}
           </div>
       </div>
     );
   }
 
-  private handleNavigation  = (activityIndex: number) => () =>{
+  private handleNavigation  = (activityIndex: number) => () => {
     const { activities, setCurrentActivity, setCurrentQuestion} = this.props;
     const activitiesArray = activities.toArray();
     if ( activityIndex >= 0 && activityIndex < activitiesArray.length ) {

--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -7,6 +7,7 @@ import { SpotlightMessageDialog } from "./spotlight-message-dialog";
 import { SpotlightStudentListDialog, spotlightColors } from "./spotlight-student-list-dialog";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import { StudentNavigator } from "../student-navigator";
+import { ActivityNavigator } from "../activity-navigator";
 
 import css from "../../../../css/portal-dashboard/response-details/response-details.less";
 
@@ -27,6 +28,7 @@ interface IProps {
   questions?: Map<string, any>;
   setAnonymous: (value: boolean) => void;
   setCurrentActivity: (activityId: string) => void;
+  setCurrentQuestion: (questionId: string) => void;
   setCurrentStudent: (studentId: string | null) => void;
   setStudentFilter: (value: string) => void;
   sortByMethod: string;
@@ -55,7 +57,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
   }
   render() {
     const { activities, anonymous, answers, currentActivity, currentStudentId, currentQuestion, hasTeacherEdition, isAnonymous, questions,
-      setAnonymous, setCurrentActivity, setCurrentStudent, setStudentFilter, sortByMethod, sortedQuestionIds, studentCount, students,
+      setAnonymous, setCurrentActivity, setCurrentQuestion, setCurrentStudent, setStudentFilter, sortByMethod, sortedQuestionIds, studentCount, students,
       trackEvent } = this.props;
     const { selectedStudents, showSpotlightDialog, showSpotlightListDialog, inQuestionMode } = this.state;
     // TODO: FEEDBACK
@@ -66,13 +68,13 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
 
     const activityId = currentActivity ? currentActivity.get("id") : firstActivity.get("id");
     let qCount = 0;
+
     activities.toArray().forEach((activity: Map<any, any>) => {
       if (activityId === activity.get("id")) {
         const questions = activity.get("questions");
         qCount = questions.count();
       }
     });
-
     return (
       <>
         <div className={css.tableHeader}>

--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -94,7 +94,8 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
           />
           <div className={`${css.responsePanel}`} data-cy="response-panel">
             {sequence &&
-              <ActivityNavigator activities={activities}
+              <ActivityNavigator
+                activities={activities}
                 currentActivity={currentActivity}
                 setCurrentActivity={setCurrentActivity}
                 setCurrentQuestion={setCurrentQuestion}

--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -65,7 +65,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
     const firstActivity = activities.first();
     const firstQuestion = questions?.first();
     const currentStudentIndex = students.findIndex((s: any) => s.get("id") === currentStudentId);
-    const sequence = activities.size > 1;
+    const isSequence = activities.size > 1;
 
     const activityId = currentActivity ? currentActivity.get("id") : firstActivity.get("id");
     let qCount = 0;
@@ -93,7 +93,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
             setListViewMode={this.setListViewMode}
           />
           <div className={`${css.responsePanel}`} data-cy="response-panel">
-            {sequence &&
+            {isSequence &&
               <ActivityNavigator
                 activities={activities}
                 currentActivity={currentActivity}
@@ -101,7 +101,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
                 setCurrentQuestion={setCurrentQuestion}
               />
             }
-            <div className={`${css.contentNavigatorArea} ${sequence? css.short : ""}`}>
+            <div className={`${css.contentNavigatorArea} ${isSequence ? css.short : ""}`}>
             { inQuestionMode ?
                 <StudentNavigator
                   students={students}

--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -65,6 +65,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
     const firstActivity = activities.first();
     const firstQuestion = questions?.first();
     const currentStudentIndex = students.findIndex((s: any) => s.get("id") === currentStudentId);
+    const sequence = activities.size > 1;
 
     const activityId = currentActivity ? currentActivity.get("id") : firstActivity.get("id");
     let qCount = 0;
@@ -92,6 +93,14 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
             setListViewMode={this.setListViewMode}
           />
           <div className={`${css.responsePanel}`} data-cy="response-panel">
+            {sequence &&
+              <ActivityNavigator activities={activities}
+                currentActivity={currentActivity}
+                setCurrentActivity={setCurrentActivity}
+                setCurrentQuestion={setCurrentQuestion}
+              />
+            }
+            <div className={`${css.contentNavigatorArea} ${sequence? css.short : ""}`}>
             { inQuestionMode ?
                 <StudentNavigator
                   students={students}
@@ -111,6 +120,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
                 hasTeacherEdition={hasTeacherEdition}
               />
             }
+            </div>
           </div>
         </div>
         <PopupStudentResponseList

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -185,6 +185,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                   questions={questions}
                   setAnonymous={setAnonymous}
                   setCurrentActivity={setCurrentActivity}
+                  setCurrentQuestion={setCurrentQuestion}
                   setCurrentStudent={setCurrentStudent}
                   setStudentFilter={setStudentSort}
                   sortByMethod={sortByMethod}


### PR DESCRIPTION
Adds ability to navigate from one activity to another while in response detail view and content is a sequence.
If user goes directly to response view without selecting a student or a question, the navigator defaults to the first question in the first activity. Otherwise it will go to the selected question.
When a user navigates between activities, the question shown is always the first question in the activity.
When content is a single activity, activity navigator is not shown.