### PR TITLE
fix local feedback testing

### DIFF
--- a/js/api.ts
+++ b/js/api.ts
@@ -295,8 +295,8 @@ export function updateReportSettings(update: any, state: ILTIPartial) {
 // It's necessary to keep the Portal progress table valid and updated.
 export function updateReportSettingsInPortal(data: any) {
   const reportUrl = gePortalReportAPIUrl();
-  const authHeader = getAuthHeader();
   if (reportUrl) {
+    const authHeader = getAuthHeader();
     return fetch(reportUrl, {
       method: "put",
       headers: {

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -86,7 +86,7 @@ describe("api helper", () => {
     beforeEach(() => {
     });
 
-    describe("when offering and token URL param is present", () => {
+    describe("when both offering and token URL params are present", () => {
       beforeEach(() => {
         window.history.replaceState({}, "Test", `/?token=abc&offering=${fakeOfferingUrl}`);
       });


### PR DESCRIPTION
this was causing problems when testing because we had no token in the url
so getAuthHeader was throwing an error

This can be tested with:
http://portal-report.concord.org/branch/fix-error-with-feedback/?enableFirestorePersistence=true

To track down this really simple change, I improved the error handling, and I put that in a different PR:
https://github.com/concord-consortium/portal-report/pull/286
