### PR TITLE
Adds ability to show fake activity data with query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Demo: http://portal-report.concord.org/version/v3.0.0/
 
 Check recent git tags to open the most recent version.
 
-It expects two URL params: `reportUrl` and `token`. If they are not provided, it will use fake data, so it's easy to work on some features without connecting to the real Portal instance.
+It expects two URL params: `reportUrl` and `token`. If they are not provided, it will use fake sequence data, so it's easy to work on some features without connecting to the real Portal instance. If URL param `resourceType=activity` is provided, it will use fake activity data.
 
 At this time the portal report data can be presented in report view or in dashboard view. By default the report view is shown. Add the URL parameter `dashboard=true` (or any value other than "false") to show the tabular dashboard view. Add the URL parameter `portal-dashboard=true` (or any value other than "false") to show the updated and redesigned portal dashboard view.
 

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -7,228 +7,248 @@ import {
   getActivityData,
   getPageData,
   getActivityQuestionData
- } from "../utils";
+} from "../utils";
 
-context("Portal Report Smoke Test", () => {
+context("Portal Report Sequence Smoke Test", () => {
 
-    //const dashboard = new Dashboard;
+  //const dashboard = new Dashboard;
 
-    // It might be good to have an afterEach:
-    // firebase.firestore().terminate();
-    // firebase.firestore().clearPersistence();
-    // However it seems firestore is clearing any cached information on each test
-    // run, so this doesn't seem necessary.
+  // It might be good to have an afterEach:
+  // firebase.firestore().terminate();
+  // firebase.firestore().clearPersistence();
+  // However it seems firestore is clearing any cached information on each test
+  // run, so this doesn't seem necessary.
 
-    beforeEach(() => {
+  beforeEach(() => {
+    cy.visit(`/?token=12345`);
+    cy.fixture("sequence-structure.json").as("sequenceData");
+    cy.fixture("small-class-data.json").as("classData");
+    cy.fixture("answers.json").as("answerData");
+  });
 
-        cy.visit(`/?token=12345`);
-        cy.fixture("sequence-structure.json").as("sequenceData");
-        cy.fixture("small-class-data.json").as("classData");
-        cy.fixture("answers.json").as("answerData");
+  const header = new Header();
+  const body = new ReportBody();
+  const feedback = new Feedback();
+
+  context("Header components", () => {
+    it("Verifies the logo appears correctly", () => {
+      header.getLogo().should("exist").and("have.length", 1).and("be.visible");
+    });
+  });
+
+  context("Module Details", () => {
+    it("Verifies sequence name", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+        const moduleName = sequenceData.name;
+        body.getModuleName().should("be.visible").and("contain", moduleName);
+      });
+    });
+  });
+
+  context("Activity Level", () => {
+    const activityIndex = 0;
+
+    it("Verifies activity Name", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+        const activityName = getActivityData(sequenceData)[activityIndex].name;
+        cy.get(".activity").eq(activityIndex).should("be.visible").and("contain", activityName);
+      });
     });
 
-    const header = new Header();
-    const body = new ReportBody();
-    const feedback = new Feedback();
-
-    context("Header components", () => {
-        it("Verifies the logo appears correctly", () => {
-            header.getLogo().should("exist").and("have.length", 1).and("be.visible");
-        });
+    it("Checks Provide overall feedback button", () => {
+      body.getProvideOverallFeedback(activityIndex).should("be.visible").and("contain", "overall").click({ force: true });
+      cy.get(".feedback-panel").should("exist").and("be.visible");
+      cy.get(".footer").find("a").click({ force: true });
     });
 
-    context("Module Details", () => {
-        it("Verifies sequence name", () => {
-            cy.get("@sequenceData").then((sequenceData) => {
-                const moduleName = sequenceData.name;
-                body.getModuleName().should("be.visible").and("contain", moduleName);
-            });
-        });
+    it('handles MC questions without choices', () => {
+      body.openAnswersForQuestion('question-multiple_choice_without_choices');
+      cy.get('.answers-table').should('be.visible');
+      cy.get('.answers-table').should('contain', '[the selected choice has been deleted by question author]');
     });
+  });
 
-    context("Activity Level", () => {
-        const activityIndex = 0;
+  context("Portal Report Settings", () => {
+    const activityIndex = 0;
+    const questionIndex = 0;
 
-        it("Verifies activity Name", () => {
-            cy.get("@sequenceData").then((sequenceData) => {
-                const activityName = getActivityData(sequenceData)[activityIndex].name;
-                cy.get(".activity").eq(activityIndex).should("be.visible").and("contain", activityName);
-            });
-        });
-
-        it("Checks Provide overall feedback button", () => {
-            body.getProvideOverallFeedback(activityIndex).should("be.visible").and("contain", "overall").click({ force: true });
-            cy.get(".feedback-panel").should("exist").and("be.visible");
-            cy.get(".footer").find("a").click({ force: true });
-        });
-
-        it('handles MC questions without choices', () => {
-            body.openAnswersForQuestion('question-multiple_choice_without_choices');
-            cy.get('.answers-table').should('be.visible');
-            cy.get('.answers-table').should('contain', '[the selected choice has been deleted by question author]');
-        });
-    });
-
-    context("Portal Report Settings", () => {
-        const activityIndex = 0;
-        const questionIndex = 0;
-
-        it("Selects questions and shows selected (Activity 1)", () => {
-            cy.get("@sequenceData").then((sequenceData) => {
-                let pageData = getPageData(getActivityData(sequenceData)[activityIndex]);
-                let checkboxCount = 0;
-                let questionData;
-                // Get unhidden report, for each page check each question header for checkbox then check
-                for (let i = 0; i < pageData.length; i++) {
-                    questionData = getPageQuestionData(pageData[i]);
-                    for (let j = 0; j < questionData.length; j++) {
-                        header.getCheckbox(checkboxCount).check().should("be.checked");
-                        checkboxCount++;
-                    }
-                }
-                header.getShowSelectedButton().should("be.visible").click({ force: true });
-            });
-            body.getActivities().eq(activityIndex).should("not.have.class", "hidden");
-            body.getActivities().eq(activityIndex + 1).should("have.class", "hidden");
-        });
-
-        function checkStudentNames(students, contains) {
-          students.forEach(student => {
-            body.checkForStudentNames(contains, student.first_name);
-          });
+    it("Selects questions and shows selected (Activity 1)", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+        let pageData = getPageData(getActivityData(sequenceData)[activityIndex]);
+        let checkboxCount = 0;
+        let questionData;
+        // Get unhidden report, for each page check each question header for checkbox then check
+        for (let i = 0; i < pageData.length; i++) {
+          questionData = getPageQuestionData(pageData[i]);
+          for (let j = 0; j < questionData.length; j++) {
+            header.getCheckbox(checkboxCount).check().should("be.checked");
+            checkboxCount++;
+          }
         }
-
-        it("Shows/Hides student names", () => { // Add into context
-            cy.get("@classData").then((classData) => {
-                const students = classData.students;
-
-                body.getResponseTable().should("not.exist");
-                body.getActivities().eq(activityIndex).within(() => {
-                    body.getShowResponses(questionIndex).should("exist").and("be.visible").click({ force: true });
-                });
-                body.getResponseTable().should("exist").and("be.visible");
-                checkStudentNames(students, true);
-                header.getHideShowNames().should("be.visible").click({ force: true });
-                checkStudentNames(students, false);
-            });
-        });
-
-        // This test looks incomplete
-        it.skip("Shows activity 1 responses for students with answers", () => {
-            cy.get("@sequenceData").then((sequenceData) => {
-                let activityData = getActivityData(sequenceData);
-
-                cy.get("@answerData").then((answerData) => {
-                    let pages;
-                    let questions;
-                    let answers = answerData;
-
-                    let currentActivity;
-                    let currentPage;
-                    let currentQuestion;
-
-                    for (let i = 0; i <= activityData.length; i++) {
-                        currentActivity = activityData[i];
-                        pages = getPageData(currentActivity);
-
-                        for (let j = 0; j <= pages.length; j++){
-                            currentPage = pages[j];
-                            questions = getPageQuestionData(currentPage);
-
-                            for (let k = 0; k < questions.length; k++) {
-                                currentQuestion = questions[k];
-                            }
-                        }
-                    }
-                    // eslint-disable-next-line no-undef
-                    body.getActivities().should("have.length", activityNum);
-                    body.getShowResponses(questionIndex).should("be.visible").click({ force: true });
-                    /**
-                     * i = 1
-                     * cy.get the sequence data
-                     * for each i
-                     * get question_number i
-                     */
-                    body.getHideResponses(questionIndex).click({ force: true });
-                    cy.wait(10000);
-                });
-            });
-        });
+        header.getShowSelectedButton().should("be.visible").click({ force: true });
+      });
+      body.getActivities().eq(activityIndex).should("not.have.class", "hidden");
+      body.getActivities().eq(activityIndex + 1).should("have.class", "hidden");
     });
 
-    context("Activity Level Feedback", () => {
-        const activityIndex = 0;
-        const studentIndex = 2;
-        const writtenFeedbackText = "Testing Testing 1 2 3...";
-        const studentScore = "8";
+    function checkStudentNames(students, contains) {
+      students.forEach(student => {
+        body.checkForStudentNames(contains, student.first_name);
+      });
+    }
 
-        it("checks for activity name in Feedback", () => {
-            cy.get("@sequenceData").then((sequenceData) => {
-                const activityName = getActivityData(sequenceData)[activityIndex].name;
+    it("Shows/Hides student names", () => { // Add into context
+      cy.get("@classData").then((classData) => {
+        const students = classData.students;
 
-                body.pullUpFeedbackForActivity(activityIndex);
-                feedback.getActivityHeader().should("be.visible").and("contain", activityName);
-            });
+        body.getResponseTable().should("not.exist");
+        body.getActivities().eq(activityIndex).within(() => {
+          body.getShowResponses(questionIndex).should("exist").and("be.visible").click({ force: true });
         });
-
-        //Update this to use better data for student counts
-        it("checks student response status counts", () => {
-            cy.get("@sequenceData").then((sequenceData) => {
-                body.pullUpFeedbackForActivity(activityIndex);
-                feedback.getGiveScoreCheckbox().click();
-                feedback.getScoredStudentsCount().should("be.visible").and("contain", "0");
-                feedback.getStudentWaitingForFeedbackCount().should("be.visible").and("contain", "4");
-                feedback.getNoAnswerStudentsCount().should("be.visible").and("contain", "2");
-            });
-        });
-
-        it("check scoring options", () => {
-            body.pullUpFeedbackForActivity(activityIndex);
-            feedback.getRubricCheckbox().should("exist").and("be.visible").and("not.be.checked").check();
-            feedback.getGiveScoreCheckbox().should("exist").and("be.visible").and("not.be.checked");
-            feedback.getWrittenFeedbackCheckbox().should("exist").and("be.visible").and("not.be.checked");
-            feedback.getManualScoringOption().should("exist").and("be.visible").and("not.be.checked");
-            cy.root();
-            feedback.getAutoScoringOption().should("exist").and("be.visible").and("not.be.checked");
-            feedback.getRubricScoringOption().should("exist").and("be.visible").and("not.be.checked");
-        });
-
-        it("checks toggle for show all students", () => {
-            cy.get("@classData").then((classData) => {
-                let studentTotal = classData.students.length;
-
-                body.pullUpFeedbackForActivity(activityIndex);
-                feedback.getGiveScoreCheckbox().click();
-                feedback.getShowAllStudentsToggle().should("not.be.checked");
-                feedback.getShowAllStudentsToggle().click();
-                cy.get(".feedback-row").should("have.length", studentTotal);
-            });
-        });
-
-        it("selects a student from list and provides written feedback and score", () => {
-            body.pullUpFeedbackForActivity(activityIndex);
-            feedback.getWrittenFeedbackCheckbox().click();
-            feedback.getGiveScoreCheckbox().click();
-            feedback.getShowAllStudentsToggle().click();
-            feedback.getStudentSelection().select((studentIndex + 1).toString());
-            feedback.getWrittenFeedbackTextarea(studentIndex).focus();
-            feedback.getWrittenFeedbackTextarea(studentIndex).type(writtenFeedbackText);
-            feedback.getStudentScoreInput(studentIndex).clear();
-            feedback.getStudentScoreInput(studentIndex).type(studentScore);
-            feedback.getCompleteStudentFeedback(studentIndex).click();
-        });
-
-        // This will open a new tab with a view of this student's work
-        it("Checks student report for feedback", () => {
-            body.pullUpFeedbackForActivity(activityIndex);
-            feedback.getGiveScoreCheckbox().click();
-            feedback.getShowAllStudentsToggle().click();
-            feedback.getStudentWorkLink(studentIndex).should("be.visible")
-              .then(($studentWorkLink) => {
-                // remove target=_blank so the link opens in the same window
-                $studentWorkLink.attr("target", null);
-              }).click();
-            cy.contains("Amy Galloway");
-        });
+        body.getResponseTable().should("exist").and("be.visible");
+        checkStudentNames(students, true);
+        header.getHideShowNames().should("be.visible").click({ force: true });
+        checkStudentNames(students, false);
+      });
     });
+
+    // This test looks incomplete
+    it.skip("Shows activity 1 responses for students with answers", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+        let activityData = getActivityData(sequenceData);
+
+        cy.get("@answerData").then((answerData) => {
+          let pages;
+          let questions;
+          let answers = answerData;
+
+          let currentActivity;
+          let currentPage;
+          let currentQuestion;
+
+          for (let i = 0; i <= activityData.length; i++) {
+            currentActivity = activityData[i];
+            pages = getPageData(currentActivity);
+
+            for (let j = 0; j <= pages.length; j++) {
+              currentPage = pages[j];
+              questions = getPageQuestionData(currentPage);
+
+              for (let k = 0; k < questions.length; k++) {
+                currentQuestion = questions[k];
+              }
+            }
+          }
+          // eslint-disable-next-line no-undef
+          body.getActivities().should("have.length", activityNum);
+          body.getShowResponses(questionIndex).should("be.visible").click({ force: true });
+          /**
+           * i = 1
+           * cy.get the sequence data
+           * for each i
+           * get question_number i
+           */
+          body.getHideResponses(questionIndex).click({ force: true });
+          cy.wait(10000);
+        });
+      });
+    });
+  });
+
+  context("Activity Level Feedback", () => {
+    const activityIndex = 0;
+    const studentIndex = 2;
+    const writtenFeedbackText = "Testing Testing 1 2 3...";
+    const studentScore = "8";
+
+    it("checks for activity name in Feedback", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+        const activityName = getActivityData(sequenceData)[activityIndex].name;
+
+        body.pullUpFeedbackForActivity(activityIndex);
+        feedback.getActivityHeader().should("be.visible").and("contain", activityName);
+      });
+    });
+
+    //Update this to use better data for student counts
+    it("checks student response status counts", () => {
+      cy.get("@sequenceData").then((sequenceData) => {
+        body.pullUpFeedbackForActivity(activityIndex);
+        feedback.getGiveScoreCheckbox().click();
+        feedback.getScoredStudentsCount().should("be.visible").and("contain", "0");
+        feedback.getStudentWaitingForFeedbackCount().should("be.visible").and("contain", "4");
+        feedback.getNoAnswerStudentsCount().should("be.visible").and("contain", "2");
+      });
+    });
+
+    it("check scoring options", () => {
+      body.pullUpFeedbackForActivity(activityIndex);
+      feedback.getRubricCheckbox().should("exist").and("be.visible").and("not.be.checked").check();
+      feedback.getGiveScoreCheckbox().should("exist").and("be.visible").and("not.be.checked");
+      feedback.getWrittenFeedbackCheckbox().should("exist").and("be.visible").and("not.be.checked");
+      feedback.getManualScoringOption().should("exist").and("be.visible").and("not.be.checked");
+      cy.root();
+      feedback.getAutoScoringOption().should("exist").and("be.visible").and("not.be.checked");
+      feedback.getRubricScoringOption().should("exist").and("be.visible").and("not.be.checked");
+    });
+
+    it("checks toggle for show all students", () => {
+      cy.get("@classData").then((classData) => {
+        let studentTotal = classData.students.length;
+
+        body.pullUpFeedbackForActivity(activityIndex);
+        feedback.getGiveScoreCheckbox().click();
+        feedback.getShowAllStudentsToggle().should("not.be.checked");
+        feedback.getShowAllStudentsToggle().click();
+        cy.get(".feedback-row").should("have.length", studentTotal);
+      });
+    });
+
+    it("selects a student from list and provides written feedback and score", () => {
+      body.pullUpFeedbackForActivity(activityIndex);
+      feedback.getWrittenFeedbackCheckbox().click();
+      feedback.getGiveScoreCheckbox().click();
+      feedback.getShowAllStudentsToggle().click();
+      feedback.getStudentSelection().select((studentIndex + 1).toString());
+      feedback.getWrittenFeedbackTextarea(studentIndex).focus();
+      feedback.getWrittenFeedbackTextarea(studentIndex).type(writtenFeedbackText);
+      feedback.getStudentScoreInput(studentIndex).clear();
+      feedback.getStudentScoreInput(studentIndex).type(studentScore);
+      feedback.getCompleteStudentFeedback(studentIndex).click();
+    });
+
+    // This will open a new tab with a view of this student's work
+    it("Checks student report for feedback", () => {
+      body.pullUpFeedbackForActivity(activityIndex);
+      feedback.getGiveScoreCheckbox().click();
+      feedback.getShowAllStudentsToggle().click();
+      feedback.getStudentWorkLink(studentIndex).should("be.visible")
+        .then(($studentWorkLink) => {
+          // remove target=_blank so the link opens in the same window
+          $studentWorkLink.attr("target", null);
+        }).click();
+      cy.contains("Amy Galloway");
+    });
+  });
+});
+
+context("Portal Report Activity Smoke Test", () => {
+  beforeEach(() => {
+    cy.visit(`/?resourceType=activity`);
+    cy.fixture("activity-structure.json").as("activityData");
+    cy.fixture("small-class-data.json").as("classData");
+    cy.fixture("activity-answers.json").as("answerData");
+  });
+
+  const header = new Header();
+  const body = new ReportBody();
+
+  describe("Report shows activity data", () => {
+    it("verifies activity title", () => {
+      cy.get("@activityData").then((activityData) => {
+        const activityName = activityData.name;
+        body.getActivityName(0).should("be.visible").and("contain", activityName);
+      });
+    });
+  });
 });

--- a/cypress/support/elements/portal-report/report-body.js
+++ b/cypress/support/elements/portal-report/report-body.js
@@ -11,7 +11,7 @@ class ReportBody {
         return cy.get(".sticky-inner-wrapper > h2").eq(0);
     }
     getActivityName(idx) {
-        return cy.get(".activity").children("first").eq(idx);
+        return cy.get(".activity").first().eq(idx);
     }
     //
     //Activity Level

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -1,8 +1,8 @@
 import { firestoreInitialized } from "../db";
 import fakeSequenceStructure from "../data/sequence-structure.json";
-// import fakeActivityStructure from "../data/activity-structure.json";
+import fakeActivityStructure from "../data/activity-structure.json";
 import fakeAnswers from "../data/answers.json";
-// import fakeAnswers from "../data/average-class-activity-answers.json";
+import fakeActivityAnswers from "../data/activity-answers.json";
 import { AnyAction, Dispatch } from "redux";
 import {
   IPortalRawData,
@@ -122,19 +122,27 @@ function _receivePortalData(db: firebase.firestore.Firestore,
   }
   const source = rawPortalData.sourceKey;
   if (source === "fake.authoring.system") { // defined in data/offering-data.json
-    // Use fake data.
-    dispatch({
-      type: RECEIVE_RESOURCE_STRUCTURE,
-      response: fakeSequenceStructure,
-    });
-    // dispatch({
-    //   type: RECEIVE_RESOURCE_STRUCTURE,
-    //   response: fakeActivityStructure,
-    // });
-    dispatch({
-      type: RECEIVE_ANSWERS,
-      response: fakeAnswers,
-    });
+    // Use fake data. Default shows sequence fake resource and answer
+    // resourceType query param allows for switching to show fake activity resource and answer
+    if(urlStringParam(window.location.search, "resourceType")==="activity") {
+      dispatch({
+        type: RECEIVE_RESOURCE_STRUCTURE,
+        response: fakeActivityStructure,
+      });
+      dispatch({
+        type: RECEIVE_ANSWERS,
+        response: fakeActivityAnswers,
+      });
+    } else {
+      dispatch({
+        type: RECEIVE_RESOURCE_STRUCTURE,
+        response: fakeSequenceStructure,
+      });
+      dispatch({
+        type: RECEIVE_ANSWERS,
+        response: fakeAnswers,
+      });
+    }
   } else {
     watchResourceStructure(db, source, resourceUrl, dispatch);
 

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -124,7 +124,7 @@ function _receivePortalData(db: firebase.firestore.Firestore,
   if (source === "fake.authoring.system") { // defined in data/offering-data.json
     // Use fake data. Default shows sequence fake resource and answer
     // resourceType query param allows for switching to show fake activity resource and answer
-    if(urlStringParam(window.location.search, "resourceType")==="activity") {
+    if(urlStringParam(window.location.search, "resourceType") === "activity") {
       dispatch({
         type: RECEIVE_RESOURCE_STRUCTURE,
         response: fakeActivityStructure,


### PR DESCRIPTION
User can now add `resourceType=activity` query param to show activity resource and answer. It defaults to showing sequence data if query param is not present.
This should make it easier to switch between fake sequence and fake activity data without having to change it in code.