### PR TITLE
Add feedback review flags

### DIFF
--- a/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
@@ -29,7 +29,8 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
 
   const updateFeedback = () => {
     if (activityId && studentId && updateActivityFeedback && textareaRef.current?.value !== undefined) {
-      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value});
+      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value,
+                                                                    hasBeenReviewed: true});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/feedback-question-rows.tsx
+++ b/js/components/portal-dashboard/feedback/feedback-question-rows.tsx
@@ -66,6 +66,7 @@ export const FeedbackQuestionRows: React.FC<IProps> = (props) => {
           { answer &&
             <QuestionFeedbackTextarea
               key={currentQuestionId + currentStudentId + "textarea"}
+              answer={answer}
               answerId={answerId}
               feedback={feedback}
               updateQuestionFeedback={updateQuestionFeedback}

--- a/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
@@ -1,8 +1,11 @@
 import React, { useLayoutEffect, useRef, useState, useCallback } from "react";
 import { throttle } from "lodash";
+import { answerHash } from "../../../util/misc";
+import { Map } from "immutable";
 
 interface IProps {
   answerId: string;
+  answer: Map<string, any>;
   feedback: any;
   updateQuestionFeedback: (answerId: string, feedback: any) => void;
 }
@@ -27,7 +30,8 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
 
   const updateFeedback = () => {
     if (answerId && textareaRef.current?.value !== undefined) {
-      updateQuestionFeedback(answerId, {feedback: textareaRef.current?.value});
+      updateQuestionFeedback(answerId, {feedback: textareaRef.current?.value,
+                                        hasBeenReviewedForAnswerHash: answerHash(props.answer)});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/question-level-feedback-student-rows.tsx
+++ b/js/components/portal-dashboard/feedback/question-level-feedback-student-rows.tsx
@@ -57,6 +57,7 @@ export const QuestionLevelFeedbackStudentRows: React.FC<IProps> = (props) => {
           { answer &&
             <QuestionFeedbackTextarea
               key={currentQuestionId + studentId + "-textarea"}
+              answer={answer}
               answerId={answerId}
               feedback={feedback}
               updateQuestionFeedback={updateQuestionFeedback}


### PR DESCRIPTION
This PR adds the review flag when submitting feedback which allows us to determine if feedback has been submitted and it it needs to be updated by examining the feedback in the Redux state.  Although feedback was being submitted to the student, we we're marking these internal feedback flags.