### PR TITLE
Fix bad regex in resource url parser

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -546,7 +546,7 @@ let loggingEnabled = parsedQuery.logging === "true";
 const debugLogging = parsedQuery.debugLogging === "true";
 
 export function setLoggingVars(resourceUrl: string, rawPortalData: IPortalRawData) {
-  const match = resourceUrl.match(/\/(activities|sequences)\/(\d)+/);
+  const match = resourceUrl.match(/\/(activities|sequences)\/(\d+)/);
   if (match) {
     const type = match[1] === "activities" ? "activity" : "sequence";
     loggingActivity = `${type}: ${match[2]}`;

--- a/test/actions/index_spec.js
+++ b/test/actions/index_spec.js
@@ -20,11 +20,11 @@ describe("actions/index", () => {
   describe("setLoggingVars", () => {
 
     it("handles activities", () => {
-      expect(setLoggingVars("http://example.com/activities/1", {}).loggingActivity).toBe("activity: 1");
+      expect(setLoggingVars("http://example.com/activities/100", {}).loggingActivity).toBe("activity: 100");
     });
 
     it("handles sequences", () => {
-      expect(setLoggingVars("http://example.com/sequences/2", {}).loggingActivity).toBe("sequence: 2");
+      expect(setLoggingVars("http://example.com/sequences/200", {}).loggingActivity).toBe("sequence: 200");
     });
 
     it("handles contextId", () => {


### PR DESCRIPTION
The regex was returning the last id digit instead of all the id digits.  This wasn't caught in the test coverage as the tests all used single digit ids.