### PR TITLE
Remove manual resize option for input fields.

### DIFF
--- a/css/portal-dashboard/feedback/feedback-rows.less
+++ b/css/portal-dashboard/feedback/feedback-rows.less
@@ -77,7 +77,7 @@
         min-height: 50px;
         outline: none;
         padding: 5px 10px 13px;
-        resize: vertical;
+        resize: none;
         width: calc(100% - 20px);
 
         &:focus {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176083561

[#176083561]

This removes the manual resize option for the input fields per the PT story note that says if manual resizing adds complexity, only use the dynamic, responsive option.