### PR TITLE
fix several issues with the api error handling

### DIFF
--- a/cypress/integration/api-error.spec.js
+++ b/cypress/integration/api-error.spec.js
@@ -1,10 +1,19 @@
 context("Test api error", () => {
   context("when an invalid offering url is used", () => {
     before(() => {
-      cy.visit("/?offering=http://example.com");
+      cy.visit("/?token=1234&offering=http://example.com");
     });
     it('shows an error message to user', () => {
       cy.contains("Connection to server failed");
+    });
+  });
+  context("when the server returns an error status code", () => {
+    before(() => {
+      cy.intercept(/[^=]\/fakeOfferingPath/, {statusCode: 500, body: "Cypress Fake Error"})
+      cy.visit("/?token=1234&offering=/fakeOfferingPath");
+    });
+    it('shows an error message to user', () => {
+      cy.contains("Cypress Fake Error");
     });
   });
 });

--- a/cypress/integration/geode-dashboard-smoke-test.spec.js
+++ b/cypress/integration/geode-dashboard-smoke-test.spec.js
@@ -139,8 +139,7 @@ context("Geode Dashboard Smoke Test", () => {
                 }
 
                 dashboard.getExpandedMCAnswerDetails()
-                    .should("not.be.visible")
-                    .and("not.exist");
+                    .should("not.exist");
 
                 // This is assuming the 2nd question is a multiple choice question
                 dashboard.getExpandQuestionDetails().eq(1)
@@ -154,7 +153,7 @@ context("Geode Dashboard Smoke Test", () => {
                     .should("exist")
                     .click({ force: true });
                 dashboard.getExpandedQuestionPanel()
-                    .should("not.be.visible");
+                    .should("not.exist");
             });
         });
         it("can expand activities to show questions", () => {
@@ -170,7 +169,7 @@ context("Geode Dashboard Smoke Test", () => {
                 });
             });
             dashboard.getActivityQuestionsText()
-                .should("not.be.visible");
+                .should("not.exist");
             dashboard.getActivityQuestionToggle().eq(0)
                 .click({ force: true });
             dashboard.getActivityQuestionsText()
@@ -178,7 +177,7 @@ context("Geode Dashboard Smoke Test", () => {
             dashboard.getActivityQuestionsText().eq(0)
                 .click({ force: true });
             dashboard.getActivityQuestionsText()
-                .should("not.be.visible");
+                .should("not.exist");
         });
 
         // it.only('Checks for one students data', () => {
@@ -255,8 +254,7 @@ context("Geode Dashboard Smoke Test", () => {
                     .and("contain", "No response");
 
                 dashboard.getExpandedMCAnswers()
-                    .should("not.exist")
-                    .and("not.be.visible");
+                    .should("not.exist");
                 dashboard.getShowHideResponse()
                     .should("exist")
                     .click({ force: true })
@@ -270,14 +268,13 @@ context("Geode Dashboard Smoke Test", () => {
                 .should("exist")
                 .click({ force: true });
             dashboard.getExpandedQuestionPanel()
-                .should("not.be.visible");
+                .should("not.exist");
         });
         it("hide responses", () => {
             dashboard.getOpenCloseStudents()
                 .click({ force: true });
             dashboard.getExpandedMCAnswers()
-                .should("not.be.visible")
-                .and("not.exist");
+                .should("not.exist");
             dashboard.getExpandQuestionDetails().eq(1)
                 .click({ force: true });
             dashboard.getShowHideResponse()
@@ -303,8 +300,7 @@ context("Geode Dashboard Smoke Test", () => {
                 .and("contain", "b")
                 .and("contain", "No response");
             dashboard.getExpandedMCAnswers()
-                .should("not.exist")
-                .and("not.be.visible");
+                .should("not.exist");
             dashboard.getShowHideResponse()
                 .should("exist")
                 .click({ force: true });
@@ -315,7 +311,7 @@ context("Geode Dashboard Smoke Test", () => {
                 .should("exist")
                 .click({ force: true });
             dashboard.getExpandedQuestionPanel()
-                .should("not.be.visible");
+                .should("not.exist");
         });
 
     });

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -5,7 +5,7 @@ context("Portal Dashboard Question Details Panel", () => {
 
   describe('opening and closing the question details panel', () => {
     it('verify we can click to open a question and see the question tab expanded', () => {
-      cy.get('[data-cy=question-overlay-header]').should('not.be.visible');
+      cy.get('[data-cy=question-overlay-header]').should('not.exist');
       cy.get('[data-cy=collapsed-activity-button]').first().click();
       cy.get('[data-cy=activity-question-button]').first().click();
       cy.get('[data-cy=question-overlay-header]').should('be.visible');
@@ -21,7 +21,7 @@ context("Portal Dashboard Question Details Panel", () => {
 
     it('verify we can click to close the question details panel', () => {
       cy.get('[data-cy=question-overlay-header-button]').first().click();
-      cy.get('[data-cy=question-overlay-header]').should('not.be.visible');
+      cy.get('[data-cy=question-overlay-header]').should('not.exist');
     });
   });
 
@@ -105,7 +105,7 @@ context("Portal Dashboard Question Details Panel", () => {
     });
     it('verify show/hide button behaves correctly', () => {
       cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
-      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('not.be.visible');
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('not.exist');
       cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
       cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-title]').should('be.visible');
       cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
@@ -32,7 +32,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=spotlight-toggle').should('be.visible').click();
       cy.get('[data-cy=spotlight-dialog]').should('be.visible');
       cy.get('[data-cy=spotlight-dialog-close-button]').should('be.visible').click();
-      cy.get('[data-cy=spotlight-dialog]').should('not.be.visible');
+      cy.get('[data-cy=spotlight-dialog]').should('not.exist');
     });
   });
   context('Activity nav area', ()=>{
@@ -150,7 +150,7 @@ context("Portal Dashboard Question Details Panel", () => {
       });
       it('verify close spotlight',()=>{
         cy.get('[data-cy=close-spotlight-dialog-button]').should('be.visible').click();
-        cy.get('[data-cy=spotlight-students-list-dialog]').should('not.be.visible');
+        cy.get('[data-cy=spotlight-students-list-dialog]').should('not.exist');
       });
     });
     //TODO add tests for filtering when implemented

--- a/cypress/support/elements/portal-report/feedback.js
+++ b/cypress/support/elements/portal-report/feedback.js
@@ -59,14 +59,14 @@ class Feedback {
         return cy.get(".feedback-row").eq(stuIdx).find("textarea");
     }
     getStudentScoreInput(stuIdx) {
-        return cy.get(".feedback-row").eq(stuIdx).within(() => {
-            cy.get(".score").find("input");
-        });
+        return cy.get(".feedback-row").eq(stuIdx)
+            .find(".score")
+            .find("input");
     }
     getCompleteStudentFeedback(stuIdx) {
-        return cy.get(".feedback-row").eq(stuIdx).within(() => {
-            cy.get(".feedback-complete").find("input");
-        });
+        return cy.get(".feedback-row").eq(stuIdx)
+            .find(".feedback-complete")
+            .find("input");
     }
 
     getStudentsAwaitingFeedbackCount(answersData) {

--- a/cypress/support/elements/portal-report/header.js
+++ b/cypress/support/elements/portal-report/header.js
@@ -27,10 +27,11 @@ class Header {
 
     getCheckbox(i) {
         return cy.get(".report-content")
-            .not(".hidden").within(() => {
-                cy.get(".question-header").eq(i)
-                    .children().eq(0);
-            });
+            .not(".hidden")
+            .find(".question-header")
+            .eq(i)
+            .children()
+            .eq(0);
     }
     getLogo() {
         return cy.get(".logo");

--- a/cypress/support/elements/portal-report/report-body.js
+++ b/cypress/support/elements/portal-report/report-body.js
@@ -17,9 +17,8 @@ class ReportBody {
     //Activity Level
     //
     getProvideOverallFeedback(aIdx) {
-        return cy.get(".activity").eq(aIdx).within(() => {
-            getByCypressTag("feedbackButton").eq(0);
-        });
+        return cy.get(".activity").eq(aIdx)
+          .find("[data-cy=feedbackButton]:contains('overall')");
     }
     getActivities() {
         return cy.get('div [data-cy = "activity"]');
@@ -41,7 +40,7 @@ class ReportBody {
         return getByCypressTag("question-link");
     }
     getQuestionTitle(idx) {
-        return cy.get(".question").eq(idx).within(() => { cy.get("a").find("span"); });
+        return cy.get(".question").eq(idx).find("a").find("span");
     }
     getProvideFeedback(aIdx, qIdx) {
         return getByCypressTag("feedback");

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -17,8 +17,6 @@ function handleApiError(actionType, apiType, errorAction, next, error) {
   // object as well as the stack trace of the console state. Both can be useful
   console.error(`error calling API: ${apiType} during action: ${actionType} (error below)\n`, error);
   if ((error.name === "APIError") && errorAction) {
-    // CHECKME: is this valid middleware behavior? we are calling next and
-    // not returning it
     next(errorAction(error.response));
     return;
   }
@@ -30,8 +28,6 @@ function handleApiError(actionType, apiType, errorAction, next, error) {
       status: 599,
       statusText: error.message,
     };
-    // CHECKME: is this valid middleware behavior? we are calling next and
-    // not returning its result
     next(errorAction(response));
     return;
   }
@@ -56,8 +52,6 @@ export default store => next => action => {
     } catch (error) {
       // Some callApi functions throw errors during setup, before they
       // return a promise this catch here handles that case.
-      // NOTE: if this an unhandled exception it will stop the `next(action)`
-      // from being called
       handleApiError(action.type, type, errorAction, next, error);
     }
   }

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -11,7 +11,11 @@ import { getFirestore } from "./db";
 // In some cases callApi returns a promise which might throw an error when it is
 // being resolved. In other cases callApi will throw an error directly before it
 // returns the promise
-function handleApiError(actionType, apiType, errorAction, next, error) {
+function handleApiError(action, next, error) {
+  const actionType = action.type;
+  const apiType = action.callAPI.type;
+  const errorAction = action.callAPI.errorAction;
+
   // Log this error to the console in addtion to dispatching the errorAction
   // In chrome this log message includes both the stack trace from the error
   // object as well as the stack trace of the console state. Both can be useful
@@ -47,12 +51,12 @@ export default store => next => action => {
         // The order here is important. In some cases the successAction causes its
         // own error, we don't want to handle that here because we'd incorrectly
         // be reporting the action type and api type
-        .catch(error => handleApiError(action.type, type, errorAction, next, error))
+        .catch(error => handleApiError(action, next, error))
         .then(response => successAction && next(successAction(response)));
     } catch (error) {
       // Some callApi functions throw errors during setup, before they
       // return a promise this catch here handles that case.
-      handleApiError(action.type, type, errorAction, next, error);
+      handleApiError(action, next, error);
     }
   }
   return next(action);

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -44,7 +44,7 @@ function handleApiError(action, next, error) {
 export default store => next => action => {
   if (action.callAPI) {
     const state = store.getState();
-    const { type, data, successAction, errorAction} = action.callAPI;
+    const { type, data, successAction } = action.callAPI;
     try {
       callApi(type, data, state)
         // Try to catch errors from the promise returned by callApi
@@ -55,7 +55,7 @@ export default store => next => action => {
         .then(response => successAction && next(successAction(response)));
     } catch (error) {
       // Some callApi functions throw errors during setup, before they
-      // return a promise this catch here handles that case.
+      // return a promise. This catch here handles that case.
       handleApiError(action, next, error);
     }
   }

--- a/js/api-middleware.js
+++ b/js/api-middleware.js
@@ -4,7 +4,6 @@ import {
   updateFeedbackSettings,
   updateQuestionFeedbacks,
   updateActivityFeedbacks,
-  APIError,
   fetchRubric
 } from "./api";
 import { getFirestore } from "./db";

--- a/js/api.ts
+++ b/js/api.ts
@@ -331,7 +331,7 @@ export function feedbackSettingsFirestorePath(sourceKey: string, instanceParams?
 // parameters. Currently this is not used with a successFunction
 export function updateFeedbackSettings(data: any, state: IStateReportPartial) {
   const { settings } = data;
-  const promises = [];
+  const promises: Promise<any>[] = [];
 
   if (settings.activitySettings) {
     const { activityId, activityIndex } = data;

--- a/js/api.ts
+++ b/js/api.ts
@@ -297,8 +297,8 @@ export function updateReportSettings(update: any, state: ILTIPartial) {
 // thrown during the getAuthHeader.
 export async function updateReportSettingsInPortal(data: any) {
   const reportUrl = gePortalReportAPIUrl();
-  const authHeader = getAuthHeader();
   if (reportUrl) {
+    const authHeader = getAuthHeader();
     return fetch(reportUrl, {
       method: "put",
       headers: {

--- a/js/components/report/data-fetch-error.js
+++ b/js/components/report/data-fetch-error.js
@@ -8,14 +8,14 @@ export default class DataFetchError extends PureComponent {
     this.state = {};
   }
 
-  // Inorder to reuse updateBodyText we can't call it in the constructor because
+  // In order to reuse updateBodyText we can't call it in the constructor because
   // we can't call setState until the component has been mounted
   componentDidMount() {
     this.updateBodyText();
   }
 
   componentDidUpdate(prevProps) {
-    if(prevProps.error !== this.props.error) {
+    if (prevProps.error !== this.props.error) {
       this.updateBodyText();
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4446,18 +4446,18 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -7365,9 +7365,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
     "@types/sizzle": {
@@ -7964,9 +7964,9 @@
       "dev": true
     },
     "arch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
       "dev": true
     },
     "archy": {
@@ -10715,9 +10715,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.1.0.tgz",
-      "integrity": "sha512-craPRO+Viu4268s7eBvX5VJW8aBYcAQT+EwEccQSMY+eH1ZPwnxIgyDlmMWvxLVX9SkWxOlZbEycPyzanQScBQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.2.1.tgz",
+      "integrity": "sha512-OYkSgzA4J4Q7eMjZvNf5qWpBLR4RXrkqjL3UZ1UzGGLAskO0nFTi/RomNTG6TKvL3Zp4tw4zFY1gp5MtmkCZrA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -10732,7 +10732,7 @@
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-table3": "~0.6.0",
-        "commander": "^4.1.1",
+        "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "debug": "^4.1.1",
         "eventemitter2": "^6.4.2",
@@ -10750,10 +10750,10 @@
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
         "ospath": "^1.2.2",
-        "pretty-bytes": "^5.3.0",
+        "pretty-bytes": "^5.4.1",
         "ramda": "~0.26.1",
         "request-progress": "^3.0.0",
-        "supports-color": "^7.1.0",
+        "supports-color": "^7.2.0",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "url": "^0.11.0",
@@ -10761,12 +10761,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -10796,9 +10795,9 @@
           "dev": true
         },
         "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
           "dev": true
         },
         "cross-spawn": {
@@ -10813,18 +10812,18 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "execa": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -10869,13 +10868,21 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
           }
         },
         "lodash": {
@@ -13910,12 +13917,20 @@
       }
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "1.3.7"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+          "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+          "dev": true
+        }
       }
     },
     "global-modules": {
@@ -18203,12 +18218,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -18715,9 +18729,9 @@
       }
     },
     "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
     },
     "moo": {
@@ -20250,9 +20264,9 @@
       "dev": true
     },
     "pretty-bytes": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+      "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "autoprefixer": "^9.7.6",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.3",
-    "cypress": "^5.1.0",
+    "cypress": "^6.2.0",
     "cypress-commands": "^1.1.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",

--- a/test/components/report/data-fetch-error_spec.js
+++ b/test/components/report/data-fetch-error_spec.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { mount } from "enzyme";
+import DataFetchError from "../../../js/components/report/data-fetch-error";
+
+describe("<DataFetchError />", () => {
+  let dataFetchError;
+
+  describe("when the error has a plain text body", () => {
+    beforeEach(() => {
+      dataFetchError = mount(<DataFetchError
+        error={{title: "fake title", body: "fake error body"}}
+      />);
+    });
+
+    it("should render the text", () => {
+      expect(dataFetchError.text()).toEqual(expect.stringContaining("fake error body"));
+    });
+  });
+
+  describe("when the error has a url and no body", () => {
+    beforeEach(() => {
+      dataFetchError = mount(<DataFetchError
+        error={{title: "fake title", url: "http://example.com"}}
+      />);
+    });
+
+    it("should render the url", () => {
+      expect(dataFetchError.text()).toEqual(expect.stringContaining("URL: http://example.com"));
+    });
+  });
+
+  // <div>URL: {error.url}</div>
+  // <div>Status: {error.status}</div>
+  // <div>Status text: {error.statusText}</div>
+
+  // The data fetch error also supports an error which is the response from a fetch
+  // in this case the error.body is a ReadableStream. This is tested by
+  // cypress/integration/api-error.spec.js
+});


### PR DESCRIPTION
Runtime changes:
- callAPI now handles errors thrown during promise evaluation or when an api function throws an error before returning the promise.
- APIError now extends Error which provides stack traces at the location the error was generated. Extending Error can be problematic because it breaks instanceof checks. That happens due to transpiling. Several articles on this, here is one example: https://www.bennadel.com/blog/3226-experimenting-with-error-sub-classing-using-es5-and-typescript-2-1-5.htm
- to work around the instanceof check above, now the name property is used instead of instanceof to identify APIError objects.
- remove the re-throwing of the error since we are already printing it to the console. There might be edge
cases where some un handled error happens during the callAPI setup, which could stop the code if we threw it again. And maybe that would be good thing in some cases, but I don't think those edge cases are worth the confusion. In the general case the error will happen in a promise so there isn't a way to stop the code.
- update some api functions to be properly async so their errors can be caught using the standard promise.catch
approach.
- fix the DataFetchError component so it actually displays the content of error responses which have bodies.

Test changes:
- Update to Cypress 6.2
- Update cypress tests to support 6.2:
  - `should("not.be.visible")` fails in cypress 6 if the element doesn't exist
  - `cy.get("first").within(() => { cy.get("child of first") })` now yields `first` instead of `child of first`. This matches what the documentation has been saving for a long time: https://docs.cypress.io/api/commands/within.html#Yields but until recently within did not behave this way.  This was "fixed" in Cypress 5.4:  https://docs.cypress.io/guides/references/changelog.html#5-4-0:~:text=When%20a%20command%20is%20chained%20after%20.within()
Our code was assuming that within would return the last subject of the function passed to within. So those cases were changed to using a 'find' call instead.
- added tests for the different ways errors can be thrown in callApi
- added tests of the DataFetchError component
- added tests of the updateReportSettingsInPortal, this is the code path that was causing the issue which is why I got started on this error improvement PR.