### PR TITLE
Logged in user report part 2

### DIFF
--- a/cypress/integration/anonymous-user-report.spec.js
+++ b/cypress/integration/anonymous-user-report.spec.js
@@ -1,7 +1,7 @@
 context("Test anonymous user report", () => {
     before(() => {
         cy.fixture("sequence-structure.json").as("sequenceData");
-        cy.visit("/?runKey=12345&answerSource=localhost");
+        cy.visit("/?runKey=12345&answersSourceKey=localhost");
     });
     describe("test anonymous user can open their own report", () => {
         it('Test correct user is shown', () => {

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -41,7 +41,7 @@ In this diagram the Activity Player could be substituted for another third party
 
 - URL: `${auth-domain}/auth/oauth_authorize` This uses the `auth-domain` from the launch params to know where to send the OAuth2 request to.
 - Params:
-  - **clientId** currently hardcoded to `"token-service-example-app"`. This needs to be the name of a client in the portal that has a redirect url which exactly matches the `redirectUri` below. And the client "client type" needs to be configured as 'public', so it allows browser requests for access_tokens.
+  - **clientId** currently hardcoded to `"portal-report"`. This needs to be the `App Id` a client in the portal that has a redirect url which exactly matches the `redirectUri` below. And the client "client type" needs to be configured as 'public', so it allows browser requests for access_tokens.
   - **redirectUri** current portal-report url without any parameters (this way it will include any version or branch path)
   - **state** this is a random string that is used as a key to restore all of the params from the launch after OAuth2 is done. The state has a size limit so the params themselves cannot be sent directly as the state.
 - Code Location: `api.ts#authorizeInPortal`

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -29,7 +29,7 @@ In this diagram the Activity Player could be substituted for another third party
 #### Initial Launch Params (#1 in the diagram)
 
 - **class** URL to portal class api to get info about the class
-- **firebase-app** firebase app name in the portal. It defaults to "report-service". You might set this to work ith the development firestore database with "report-service-dev"
+- **firebase-app** firebase app name in the portal. It defaults to "report-service". You might set this to work with the development firestore database with "report-service-dev"
 - **offering** URL used to request info from the portal about this assignment in the portal
 - **reportType** always set to `offering`
 - **studentId** user id of the student this report is being opened for
@@ -41,14 +41,14 @@ In this diagram the Activity Player could be substituted for another third party
 
 - URL: `${auth-domain}/auth/oauth_authorize` This uses the `auth-domain` from the launch params to know where to send the OAuth2 request to.
 - Params:
-  - **clientId** currently hardcoded to `"token-service-example-app"`. This needs to be the name of a client in the portal that has a redirect url which exactly matches the redirectUri below. And the client "client type" needs to be configured as 'public', so it allows browser requests for access_tokens.
+  - **clientId** currently hardcoded to `"token-service-example-app"`. This needs to be the name of a client in the portal that has a redirect url which exactly matches the `redirectUri` below. And the client "client type" needs to be configured as 'public', so it allows browser requests for access_tokens.
   - **redirectUri** current portal-report url without any parameters (this way it will include any version or branch path)
   - **state** this is a random string that is used a key to restore all of the params from the launch after OAuth2 is done. The state has a size limit so the params be sent directly as the state.
 - Code Location: `api.ts#authorizeInPortal`
 
 #### Source Keys in Firestore
 
-This is brief description of source keys used by the portal report. A more detailed description is in [source-key.md](source-key.md)
+This is a brief description of source keys used by the portal report. A more detailed description is in [source-key.md](source-key.md)
 
 
 ##### Resource Structure Source Key
@@ -81,7 +81,7 @@ If the query parameters of the url do not include values for `offering` and `cla
 
 If we do have `offering` and `class` parameters, then `api.js` will first attempt to get the data for the offering and class from the portal. To do this it also needs a `token` parameter, which is used to authenticate with the portal and expires after one hour. Besides the class and offering data, we will also fetch a firestore JWT from the portal, given the classHash (from the fetched class data) and the token. Using this JWT, we can authenticate with Firestore. Once we have successfully authenticated, `receivePortalData` is called in `index.ts`, which starts watching the sequence structure and answer data.
 
-To test the portal using real data, the easiest way is simply to open a report as a teacher from the portal, and then replace the url host and path with `localhost:8080`. Alternatively, if it is OK mess with the assignment, you can add an additional report to the resource which launches your localhost report. An example of this is the "Developers Tracked Questions (Local)" external report.
+To test the portal using real data, the easiest way is simply to open a report as a teacher from the portal, and then replace the url host and path with `localhost:8080`. Alternatively, if it is OK to mess with the assignment, you can add an additional report to the resource which launches your localhost report. An example of this is the "Developers Tracked Questions (Local)" external report.
 
 ### URL Parameters
 

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -43,7 +43,7 @@ In this diagram the Activity Player could be substituted for another third party
 - Params:
   - **clientId** currently hardcoded to `"token-service-example-app"`. This needs to be the name of a client in the portal that has a redirect url which exactly matches the `redirectUri` below. And the client "client type" needs to be configured as 'public', so it allows browser requests for access_tokens.
   - **redirectUri** current portal-report url without any parameters (this way it will include any version or branch path)
-  - **state** this is a random string that is used a key to restore all of the params from the launch after OAuth2 is done. The state has a size limit so the params be sent directly as the state.
+  - **state** this is a random string that is used as a key to restore all of the params from the launch after OAuth2 is done. The state has a size limit so the params themselves cannot be sent directly as the state.
 - Code Location: `api.ts#authorizeInPortal`
 
 #### Source Keys in Firestore

--- a/docs/report-service.md
+++ b/docs/report-service.md
@@ -14,27 +14,45 @@ The new researcher report system reads data from the report-service.
 
 The following collections make up the report-service:
 
-`sources/${source}/resources`
+##### `sources/${source}/resources`
 Each document represents an activity or sequence that can be reported on.
 Each document lists the reportable questions or items and what pages they are on.
 It also includes information about what the correct answer is.
 
-`sources/${source}/answers`
+Authoring systems (LARA) writes.
+Reporting systems (portal-report researcher-report) read.
+
+##### `sources/${source}/answers`
 Each document represents a single answer to a question or item
 
-`sources/${source}/user_settings/${validFsId(platformUserId)}/resource_link/${validFsId(resourceLinkId)}`
+Runtimes (LARA and AP) write.
+Reporting Systems (portal-report researcher-report) read.
+
+##### `sources/${source}/user_settings/${validFsId(platformUserId)}/resource_link/${validFsId(resourceLinkId)}`
 Each document represents the settings for a teacher viewing the report. Currently
 these settings are which questions should be visible, and whether the user names should be anonymized.
 Unlike most other collections the `source` in this case is the platform. In most cases that is
 learn.concord.org
 
-`sources/${source}/feedback_settings`
+Reporting System (portal-report) reads and writes.
+
+##### `sources/${source}/feedback_settings`
 Each document has info about the feedback setting for a particular assignment (resourceLink).
 There can be a cached version of the rubric.
 And for each question there can be `scoreEnabled`, `feedbackEnabled`
 
-`sources/${source}/question_feedbacks`
+Reporting System (portal-report) reads and writes.
+Potential: Runtime (LARA and AP) reads: to show feedback status to the student
+
+##### `sources/${source}/question_feedbacks`
 Each document is feedback on a specific answer by a student.
 
-`sources/${source}/activity_feedbacks`
+Reporting System (portal-report) reads and writes.
+Potential: Runtime (LARA and AP) reads: to show feedback content to the student
+
+
+##### `sources/${source}/activity_feedbacks`
 Each document is feedback on the whole activity by a student
+
+Reporting System (portal-report) reads and writes.
+Potential: Runtime (LARA and AP) reads: to show feedback content to the student

--- a/docs/source-key.md
+++ b/docs/source-key.md
@@ -2,7 +2,7 @@
 
 In the report service database the data is segmented in to 'sources'. Each source has a 'sourceKey'.
 
-They were original intended to segment the data stored in the report-service. This way tools working with the report-service wouldn't accidentally clobber some other tool's data. However, we are now sharing this data between multiple tools, so they aren't as useful as they used to be.
+They were originally intended to segment the data stored in the report-service. This way tools working with the report-service wouldn't accidentally clobber some other tool's data. However, we are now sharing this data between multiple tools, so they aren't as useful as they used to be.
 
 ## Shared Source Keys
 

--- a/docs/source-key.md
+++ b/docs/source-key.md
@@ -44,7 +44,7 @@ Soon the AP is going to start saving the page the student is currently on. I thi
 - the offeringUrl
 That'd make it easier for some reports to be launched without needing as many parameters as they currently do.
 
-### Details about `tool_id` in the answers documents
+## Details about `tool_id` in the answers documents
 It is always added by the AP with a value of `portalData.toolId`. And this is the activity-player URL including its path so it would include the version or branch info if that was used. So this tool_id value works well for identifying which tool actually wrote the answer regardless of which source it is under.
 
 LARA also always adds this to the answers. Its value is either the REPORT_SERVICE_TOOL_ID if it is set or REPORT_SERVICE_SELF_URL otherwise.  The REPORT_SERVICE_SELF_URL is required to be set. The REPORT_SERVICE_TOOL_ID is optional and normally used in the dev environment.  
@@ -101,7 +101,7 @@ The source is not currently checked by any of the access rules.
 ### What about conflicting documents?  
 If we don't use the source then the activity-player and LARA answer documents will be mixed in the same folder.
 
-The answer documents currently include a `tool_id`. In the AP this domain plus the path of the url of the running the activity player so it also includes the version or branch in. LARA always adds this to the answers, and it typically should be `https://authoring.concord.org` or a developer might set it to something else for testing purposes.
+The answer documents currently include a `tool_id`. In the AP this is a the AP domain plus the path, so for example it would be `https://activity-player.concord.org/version/1.0.0`. The LARA runtime also adds this to the answers, and it typically will be `https://authoring.concord.org`. See the Details about `tool_id`... section.
 
 So this is a way to differentiate between the two types of answer documents.
 

--- a/docs/source-key.md
+++ b/docs/source-key.md
@@ -2,7 +2,7 @@
 
 In the report service database the data is segmented in to 'sources'. Each source has a 'sourceKey'.
 
-They were original intended to segment the data stored in the report-service. This way tools working with the report-service wouldn't accidentally clobber some other tools data. However, we are now sharing this data between multiple tools, so they aren't as useful as they used to be.
+They were original intended to segment the data stored in the report-service. This way tools working with the report-service wouldn't accidentally clobber some other tool's data. However, we are now sharing this data between multiple tools, so they aren't as useful as they used to be.
 
 ## Shared Source Keys
 
@@ -27,8 +27,8 @@ The sourceKey for production feedback documents is:
 - `authoring.concord.org`: this is where the portal-report writes
 
 ### resources
-These documents represent the activity or sequence structure that the portal-report and Athen report are reporting on. The structure includes the activity title, pages, questions, and question prompts.
-Currently only LARA writes resource documents. The portal-report and the Athena report reads these documents.
+These documents represent the activity or sequence structure that the portal-report and Athena report are reporting on. The structure includes the activity title, pages, questions, and question prompts.
+Currently only LARA writes resource documents. The portal-report and the Athena report read these documents.
 
 The sourceKey for production resource documents is:
 - `authoring.concord.org`
@@ -47,7 +47,7 @@ That'd make it easier for some reports to be launched without needing as many pa
 ### Details about `tool_id` in the answers documents
 It is always added by the AP with a value of `portalData.toolId`. And this is the activity-player URL including its path so it would include the version or branch info if that was used. So this tool_id value works well for identifying which tool actually wrote the answer regardless of which source it is under.
 
-LARA also always adds this to the answers. Is value is either the REPORT_SERVICE_TOOL_ID if it is set or REPORT_SERVICE_SELF_URL otherwise.  The REPORT_SERVICE_SELF_URL is required to be set. The REPORT_SERVICE_TOOL_ID is optional and normally used in the dev environment.  
+LARA also always adds this to the answers. Its value is either the REPORT_SERVICE_TOOL_ID if it is set or REPORT_SERVICE_SELF_URL otherwise.  The REPORT_SERVICE_SELF_URL is required to be set. The REPORT_SERVICE_TOOL_ID is optional and normally used in the dev environment.  
 
 Typically the tool_id in the answers will be authoring.concord.org.
 
@@ -70,7 +70,7 @@ If we say the source should be the domain of the application that writes the dat
 ### sourceKey is sort of the domain of resource the document is related to
 In this case the sourceKey is the domain that the documents are related too. So if a document is about a user and the user is authenticated in the portal then the sourceKey would be portal domain. Or if the document is feedback about an activity and the activity is coming from authoring.concord.org then the feedback document should also have a sourceKey of authoring.concord.org.
 
-A rational for this design goal is that the ids of the documents could then be relative to the resource they are related to. So then the document ids do not need to be globally unique and there is a no chance of conflicts.
+A rationale for this design goal is that the ids of the documents could then be relative to the resource they are related to. So then the document ids do not need to be globally unique and there is a no chance of conflicts.
 
 Looking at the current code though this filter:
 
@@ -81,13 +81,13 @@ Looking at the current code though this filter:
 
 #### Ambiguous
 - `question_feedbacks` is written by portal-report, but the documents are related to the answer created by the runtime (either activity player or LARA), the question created by LARA, and the assignment in the portal. The related resources can all be discovered from the answer, so we could say the source key should be the domain of the runtime which generated the answers. Currently the sourceKey is `authoring.concord.org`, which is correct for the LARA runtime but incorrect for the activity player runtime.
-- `activity_feedbacks` is written by portal-report, but the documents are related to the student's work on the assignment. Currently this associating is stored using the portal's contextId for the assignment and portalStudentId. The actual work is really from the runtime, but there not yet any document saved by the runtime representing the student's work. When the activity player saves the student's current page, then there will be a document for this work. Assuming we move towards this document of student work, then the related resource is the domain of the runtime which generated the work. Currently the sourceKey is `authoring.concord.org`, which is correct for the LARA runtime but incorrect for the activity player runtime.
+- `activity_feedbacks` is written by portal-report, but the documents are related to the student's work on the assignment. Currently this association is stored using the portal's contextId for the assignment and portalStudentId. The actual work is really from the runtime, but there is not yet any document saved by the runtime representing the student's work. When the activity player saves the student's current page, then there will be a document for this work. Assuming we move towards this document of student work, then the related resource is the domain of the runtime which generated the work. Currently the sourceKey is `authoring.concord.org`, which is correct for the LARA runtime but incorrect for the activity player runtime.
 
 #### Incorrect
 - `feedback_settings` is written by portal-report, but the settings are specific to an assignment in the portal. The sourceKey is `authoring.concord.org`. This is incorrect with this design goal, it should be `learn.concord.org`.
 
 ## Possible Improvement: Replace sourceKey with rootKey
-Here is an idea of way to improve the ambiguous use of sourceKeys above.
+Here is an idea to improve the ambiguous use of sourceKeys above.
 
 A single rootKey would be shared by AP, portal-report, LARA, and researcher report.
 The rootKey would default to something like 'production', but could be overridden for staging
@@ -105,11 +105,11 @@ The answer documents currently include a `tool_id`. In the AP this domain plus t
 
 So this is a way to differentiate between the two types of answer documents.
 
-The question_id in the answer documents is not globably unique by itself, but combining it with the resource_url should uniquely identify the question from the authored content. The same question might be shared by some LARA and AP answers, so a search of answers using just `question_id` and `resource_url` could turn up some answer documents from both systems. However, any reporting system should also be using a `resource_link_id` and/or `run_key` these fields should constrain the answers to a single system.  There are cases that come up with migration where some answers from both systems might share a `resource_link_id`, but that is intentional in the case of a migration.
+The question_id in the answer documents is not globally unique by itself, but combining it with the resource_url should uniquely identify the question from the authored content. The same question might be shared by some LARA and AP answers, so a search of answers using just `question_id` and `resource_url` could turn up some answer documents from both systems. However, any reporting system should also be using a `resource_link_id` and/or `run_key` these fields should constrain the answers to a single system.  There are cases that come up with migration where some answers from both systems might share a `resource_link_id`, but that is intentional in the case of a migration.
 
 Perhaps a researcher wants to look at answers to a question across many classes. In that case the query would be:
 `resource_url = https://example.com and question_id = 234`
-That could then pick up answers from different systems. That is hopefully what the researcher would want beause it indicates the same question was given in multiple systems. If a researcher wants to limit the search to just answers created by a particular runtime they'd need to include the `tool_id` in the query.
+That could then pick up answers from different systems. That is hopefully what the researcher would want because it indicates the same question was given in multiple systems. If a researcher wants to limit the search to just answers created by a particular runtime they'd need to include the `tool_id` in the query.
 
 ## What about local development?
 Currently the portal-report source is determined from the activityUrl from the offering when there is a logged in user.

--- a/docs/source-key.md
+++ b/docs/source-key.md
@@ -1,0 +1,127 @@
+# Source Key
+
+In the report service database the data is segmented in to 'sources'. Each source has a 'sourceKey'.
+
+They were original intended to segment the data stored in the report-service. This way tools working with the report-service wouldn't accidentally clobber some other tools data. However, we are now sharing this data between multiple tools, so they aren't as useful as they used to be.
+
+## Shared Source Keys
+
+### answers
+The LARA Runtime, AP, portal-report, and Athena researcher report, all need to look at the same answers.
+The LARA Runtime and AP write these answers. The portal-report and Athena researcher report read these answers.
+
+For testing purposes it would also be useful for the portal-report to write these answers.
+
+The sourceKeys for production answers are:
+- `activity-player.concord.org`: this is where the AP writes answers
+- `authoring.concord.org`: this is where LARA writes answers
+
+Note:
+The activity-player can be configured to read and write answers to the `authoring.concord.org` for testing a migration path. This is done using the activity player's `report-source` url parameter.
+
+### question_feedbacks and activity_feedbacks
+Currently only the portal-report reads and writes the feedback documents.
+It is likely the AP will start to look at the feedback so it can show it to the students when they are running the activity.
+
+The sourceKey for production feedback documents is:
+- `authoring.concord.org`: this is where the portal-report writes
+
+### resources
+These documents represent the activity or sequence structure that the portal-report and Athen report are reporting on. The structure includes the activity title, pages, questions, and question prompts.
+Currently only LARA writes resource documents. The portal-report and the Athena report reads these documents.
+
+The sourceKey for production resource documents is:
+- `authoring.concord.org`
+
+## Read or Write
+A key part is the write and read or directionality of the data in the various sources.  This read and write stuff also applies to permissions. Ideally the permissions should prevent the other apps and users from writing to documents which they only should read.
+
+Currently the access rules in the report service do not prevent apps from writing to documents. If the current user has access to write to a document in one app, then they have access to write in any app. That might not be something worth fixing.
+
+## New collections
+Soon the AP is going to start saving the page the student is currently on. I think it would be best if that was saved in a run specific document in a new collection. Following the pattern of the answer documents, then it should have a sourceKey of `activity-player.concord.org`. These run documents would be indexed by run_key or by resourceLinkId+userId. They could contain additional info besides the current page:
+- the resourceUrl
+- the offeringUrl
+That'd make it easier for some reports to be launched without needing as many parameters as they currently do.
+
+### Details about `tool_id` in the answers documents
+It is always added by the AP with a value of `portalData.toolId`. And this is the activity-player URL including its path so it would include the version or branch info if that was used. So this tool_id value works well for identifying which tool actually wrote the answer regardless of which source it is under.
+
+LARA also always adds this to the answers. Is value is either the REPORT_SERVICE_TOOL_ID if it is set or REPORT_SERVICE_SELF_URL otherwise.  The REPORT_SERVICE_SELF_URL is required to be set. The REPORT_SERVICE_TOOL_ID is optional and normally used in the dev environment.  
+
+Typically the tool_id in the answers will be authoring.concord.org.
+
+## Design Guidelines
+Deciding what sourceKey to use a for a new type of document is not easy because there isn't a consistent set of rules. So the best option with the current implementation is to look at the other sourceKeys and use your best judgment.
+
+### sourceKey is sort of the domain of application writing data
+If we say the source should be the domain of the application that writes the data, here is a analysis of the current code through that filter:
+
+#### Correct
+- `resources` only LARA writes here so it should be authoring.concord.org and it is.
+- `answers` it is `activity-player.concord.org` when the AP writes answers and `authoring.concord.org` when LARA write answers.
+
+#### Incorrect
+- `user_settings` is written by portal-report.concord.org, but the sourceKey is `learn.concord.org`
+- `feedback_settings` is written by portal-report but the sourceKey is `authoring.concord.org`
+- `question_feedbacks` is written by portal-report but the sourceKey is `authoring.concord.org`
+- `activity_feedbacks` is written by portal-report but the sourceKey is `authoring.concord.org`
+
+### sourceKey is sort of the domain of resource the document is related to
+In this case the sourceKey is the domain that the documents are related too. So if a document is about a user and the user is authenticated in the portal then the sourceKey would be portal domain. Or if the document is feedback about an activity and the activity is coming from authoring.concord.org then the feedback document should also have a sourceKey of authoring.concord.org.
+
+A rational for this design goal is that the ids of the documents could then be relative to the resource they are related to. So then the document ids do not need to be globally unique and there is a no chance of conflicts.
+
+Looking at the current code though this filter:
+
+#### Correct
+- `user_settings` is written by portal-report.concord.org, but the user the document is for is a user id from learn.concord.org. So the sourceKey is `learn.concord.org`.
+- `resources` only LARA writes here and the related resource is the activity or sequence in LARA. So the source key is `authoring.concord.org`.
+- `answers` the runtime writes here and the related resource is the student work. For LARA this student work is stored in LARA's database. For the activity-player the student work is completely stored in the report-service. So the sourceKey is `authoring.concord.org` when LARA write answers. And it is `activity-player.concord.org` when the AP writes answers.
+
+#### Ambiguous
+- `question_feedbacks` is written by portal-report, but the documents are related to the answer created by the runtime (either activity player or LARA), the question created by LARA, and the assignment in the portal. The related resources can all be discovered from the answer, so we could say the source key should be the domain of the runtime which generated the answers. Currently the sourceKey is `authoring.concord.org`, which is correct for the LARA runtime but incorrect for the activity player runtime.
+- `activity_feedbacks` is written by portal-report, but the documents are related to the student's work on the assignment. Currently this associating is stored using the portal's contextId for the assignment and portalStudentId. The actual work is really from the runtime, but there not yet any document saved by the runtime representing the student's work. When the activity player saves the student's current page, then there will be a document for this work. Assuming we move towards this document of student work, then the related resource is the domain of the runtime which generated the work. Currently the sourceKey is `authoring.concord.org`, which is correct for the LARA runtime but incorrect for the activity player runtime.
+
+#### Incorrect
+- `feedback_settings` is written by portal-report, but the settings are specific to an assignment in the portal. The sourceKey is `authoring.concord.org`. This is incorrect with this design goal, it should be `learn.concord.org`.
+
+## Possible Improvement: Replace sourceKey with rootKey
+Here is an idea of way to improve the ambiguous use of sourceKeys above.
+
+A single rootKey would be shared by AP, portal-report, LARA, and researcher report.
+The rootKey would default to something like 'production', but could be overridden for staging
+and development testing.
+
+All data would have to change. AP, portal-report, LARA, and researcher report would need to support this new approach, and ideally also be backward compatible with old approach so we can do the migration easily.
+
+### What about the access rules?
+The source is not currently checked by any of the access rules.
+
+### What about conflicting documents?  
+If we don't use the source then the activity-player and LARA answer documents will be mixed in the same folder.
+
+The answer documents currently include a `tool_id`. In the AP this domain plus the path of the url of the running the activity player so it also includes the version or branch in. LARA always adds this to the answers, and it typically should be `https://authoring.concord.org` or a developer might set it to something else for testing purposes.
+
+So this is a way to differentiate between the two types of answer documents.
+
+The question_id in the answer documents is not globably unique by itself, but combining it with the resource_url should uniquely identify the question from the authored content. The same question might be shared by some LARA and AP answers, so a search of answers using just `question_id` and `resource_url` could turn up some answer documents from both systems. However, any reporting system should also be using a `resource_link_id` and/or `run_key` these fields should constrain the answers to a single system.  There are cases that come up with migration where some answers from both systems might share a `resource_link_id`, but that is intentional in the case of a migration.
+
+Perhaps a researcher wants to look at answers to a question across many classes. In that case the query would be:
+`resource_url = https://example.com and question_id = 234`
+That could then pick up answers from different systems. That is hopefully what the researcher would want beause it indicates the same question was given in multiple systems. If a researcher wants to limit the search to just answers created by a particular runtime they'd need to include the `tool_id` in the query.
+
+## What about local development?
+Currently the portal-report source is determined from the activityUrl from the offering when there is a logged in user.
+1. So if a developer uses their localhost instance to load in data from a production activity, their localhost will be writing at least feedback documents into the production database.
+2. With the activity player, it currently figures out the answer source from its own URL. So that means the answers will go into the localhost source.
+
+The current approach with the portal-report is not good, but it is kind of necessary in order to be able to test feedback from a production class.
+The current approach with the activity player is pretty good it keeps data separated. It still could lead to conflicts between local developers, so it would be better if they overwrote this source. Or we configured webpack to automatically figure out their username and overwrite it.
+
+If the activity player used the domain of the activity file as its sourceKey then a developer running it locally with a remote activity could clobber some production answers. However the toolId stored in the answer would include localhost and unless it was launched from the portal it would not have a matching resourceLinkId.
+
+## What about ease of Firestore UI usage?
+The source keys can make it easier to look at answer documents from one system or the other. And because the UI doesn't support searching by multiple properties at once if we always had to include a `tool_id` filter to only look at LARA or only look at Activity Player, then we can't easily filter by anything else.
+
+I think in most cases the filter would be based on properties that should be unique to one system or the other. I can certainly see this leading to problems. But I think these issues are less important that cleaning up the various apps so the sourceKey stuff is less confusing.

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -109,7 +109,7 @@ function _receivePortalData(db: firebase.firestore.Firestore,
   // In those cases the offering.activity_url will look something like:
   // https://activity-player.concord.org?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F123.json
   let resourceUrl;
-  if (urlStringParam(rawPortalData.offering.activity_url, "activity")) {
+  if (urlStringParam(rawPortalData.offering.activity_url.split("?")[1], "activity")) {
     resourceUrl = decodeURIComponent(((rawPortalData.offering.activity_url?.split(".json")[0]).split("activity="))[1].replace("%2Fapi%2Fv1", ""));
   } else {
     resourceUrl = rawPortalData.offering.activity_url.toLowerCase();
@@ -136,10 +136,12 @@ function _receivePortalData(db: firebase.firestore.Firestore,
       response: fakeAnswers,
     });
   } else {
-    watchResourceStructure(db, source, resourceUrl, dispatch);
+    const resourceSource = urlParam("resourceSource") || source;
+    watchResourceStructure(db, resourceSource, resourceUrl, dispatch);
 
     // Watch the Answers
-    watchCollection(db, `sources/${source}/answers`, RECEIVE_ANSWERS,
+    const answerSource = urlParam("answerSource") || source;
+    watchCollection(db, `sources/${answerSource}/answers`, RECEIVE_ANSWERS,
       rawPortalData, dispatch);
   }
 

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -108,7 +108,7 @@ function _receivePortalData(db: firebase.firestore.Firestore,
     type: RECEIVE_PORTAL_DATA,
     response: rawPortalData
   });
-  const resourceUrl = _getResourceUrl(rawPortalData);
+  const resourceUrl = _getResourceUrl(rawPortalData.offering.activity_url);
   const source = rawPortalData.sourceKey;
   if (source === "fake.authoring.system") { // defined in data/offering-data.json
     // Use fake data.
@@ -148,20 +148,20 @@ function _receivePortalData(db: firebase.firestore.Firestore,
     rawPortalData, dispatch);
 }
 
-function _getResourceUrl(rawPortalData: IPortalRawData) {
+function _getResourceUrl(activityUrl: string) {
   let resourceUrl;
 
   // This is to support reporting on activity player based external activities.
   // In those cases the offering.activity_url will look something like:
   // https://activity-player.concord.org?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F123.json
-  const activityUrlParts = queryString.parseUrl(rawPortalData.offering.activity_url);
+  const activityUrlParts = queryString.parseUrl(activityUrl);
   const activityUrlActivityParam = activityUrlParts.query.activity;
   if (activityUrlActivityParam && typeof activityUrlActivityParam === "string" ) {
     // The activity param of an activity-player url points to a /api/v1/activities/123.json
     // However the activity structure is stored in the portal using its canonical url of /activites/123
     resourceUrl = activityUrlActivityParam.replace("/api/v1", "").replace(".json", "");
   } else {
-    resourceUrl = rawPortalData.offering.activity_url.toLowerCase();
+    resourceUrl = activityUrl.toLowerCase();
   }
 
   if (resourceUrl.match(/http:\/\/.*\.concord\.org/)) {

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -59,8 +59,7 @@ export function fetchAndObserveData() {
   if (runKeyValue) {
     const activity = urlParam("activity") || "";
     const source = activity ? makeSourceKey(activity) : "";
-    // FIXME: this really looks broken, the answerSource should never by the host of the portal-report
-    const answerSource = urlParam("answerSource") || window.location.host;
+    const answersSourceKey = urlParam("answersSourceKey") || source;
     return (dispatch: Dispatch, getState: any) => {
       dispatch({
         type: SET_ANONYMOUS_VIEW,
@@ -80,7 +79,7 @@ export function fetchAndObserveData() {
             response: fakeSequenceStructure,
           });
         }
-        watchAnonymousAnswers(db, answerSource, runKeyValue, dispatch);
+        watchAnonymousAnswers(db, answersSourceKey, runKeyValue, dispatch);
       });
     };
   } else {
@@ -125,12 +124,11 @@ function _receivePortalData(db: firebase.firestore.Firestore,
       response: fakeAnswers,
     });
   } else {
-    const resourceSource = urlParam("resourceSource") || source;
-    watchResourceStructure(db, resourceSource, resourceUrl, dispatch);
+    watchResourceStructure(db, source, resourceUrl, dispatch);
 
     // Watch the Answers
-    const answerSource = urlParam("answerSource") || source;
-    watchCollection(db, `sources/${answerSource}/answers`, RECEIVE_ANSWERS,
+    const answersSourceKey = urlParam("answersSourceKey") || source;
+    watchCollection(db, `sources/${answersSourceKey}/answers`, RECEIVE_ANSWERS,
       rawPortalData, dispatch);
   }
 
@@ -158,7 +156,7 @@ function _getResourceUrl(activityUrl: string) {
   const activityUrlActivityParam = activityUrlParts.query.activity;
   if (activityUrlActivityParam && typeof activityUrlActivityParam === "string" ) {
     // The activity param of an activity-player url points to a /api/v1/activities/123.json
-    // However the activity structure is stored in the portal using its canonical url of /activites/123
+    // However the activity structure is stored in the report service using its canonical url of /activites/123
     resourceUrl = activityUrlActivityParam.replace("/api/v1", "").replace(".json", "");
   } else {
     resourceUrl = activityUrl.toLowerCase();

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -1,4 +1,4 @@
-import { firestoreInitialized } from "../db";
+import { getFirestore } from "../db";
 import fakeSequenceStructure from "../data/sequence-structure.json";
 // import fakeActivityStructure from "../data/activity-structure.json";
 import fakeAnswers from "../data/answers.json";
@@ -25,7 +25,7 @@ import { requestRubric } from "./rubric";
 import * as firebase from "firebase/app";
 import "firebase/firestore";
 import { RootState } from "../reducers";
-import { urlParam, urlStringParam } from "../util/misc";
+import { urlParam } from "../util/misc";
 import queryString from "query-string";
 
 export const SET_ANONYMOUS_VIEW = "SET_ANONYMOUS_VIEW";
@@ -67,7 +67,7 @@ export function fetchAndObserveData() {
         runKey: runKeyValue
       });
 
-      firestoreInitialized.then(db => {
+      getFirestore().then(db => {
         if (activity) {
           watchResourceStructure(db, source, activity, dispatch);
         }
@@ -98,7 +98,7 @@ export function fetchAndObserveData() {
 
 function receivePortalData(rawPortalData: IPortalRawData) {
   return (dispatch: Dispatch) => {
-    firestoreInitialized.then(db => _receivePortalData(db, rawPortalData, dispatch));
+    getFirestore().then(db => _receivePortalData(db, rawPortalData, dispatch));
   };
 }
 

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -109,10 +109,11 @@ function _getResourceUrl(rawPortalData: IPortalRawData) {
   // In those cases the offering.activity_url will look something like:
   // https://activity-player.concord.org?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F123.json
   const activityUrlParts = queryString.parseUrl(rawPortalData.offering.activity_url);
-  if (activityUrlParts.query.activity) {
+  const activityUrlActivityParam = activityUrlParts.query.activity;
+  if (activityUrlActivityParam && typeof activityUrlActivityParam === "string" ) {
     // The activity param of an activity-player url points to a /api/v1/activities/123.json
     // However the activity structure is stored in the portal using its canonical url of /activites/123
-    resourceUrl = activityUrlParts.query.activity.replace("/api/v1", "").replace(".json", "");
+    resourceUrl = activityUrlActivityParam.replace("/api/v1", "").replace(".json", "");
   } else {
     resourceUrl = rawPortalData.offering.activity_url.toLowerCase();
   }

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -102,32 +102,6 @@ function receivePortalData(rawPortalData: IPortalRawData) {
   };
 }
 
-function _getResourceUrl(rawPortalData: IPortalRawData) {
-  let resourceUrl;
-
-  // This is to support reporting on activity player based external activities.
-  // In those cases the offering.activity_url will look something like:
-  // https://activity-player.concord.org?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F123.json
-  const activityUrlParts = queryString.parseUrl(rawPortalData.offering.activity_url);
-  const activityUrlActivityParam = activityUrlParts.query.activity;
-  if (activityUrlActivityParam && typeof activityUrlActivityParam === "string" ) {
-    // The activity param of an activity-player url points to a /api/v1/activities/123.json
-    // However the activity structure is stored in the portal using its canonical url of /activites/123
-    resourceUrl = activityUrlActivityParam.replace("/api/v1", "").replace(".json", "");
-  } else {
-    resourceUrl = rawPortalData.offering.activity_url.toLowerCase();
-  }
-
-  if (resourceUrl.match(/http:\/\/.*\.concord\.org/)) {
-    // Ensure that CC LARA URLs always start with HTTPS. Teacher could have assigned HTTP version to a class long
-    // time ago, but all the resources stored in Firestore assume that they're available under HTTPS now.
-    // We can't replace all the HTTP protocols to HTTPS not to break dev environments.
-    resourceUrl = resourceUrl.replace("http", "https");
-  }
-
-  return resourceUrl;
-}
-
 function _receivePortalData(db: firebase.firestore.Firestore,
   rawPortalData: IPortalRawData, dispatch: Dispatch) {
   dispatch({
@@ -172,6 +146,32 @@ function _receivePortalData(db: firebase.firestore.Firestore,
   const activityFeedbacksPath = reportActivityFeedbacksFireStorePath(rawPortalData.sourceKey);
   watchCollection(db, activityFeedbacksPath, RECEIVE_ACTIVITY_FEEDBACKS,
     rawPortalData, dispatch);
+}
+
+function _getResourceUrl(rawPortalData: IPortalRawData) {
+  let resourceUrl;
+
+  // This is to support reporting on activity player based external activities.
+  // In those cases the offering.activity_url will look something like:
+  // https://activity-player.concord.org?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F123.json
+  const activityUrlParts = queryString.parseUrl(rawPortalData.offering.activity_url);
+  const activityUrlActivityParam = activityUrlParts.query.activity;
+  if (activityUrlActivityParam && typeof activityUrlActivityParam === "string" ) {
+    // The activity param of an activity-player url points to a /api/v1/activities/123.json
+    // However the activity structure is stored in the portal using its canonical url of /activites/123
+    resourceUrl = activityUrlActivityParam.replace("/api/v1", "").replace(".json", "");
+  } else {
+    resourceUrl = rawPortalData.offering.activity_url.toLowerCase();
+  }
+
+  if (resourceUrl.match(/http:\/\/.*\.concord\.org/)) {
+    // Ensure that CC LARA URLs always start with HTTPS. Teacher could have assigned HTTP version to a class long
+    // time ago, but all the resources stored in Firestore assume that they're available under HTTPS now.
+    // We can't replace all the HTTP protocols to HTTPS not to break dev environments.
+    resourceUrl = resourceUrl.replace("http", "https");
+  }
+
+  return resourceUrl;
 }
 
 function getResourceLink(rawPortalData: IPortalRawData) {

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -7,7 +7,7 @@ import {
   APIError,
   fetchRubric
 } from "./api";
-import { firestoreInitialized } from "./db";
+import { getFirestore } from "./db";
 
 // This middleware is executed only if action includes .callAPI object.
 // It calls API action defined in callAPI.type.
@@ -53,7 +53,7 @@ function callApi(type, data, state) {
   switch (type) {
     case API_FETCH_PORTAL_DATA_AND_AUTH_FIRESTORE:
       // Make sure firestore db is ready before fetching data
-      return firestoreInitialized.then(() => fetchPortalDataAndAuthFirestore());
+      return getFirestore().then(() => fetchPortalDataAndAuthFirestore());
     case API_UPDATE_REPORT_SETTINGS:
       return updateReportSettings(data, state.get("report").toJS());
     case API_UPDATE_FEEDBACK_SETTINGS:

--- a/js/api.ts
+++ b/js/api.ts
@@ -103,7 +103,11 @@ export const initializeAuthorization = () => {
   }
   else {
     const authDomain = urlParam("auth-domain");
-    const oauthClientName = "token-service-example-app";
+    // Portal has to have AuthClient configured with this clientId.
+    // The AuthClient has to have:
+    // - redirect URLs of each branch being tested
+    // - "client type" needs to be configured as 'public', to allow browser requests
+    const oauthClientName = "portal-report";
     if (authDomain) {
       const key = Math.random().toString(36).substring(2,15);
       sessionStorage.setItem(key, window.location.search);

--- a/js/api.ts
+++ b/js/api.ts
@@ -71,18 +71,9 @@ export const makeSourceKey = (url: string | null) => {
   return url ? parseUrl(url.toLowerCase()).hostname : "";
 };
 
-// TODO: move this into the doc and reference it here
 // It is tempting to extract the right source key when the activity_url is
-// an activity player url. Then the sourceKey param would not be needed for
-// activity player report launches.
-// We do this kind of extraction here; _getResourceUrl
-// however this level of automagic will be hard to track down. It is likely
-// that some activity player activities in the portal will use custom urls to
-// their activities instead of ones authored in LARA. So these setups would
-// need to override the automatic sourceKey so their answers would be found
-// In these cases it is also likely the activity player activity launch
-// itself would use a report-source to configure the sorucekey where the
-// activity player stores its answers.
+// an activity player url. However the level of auto-magic will probably cause
+// problems in the future. See docs/launch.md for more info
 function getSourceKeyFromOffering(offering: {activity_url: string}): string {
   const sourceKeyParam = urlParam("sourceKey");
   return sourceKeyParam || makeSourceKey(offering.activity_url);

--- a/js/api.ts
+++ b/js/api.ts
@@ -82,9 +82,6 @@ function getSourceKeyFromOffering(offering: {activity_url: string}): string {
 // FIXME: If the user isn't logged in, and then they log in with a user that
 // isn't the student being reported on then just a blank screen is shown
 export const authorizeInPortal = (portalUrl: string, oauthClientName: string, state: string) => {
-  // eslint-disable-next-line no-console
-  console.log("authorizeInPortal");
-
   const portalAuth = new ClientOAuth2({
     clientId: oauthClientName,
     redirectUri: window.location.origin + window.location.pathname,
@@ -97,14 +94,10 @@ export const authorizeInPortal = (portalUrl: string, oauthClientName: string, st
 
 // Returns true if it is redirecting
 export const initializeAuthorization = () => {
-  // eslint-disable-next-line no-console
-  console.log("initializeAuthorization");
   const state = urlHashParam("state");
   accessToken = urlHashParam("access_token");
 
   if (accessToken && state) {
-    // eslint-disable-next-line no-console
-    console.log("initializeAuthorization: updating Params");
     const savedParamString = sessionStorage.getItem(state);
     window.history.pushState(null, "Portal Report", savedParamString);
   }
@@ -197,8 +190,6 @@ export function fetchFirestoreJWT(classHash: string, resourceLinkId: string | nu
 }
 
 export function authFirestore(rawFirestoreJWT: string) {
-  // eslint-disable-next-line no-console
-  console.log("authFirestore");
   const authResult = signInWithToken(rawFirestoreJWT) as Promise<firebase.auth.UserCredential | void>;
   return authResult.catch(err => {
     console.error("Firebase auth failed", err);
@@ -218,9 +209,6 @@ function fakeUserType(): "teacher" | "learner" {
 }
 
 export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
-  // eslint-disable-next-line no-console
-  console.log("fetchPortalDataAndAuthFirestore");
-
   const offeringPromise = fetchOfferingData();
   const classPromise = fetchClassData();
   return Promise.all([offeringPromise, classPromise]).then(([offeringData, classData]: [any, any]) => {
@@ -242,9 +230,6 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
         }
         const verifiedFirebaseJWT = decodedFirebaseJWT as IFirebaseJWT;
         return authFirestore(rawFirestoreJWT).then(() => {
-          // eslint-disable-next-line no-console
-          console.log("authFirestore complete");
-
           return {
             offering: offeringData,
             resourceLinkId,

--- a/js/api.ts
+++ b/js/api.ts
@@ -68,10 +68,10 @@ export interface IFirebaseJWT {
 
 // This matches the make_source_key method in LARA's report_service.rb
 export const makeSourceKey = (url: string | null) => {
-  return url ? url.replace(/https?:\/\/([^\/]+)/, "$1") : null;
+  return url ? url.replace(/https?:\/\/([^\/]+)/, "$1") : "";
 };
 
-function getSourceKey(): string | null {
+function getSourceKey(): string {
   const toolId = urlParam("tool-id");
   return makeSourceKey(toolId);
 }

--- a/js/api.ts
+++ b/js/api.ts
@@ -67,10 +67,13 @@ export interface IFirebaseJWT {
 }
 
 // This matches the make_source_key method in LARA's report_service.rb
+export const makeSourceKey = (url: string | null) => {
+  return url ? url.replace(/https?:\/\/([^\/]+)/, "$1") : null;
+};
+
 function getSourceKey(): string | null {
   const toolId = urlParam("tool-id");
-
-  return toolId ? toolId.replace(/https?:\/\/([^\/]+)/, "$1") : null;
+  return makeSourceKey(toolId);
 }
 
 export const authorizeInPortal = (portalUrl: string, oauthClientName: string, state: string) => {

--- a/js/api.ts
+++ b/js/api.ts
@@ -229,18 +229,17 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
           });
         }
         const verifiedFirebaseJWT = decodedFirebaseJWT as IFirebaseJWT;
-        return authFirestore(rawFirestoreJWT).then(() => {
-          return {
-            offering: offeringData,
-            resourceLinkId,
-            classInfo: classData,
-            userType: verifiedFirebaseJWT.claims.user_type,
-            platformId: verifiedFirebaseJWT.claims.platform_id,
-            platformUserId: verifiedFirebaseJWT.claims.platform_user_id.toString(),
-            contextId: classData.class_hash,
-            sourceKey: getSourceKeyFromOffering(offeringData)
-          };
-        });
+        return authFirestore(rawFirestoreJWT).then(() => ({
+          offering: offeringData,
+          resourceLinkId,
+          classInfo: classData,
+          userType: verifiedFirebaseJWT.claims.user_type,
+          platformId: verifiedFirebaseJWT.claims.platform_id,
+          platformUserId: verifiedFirebaseJWT.claims.platform_user_id.toString(),
+          contextId: classData.class_hash,
+          sourceKey: getSourceKeyFromOffering(offeringData)
+          })
+        );
       } else {
         // We're using fake data, including fake JWT.
         return {

--- a/js/components/portal-dashboard/question-navigator.tsx
+++ b/js/components/portal-dashboard/question-navigator.tsx
@@ -29,7 +29,7 @@ export class QuestionNavigator extends React.PureComponent<IProps, IState> {
     };
   }
   render() {
-    const { currentActivity, currentQuestion, inOverlay, hasTeacherEdition } = this.props;
+    const { currentQuestion, inOverlay, hasTeacherEdition } = this.props;
     return (
       <div className={css.questionArea}>
         <div className={css.titleWrapper}>

--- a/js/db.ts
+++ b/js/db.ts
@@ -37,11 +37,11 @@ const configurations: IConfigs = {
 
 export const DEFAULT_FIREBASE_APP = "report-service-dev";
 
-export function getFirebaseAppName() {
+export function getFirebaseAppName(): string {
   return urlParam("firebase-app") || DEFAULT_FIREBASE_APP;
 }
 
-let firestoreDBPromise = null;
+let firestoreDBPromise: Promise<firebase.firestore.Firestore> | null = null;
 
 export function initializeDB() {
   firestoreDBPromise = createDB();
@@ -105,7 +105,7 @@ async function createDB() {
 // The code using this promise could ignore the result here and just call firebase.firestore()
 // inside of the then, but using getFirestore() makes it easier to to say all direct calls to
 // firebase.firestore() should be here in db.ts
-export const getFirestore = () => {
+export const getFirestore = (): Promise<firebase.firestore.Firestore> => {
   // eslint-disable-next-line no-console
   console.log("getFirestore");
   if(firestoreDBPromise == null) {
@@ -121,21 +121,17 @@ export const signInWithToken = (rawFirestoreJWT: string) => {
   // eslint-disable-next-line no-console
   console.log("signInWithToken: " + rawFirestoreJWT);
   // It's actually useful to sign out first, as firebase seems to stay signed in between page reloads otherwise.
-  // FIXME: trying to debug an issue with signOut
-  // const signOutPromise = firebase.auth().signOut();
+  const signOutPromise = firebase.auth().signOut();
   // eslint-disable-next-line no-console
-  // console.log("signInWithToken: started signOut");
+  console.log("signInWithToken: started signOut");
   if (!SKIP_SIGN_IN) {
-    // FIXME: trying to debug an issue with signOut
-    // return signOutPromise.then(() => {
-    //   // eslint-disable-next-line no-console
-    //   console.log("signInWithToken: signedOut");
-    //
-    //   firebase.auth().signInWithCustomToken(rawFirestoreJWT);
-    // });
-    return firebase.auth().signInWithCustomToken(rawFirestoreJWT);
+    return signOutPromise.then(() => {
+      // eslint-disable-next-line no-console
+      console.log("signInWithToken: signedOut");
+
+      return firebase.auth().signInWithCustomToken(rawFirestoreJWT);
+    });
   } else {
-    // return signOutPromise;
-    return null;
+    return signOutPromise;
   }
 };

--- a/js/db.ts
+++ b/js/db.ts
@@ -50,9 +50,6 @@ export function initializeDB() {
 async function createDB() {
   const name = getFirebaseAppName();
 
-  // eslint-disable-next-line no-console
-  console.log("initializeDB: " + name);
-
   const config = configurations[name];
   firebase.initializeApp(config);
 
@@ -92,9 +89,6 @@ async function createDB() {
     // Which fake structure and fake answers to load could be specified in URL params
   }
 
-  // eslint-disable-next-line no-console
-  console.log("initializeDB: calling firebase.firestore()");
-
   return firebase.firestore();
 }
 
@@ -103,8 +97,6 @@ async function createDB() {
 // inside of the then, but using getFirestore() makes it easier to to say all direct calls to
 // firebase.firestore() should be here in db.ts
 export const getFirestore = (): Promise<firebase.firestore.Firestore> => {
-  // eslint-disable-next-line no-console
-  console.log("getFirestore");
   if(firestoreDBPromise == null) {
     throw new Error("firestore needs to be initialized first");
   }
@@ -115,17 +107,10 @@ export const getFirestore = (): Promise<firebase.firestore.Firestore> => {
 const SKIP_SIGN_IN = false;
 
 export const signInWithToken = (rawFirestoreJWT: string) => {
-  // eslint-disable-next-line no-console
-  console.log("signInWithToken: " + rawFirestoreJWT);
   // It's actually useful to sign out first, as firebase seems to stay signed in between page reloads otherwise.
   const signOutPromise = firebase.auth().signOut();
-  // eslint-disable-next-line no-console
-  console.log("signInWithToken: started signOut");
   if (!SKIP_SIGN_IN) {
     return signOutPromise.then(() => {
-      // eslint-disable-next-line no-console
-      console.log("signInWithToken: signedOut");
-
       return firebase.auth().signInWithCustomToken(rawFirestoreJWT);
     });
   } else {

--- a/js/db.ts
+++ b/js/db.ts
@@ -53,9 +53,6 @@ async function createDB() {
   // eslint-disable-next-line no-console
   console.log("initializeDB: " + name);
 
-  // Enable console logging of firestore
-  firebase.firestore.setLogLevel("debug");
-
   const config = configurations[name];
   firebase.initializeApp(config);
 

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,5 @@
-// import * as firebase from "firebase";
-// firebase.firestore.setLogLevel("debug");
+import * as firebase from "firebase";
+firebase.firestore.setLogLevel("debug");
 
 import { Provider } from "react-redux";
 import React from "react";

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,5 @@
-import * as firebase from "firebase";
-firebase.firestore.setLogLevel("debug");
+// import * as firebase from "firebase";
+// firebase.firestore.setLogLevel("debug");
 
 import { Provider } from "react-redux";
 import React from "react";

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,6 @@
+import * as firebase from "firebase";
+firebase.firestore.setLogLevel("debug");
+
 import { Provider } from "react-redux";
 import React from "react";
 import { render } from "react-dom";

--- a/js/index.js
+++ b/js/index.js
@@ -1,20 +1,21 @@
-import * as firebase from "firebase";
-firebase.firestore.setLogLevel("debug");
-
 import { Provider } from "react-redux";
 import React from "react";
 import { render } from "react-dom";
 import App from "./containers/app";
 import configureStore from "./store/configure-store";
 import { initializeAuthorization } from "./api";
+import { initializeDB } from "./db";
 
-initializeAuthorization();
-const store = configureStore();
-window.store = store;
+const redirecting = initializeAuthorization();
+if(!redirecting) {
+  initializeDB();
+  const store = configureStore();
+  window.store = store;
 
-render(
-  <Provider store={store}>
-    <App />
-  </Provider>,
-  document.getElementById("app"),
-);
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>,
+    document.getElementById("app"),
+  );
+}

--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -62,8 +62,8 @@ export function urlHashParam(name: string): string | null{
   return urlStringParam(window.location.hash, name);
 }
 
-export function urlStringParam(url: string, name: string): string | null{
-  const result = queryString.parse(url)[name];
+export function urlStringParam(stringToParse: string, name: string): string | null{
+  const result = queryString.parse(stringToParse)[name];
   if (typeof result === "string") {
     return result;
   } else if (result && result.length) {

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -103,19 +103,19 @@ describe("api helper", () => {
           },
           href: {
             ...oldPropertyDescriptors.href,
-            set: (value) => {throw new Error("must use window.location.assign instead of window.location.href=") }
+            set: (value) => {throw new Error("must use window.location.assign instead of window.location.href="); }
           }
         }
-      )
+      );
     });
 
     beforeEach(() => {
-      window.location.assign.mockReset()
+      window.location.assign.mockReset();
     });
 
     afterAll(() => {
       // restore `window.location` to the `jsdom` `Location` object
-      window.location = oldWindowLocation
+      window.location = oldWindowLocation;
     });
 
     describe("when there is no access_token param", () => {
@@ -176,6 +176,6 @@ describe("api helper", () => {
         initializeAuthorization();
         expect(window.location.assign).toHaveBeenCalledTimes(0);
       });
-    })
+    });
   });
 });

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -131,7 +131,7 @@ describe("api helper", () => {
           const urlParts = queryString.parseUrl(redirectURL);
           expect(urlParts.url).toEqual("https://portal.concord.org/auth/oauth_authorize");
           expect(urlParts.query).toMatchObject({
-            client_id: "token-service-example-app",
+            client_id: "portal-report",
             redirect_uri: "https://portal-report.unexisting.url.com/",
             response_type: "token"
           });

--- a/test/db_spec.js
+++ b/test/db_spec.js
@@ -1,0 +1,16 @@
+import { initializeDB, getFirestore } from "../js/db";
+
+describe("db helper", () => {
+  describe("getFirestore", () => {
+    it("should throw an exception if initializeDB is not called first", () => {
+      expect(getFirestore).toThrow(Error);
+    });
+    it("should return the firestore promise when initializeDB is called first", () => {
+      // Because we don't have any URL parameters firestore is being initialized
+      // with networking disabled
+      initializeDB();
+      const firestorePromise = getFirestore();
+      expect(firestorePromise).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Summary of changes:

## If we are redirecting because of OAuth2, do not load the app. 
We are redirecting with `window.location.assign(...)`, this doesn't stop the current javascript from executing. So if we do that redirect then `initializeAuthorization` returns `true`, and the main app is not rendered. See the changes in `js/index.js`.

## Delay the initialization of the firestore database until we know if we are redirecting or not.
Previously the firestore database was initialized immediately in `js/db.ts`. Now it is only initialized if we aren't redirecting. 

## Update access to Firestore db promise.
The previous code would store a promise which resolved to the firestore db and exported `firestoreInitialized`. The other code would chain promises off of that. This way those chained promises would not run until the database was fully initialized. Now `firestoreInitialzed` is replaced with `getFirestore()`. The method returns a promise that resolves to the firestore db like `firestoreInitialized` variable before, but it has the added safety check of throwing an error if that promise hasn't been created yet. The promise is now created by `initializedDB`, and that only happens if we aren't redirecting. (see above)

## expose makeSourceKey
There are a few places in the code where we need to turn URLs into sourceKeys. So this method can now be used instead of adding the custom logic everywhere.

## improve resource url logic
Replace string manipulation with `query-string` module to get the activity parameter. This library automatically decodes url parameters.  This logic was all extracted to its own function to make it easier to understand and should make testing easier.

## delay reading of `firebase-app` url param
Previously the `firebase-app` param was being loaded at the beginning. This meant that it would not be set correctly after we are redirected back to the app and the initial setup of url parameters doesn't include a `firebase-app`. So now there is a `getFirebaseAppName()` function that can be used to look up this value on demand.  Note that the `getPortalFirebaseJWTUrl` function is used for getting JWTs both for the main report as well as JWTs for interactives like Vortex. So it provides a way to override the firebaseApp. Also note that the problem this change is solving wasn't seen yet, because the default firebaseAppName matches what we were setting in the URL parameter.

## use a `portal-report` client id
When OAuth2 is used a client id needs to be sent to the portal, so it can look up the registered redirect urls to see if this is a legitimate request. The code was using a placeholder client id, now it is set to `portal-report`. I looked at the ways this client id was configured in our other SPAs. They all hardcoded the client id into the code, so I'm following that approach here too.

## Code coverage
The remaining uncovered code is around Firestore auth. It isn't easy to test. If we used the firebase emulator we could test it. But it doesn't seem worth introducing that in this PR.