### PR TITLE
Awaiting Feedback Refresh button state

### DIFF
--- a/css/portal-dashboard/response-details/popup-class-nav.less
+++ b/css/portal-dashboard/response-details/popup-class-nav.less
@@ -181,7 +181,7 @@
 
       &.disabled {
         opacity: .35;
-        cursor: none;
+        pointer-events: none;
       }
     }
   }

--- a/js/actions/dashboard.js
+++ b/js/actions/dashboard.js
@@ -22,6 +22,7 @@ export const SELECT_QUESTION = "SELECT_QUESTION";
 
 export const SET_COMPACT_REPORT = "SET_COMPACT_REPORT";
 export const SET_HIDE_FEEDBACK_BADGES = "SET_HIDE_FEEDBACK_BADGES";
+export const SET_FEEDBACK_SORT_REFRESH_ENABLED = "SET_FEEDBACK_SORT_REFRESH_ENABLED";
 
 export const TRACK_EVENT = "TRACK_EVENT";
 
@@ -157,5 +158,12 @@ export function setHideFeedbackBadges(hideFeedbackBadges) {
   return {
     type: SET_HIDE_FEEDBACK_BADGES,
     value: hideFeedbackBadges,
+  };
+}
+
+export function setFeedbackSortRefreshEnabled(refreshEnabled) {
+  return {
+    type: SET_FEEDBACK_SORT_REFRESH_ENABLED,
+    value: refreshEnabled,
   };
 }

--- a/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
@@ -7,6 +7,7 @@ interface IProps {
   activityIndex: number;
   activityStarted: boolean;
   feedback: any;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   studentId: string;
   updateActivityFeedback?: (activityId: string, activityIndex: number, platformStudentId: string, feedback: any) => void;
   trackEvent: TrackEventFunction;
@@ -36,6 +37,7 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
       if (logUpdate) {
         trackEvent("Portal-Dashboard", "AddActivityLevelFeedback", { label: feedback, parameters: { activityId, studentId }});
       }
+      props.setFeedbackSortRefreshEnabled(true);
       updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value,
                                                                     hasBeenReviewed});
     }

--- a/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
+++ b/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
@@ -16,12 +16,14 @@ interface IProps {
   feedbacksNeedingReview: Map<any, any>;
   isAnonymous: boolean;
   rubric: any;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   updateActivityFeedback: (activityId: string, activityIndex: number, platformStudentId: string, feedback: any) => void;
   trackEvent: TrackEventFunction;
 }
 
 export const ActivityLevelFeedbackStudentRows: React.FC<IProps> = (props) => {
-  const { activityId, activityIndex, feedbacks, isAnonymous, rubric, updateActivityFeedback, trackEvent } = props;
+  const { activityId, activityIndex, feedbacks, isAnonymous, rubric, setFeedbackSortRefreshEnabled, updateActivityFeedback,
+          trackEvent } = props;
 
   const feedbackRows = feedbacks.map((feedbackData: Map<any, any>) => {
     const student = feedbackData.get("student");
@@ -62,6 +64,7 @@ export const ActivityLevelFeedbackStudentRows: React.FC<IProps> = (props) => {
             feedback={feedback}
             key={activityId + studentId + "-textarea"}
             studentId={studentId}
+            setFeedbackSortRefreshEnabled={setFeedbackSortRefreshEnabled}
             updateActivityFeedback={updateActivityFeedback}
             trackEvent={trackEvent}
           />

--- a/js/components/portal-dashboard/feedback/feedback-question-rows.tsx
+++ b/js/components/portal-dashboard/feedback/feedback-question-rows.tsx
@@ -17,13 +17,15 @@ interface IProps {
   currentActivity: Map<string, any>;
   currentStudentId: string | null;
   feedbacks: Map<any, any>;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   students: Map<any, any>;
   updateQuestionFeedback: (answerId: string, feedback: any) => void;
   trackEvent: TrackEventFunction;
 }
 
 export const FeedbackQuestionRows: React.FC<IProps> = (props) => {
-  const { answers, feedbacks, currentActivity, currentStudentId, students, updateQuestionFeedback, trackEvent } = props;
+  const { answers, feedbacks, currentActivity, currentStudentId, setFeedbackSortRefreshEnabled, students, updateQuestionFeedback,
+          trackEvent } = props;
 
   const getFeedbackIcon = (feedback: string, feedbackData: Map<string, any>, answer: Map<string, any>) => {
     let feedbackBadge = <AwaitingFeedbackQuestionBadgeIcon />;
@@ -78,6 +80,7 @@ export const FeedbackQuestionRows: React.FC<IProps> = (props) => {
               questionId={currentQuestionId}
               activityId={currentActivityId}
               key={currentQuestionId + currentStudentId + "textarea"}
+              setFeedbackSortRefreshEnabled={setFeedbackSortRefreshEnabled}
               updateQuestionFeedback={updateQuestionFeedback}
               trackEvent={trackEvent}
             />

--- a/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
@@ -11,6 +11,7 @@ interface IProps {
   studentId: string | null;
   questionId: string | null;
   activityId: string | null;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   updateQuestionFeedback: (answerId: string, feedback: any) => void;
   trackEvent: TrackEventFunction;
 }
@@ -39,6 +40,7 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
       if (logUpdate) {
         trackEvent("Portal-Dashboard", "AddQuestionLevelFeedback", { label: feedback, parameters: { activityId, studentId, questionId, answerId }});
       }
+      props.setFeedbackSortRefreshEnabled(true);
       updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer)});
     }
   };

--- a/js/components/portal-dashboard/feedback/question-level-feedback-student-rows.tsx
+++ b/js/components/portal-dashboard/feedback/question-level-feedback-student-rows.tsx
@@ -19,6 +19,7 @@ interface IProps {
   feedbacks: Map<any, any>;
   feedbacksNeedingReview: Map<any, any>;
   isAnonymous: boolean;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   students: Map<any, any>;
   updateQuestionFeedback: (answerId: string, feedback: any) => void;
   trackEvent: TrackEventFunction;
@@ -71,6 +72,7 @@ export const QuestionLevelFeedbackStudentRows: React.FC<IProps> = (props) => {
               questionId={currentQuestionId}
               activityId={activityId}
               key={currentQuestionId + studentId + "-textarea"}
+              setFeedbackSortRefreshEnabled={props.setFeedbackSortRefreshEnabled}
               updateQuestionFeedback={updateQuestionFeedback}
               trackEvent={trackEvent}
             />

--- a/js/containers/portal-dashboard/feedback/activity-feedback-panel.tsx
+++ b/js/containers/portal-dashboard/feedback/activity-feedback-panel.tsx
@@ -3,6 +3,7 @@ import { Map } from "immutable";
 import { connect } from "react-redux";
 import { trackEvent, TrackEventCategory, TrackEventFunction, TrackEventFunctionOptions, updateActivityFeedback, updateActivityFeedbackSettings } from "../../../actions/index";
 import { makeGetStudentFeedbacks, makeGetAutoScores, makeGetComputedMaxScore } from "../../../selectors/activity-feedback-selectors";
+import { setFeedbackSortRefreshEnabled } from "../../../actions/dashboard";
 import { ActivityLevelFeedbackStudentRows } from "../../../components/portal-dashboard/feedback/activity-level-feedback-student-rows";
 import { FeedbackLevel, ListViewMode } from "../../../util/misc";
 
@@ -20,6 +21,7 @@ interface IProps {
   numFeedbacksGivenReview: number;
   numFeedbacksNeedingReview: number;
   rubric: any;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   settings: any;
   students: Map<any, any>;
   updateActivityFeedback: (activityId: string, activityIndex: number, platformStudentId: string, feedback: any) => void;
@@ -43,7 +45,8 @@ class ActivityFeedbackPanel extends React.PureComponent<IProps> {
   }
 
   render() {
-    const { activity, activityIndex, feedbacks, feedbacksNeedingReview, isAnonymous, rubric, updateActivityFeedback, trackEvent } = this.props;
+    const { activity, activityIndex, feedbacks, feedbacksNeedingReview, isAnonymous, rubric, updateActivityFeedback,
+            trackEvent } = this.props;
     const currentActivityId = activity?.get("id");
 
     return (
@@ -55,6 +58,7 @@ class ActivityFeedbackPanel extends React.PureComponent<IProps> {
           feedbacksNeedingReview={feedbacksNeedingReview}
           isAnonymous={isAnonymous}
           rubric={rubric}
+          setFeedbackSortRefreshEnabled={this.props.setFeedbackSortRefreshEnabled}
           updateActivityFeedback={updateActivityFeedback}
           trackEvent={trackEvent}
         />
@@ -100,6 +104,7 @@ function mapStateToProps() {
 
 const mapDispatchToProps = (dispatch: any, ownProps: any): Partial<IProps> => {
   return {
+    setFeedbackSortRefreshEnabled: (value) => dispatch(setFeedbackSortRefreshEnabled(value)),
     updateActivityFeedback: (activityId, activityIndex, platformStudentId, feedback) => dispatch(updateActivityFeedback(activityId, activityIndex, platformStudentId, feedback)),
     updateActivityFeedbackSettings: (activityId, activityIndex, feedbackFlags) => dispatch(updateActivityFeedbackSettings(activityId, activityIndex, feedbackFlags)),
     trackEvent: (category: TrackEventCategory, action: string, options?: TrackEventFunctionOptions) => dispatch(trackEvent(category, action, options)),

--- a/js/containers/portal-dashboard/feedback/question-feedback-panel.tsx
+++ b/js/containers/portal-dashboard/feedback/question-feedback-panel.tsx
@@ -70,6 +70,7 @@ class QuestionFeedbackPanel extends React.PureComponent<IProps> {
               currentActivity={activity}
               currentStudentId={currentStudentId}
               feedbacks={questionFeedbacks}
+              setFeedbackSortRefreshEnabled={this.props.setFeedbackSortRefreshEnabled}
               students={students}
               updateQuestionFeedback={this.props.updateQuestionFeedback}
               trackEvent={trackEvent}

--- a/js/containers/portal-dashboard/feedback/question-feedback-panel.tsx
+++ b/js/containers/portal-dashboard/feedback/question-feedback-panel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Map } from "immutable";
 import { connect } from "react-redux";
 import { trackEvent, TrackEventCategory, TrackEventFunction, TrackEventFunctionOptions, updateQuestionFeedback, updateQuestionFeedbackSettings } from "../../../actions/index";
+import { setFeedbackSortRefreshEnabled } from "../../../actions/dashboard";
 import { QuestionLevelFeedbackStudentRows } from "../../../components/portal-dashboard/feedback/question-level-feedback-student-rows";
 import { FeedbackQuestionRows } from "../../../components/portal-dashboard/feedback/feedback-question-rows";
 import { FeedbackLevel, ListViewMode } from "../../../util/misc";
@@ -20,6 +21,7 @@ interface IProps {
   isAnonymous: boolean;
   listViewMode: ListViewMode;
   questionFeedbacks: Map<any, any>;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   settings: any;
   students: Map<any, any>;
   updateQuestionFeedback: (answerId: string, feedback: any) => void;
@@ -58,6 +60,7 @@ class QuestionFeedbackPanel extends React.PureComponent<IProps> {
               feedbacks={questionFeedbacks}
               feedbacksNeedingReview={feedbacksNeedingReview}
               isAnonymous={isAnonymous}
+              setFeedbackSortRefreshEnabled={this.props.setFeedbackSortRefreshEnabled}
               students={students}
               updateQuestionFeedback={this.props.updateQuestionFeedback}
               trackEvent={trackEvent}
@@ -96,6 +99,7 @@ function mapStateToProps(state: any, ownProps: any): Partial<IProps> {
 
 const mapDispatchToProps = (dispatch: any, ownProps: any): Partial<IProps> => {
   return {
+    setFeedbackSortRefreshEnabled: (value) => dispatch(setFeedbackSortRefreshEnabled(value)),
     updateQuestionFeedback: (answerId, feedback) => dispatch(updateQuestionFeedback(answerId, feedback)),
     updateQuestionFeedbackSettings: (embeddableKey, feedbackFlags) => dispatch(updateQuestionFeedbackSettings(embeddableKey, feedbackFlags)),
     trackEvent: (category: TrackEventCategory, action: string, options?: TrackEventFunctionOptions) => dispatch(trackEvent(category, action, options)),

--- a/js/containers/portal-dashboard/popup-class-nav.tsx
+++ b/js/containers/portal-dashboard/popup-class-nav.tsx
@@ -56,7 +56,6 @@ class PopupClassNav extends React.PureComponent<IProps>{
                            ? "Awaiting feedback"
                            : listViewMode === "Question" ? "Questions" : "Class";
     const containerLabelType = viewMode === "FeedbackReport" || listViewMode === "Question" ? undefined : "students";
-
     return (
       <div className={`${css.popupClassNav} ${css.column}`}>
         {this.renderViewListOptions()}
@@ -65,7 +64,8 @@ class PopupClassNav extends React.PureComponent<IProps>{
           <CountContainer numItems={numItems} containerLabel={containerLabel} containerLabelType={containerLabelType} />
           {this.renderSortMenu()}
           {listViewMode === "Student" && viewMode === "ResponseDetails" && this.renderSpotlightToggle()}
-          {viewMode === "FeedbackReport" && feedbackSortByMethod === SORT_BY_FEEDBACK_PROGRESS && this.renderRefreshButton()}
+          {viewMode === "FeedbackReport" && listViewMode === "Student" && feedbackSortByMethod === SORT_BY_FEEDBACK_PROGRESS &&
+           this.renderRefreshButton()}
         </div>
       </div>
     );

--- a/js/containers/portal-dashboard/popup-class-nav.tsx
+++ b/js/containers/portal-dashboard/popup-class-nav.tsx
@@ -47,7 +47,8 @@ class PopupClassNav extends React.PureComponent<IProps>{
   }
 
   render() {
-    const { anonymous, listViewMode, numFeedbacksNeedingReview, questionCount, studentCount, setAnonymous, viewMode } = this.props;
+    const { anonymous, feedbackSortByMethod, listViewMode, numFeedbacksNeedingReview, questionCount, studentCount, setAnonymous,
+            viewMode } = this.props;
     const numItems = viewMode === "FeedbackReport"
                      ? numFeedbacksNeedingReview
                      : listViewMode === "Question" ? questionCount : studentCount;
@@ -64,7 +65,7 @@ class PopupClassNav extends React.PureComponent<IProps>{
           <CountContainer numItems={numItems} containerLabel={containerLabel} containerLabelType={containerLabelType} />
           {this.renderSortMenu()}
           {listViewMode === "Student" && viewMode === "ResponseDetails" && this.renderSpotlightToggle()}
-          { viewMode === "FeedbackReport" && this.renderRefreshButton() }
+          {viewMode === "FeedbackReport" && feedbackSortByMethod === SORT_BY_FEEDBACK_PROGRESS && this.renderRefreshButton()}
         </div>
       </div>
     );
@@ -77,6 +78,8 @@ class PopupClassNav extends React.PureComponent<IProps>{
 
   private handleStudentFeedbackSortSelect = (value: string) => () => {
     const { setStudentFeedbackSort } = this.props;
+    // TODO: update feedback sort
+    this.props.setFeedbackSortRefreshEnabled(false);
     setStudentFeedbackSort(value);
   }
 
@@ -179,6 +182,7 @@ class PopupClassNav extends React.PureComponent<IProps>{
   }
 
   private handleRefeshSelect = () => {
+    // TODO: update feedback sort
     this.props.setFeedbackSortRefreshEnabled(false);
   }
 

--- a/js/reducers/dashboard-reducer.ts
+++ b/js/reducers/dashboard-reducer.ts
@@ -2,7 +2,7 @@ import { RecordFactory } from "../util/record-factory";
 import { Map } from "immutable";
 import {
   SET_ACTIVITY_EXPANDED, SET_CURRENT_ACTIVITY, SET_CURRENT_QUESTION, SET_CURRENT_STUDENT,
-  TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION, SET_STUDENT_FEEDBACK_SORT,
+  TOGGLE_CURRENT_ACTIVITY, TOGGLE_CURRENT_QUESTION, SET_STUDENT_FEEDBACK_SORT, SET_FEEDBACK_SORT_REFRESH_ENABLED,
   SET_STUDENT_EXPANDED, SET_STUDENTS_EXPANDED, SET_STUDENT_SORT, SET_COMPACT_REPORT, SET_HIDE_FEEDBACK_BADGES,
   SORT_BY_NAME, SET_QUESTION_EXPANDED,
   SELECT_QUESTION,
@@ -29,6 +29,7 @@ export interface IDashboardState {
   compactReport: boolean;
   hideFeedbackBadges: boolean;
   feedbackSortBy: FeedbackSortType;
+  feedbackSortRefreshEnabled: boolean;
 }
 
 const INITIAL_DASHBOARD_STATE = RecordFactory<IDashboardState>({
@@ -43,6 +44,7 @@ const INITIAL_DASHBOARD_STATE = RecordFactory<IDashboardState>({
   compactReport: false,
   hideFeedbackBadges: false,
   feedbackSortBy: SORT_BY_FEEDBACK_NAME,
+  feedbackSortRefreshEnabled: false,
 });
 
 export class DashboardState extends INITIAL_DASHBOARD_STATE implements IDashboardState {
@@ -60,6 +62,7 @@ export class DashboardState extends INITIAL_DASHBOARD_STATE implements IDashboar
   compactReport: boolean;
   hideFeedbackBadges: boolean;
   feedbackSortBy: FeedbackSortType;
+  feedbackSortRefreshEnabled: boolean;
 }
 
 export default function dashboard(state = new DashboardState({}), action: any) {
@@ -103,6 +106,8 @@ export default function dashboard(state = new DashboardState({}), action: any) {
       return state.set("compactReport", action.value);
     case SET_HIDE_FEEDBACK_BADGES:
       return state.set("hideFeedbackBadges", action.value);
+    case SET_FEEDBACK_SORT_REFRESH_ENABLED:
+      return state.set("feedbackSortRefreshEnabled", action.value);
     default:
       return state;
   }

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -19,6 +19,7 @@ export const getDashboardFeedbackSortBy = state => state.getIn(["dashboard", "fe
 const getSeletedQuestionId = state => state.getIn(["dashboard", "selectedQuestion"]);
 export const getCompactReport = state => state.getIn(["dashboard", "compactReport"]);
 export const getHideFeedbackBadges = state => state.getIn(["dashboard", "hideFeedbackBadges"]);
+export const getfeedbackSortRefreshEnabled = state => state.getIn(["dashboard", "feedbackSortRefreshEnabled"]);
 
 // When a user selects a to display question details by
 // Clicking on the question column expand icon.

--- a/test/reducers/dashboard-reducer_spec.js
+++ b/test/reducers/dashboard-reducer_spec.js
@@ -15,7 +15,7 @@ describe("dashboard reducer", () => {
       compactReport: false,
       hideFeedbackBadges: false,
       feedbackSortBy: types.SORT_BY_FEEDBACK_NAME,
-      feedbackSortRefreshEnabled: true,
+      feedbackSortRefreshEnabled: false,
     });
   });
 

--- a/test/reducers/dashboard-reducer_spec.js
+++ b/test/reducers/dashboard-reducer_spec.js
@@ -15,6 +15,7 @@ describe("dashboard reducer", () => {
       compactReport: false,
       hideFeedbackBadges: false,
       feedbackSortBy: types.SORT_BY_FEEDBACK_NAME,
+      feedbackSortRefreshEnabled: true,
     });
   });
 


### PR DESCRIPTION
This PR updates the enabled/disabled state of the awaiting feedback refresh button.  State is maintained in Redux and passed to components as needed.  Changes include:
- add Redux state to keep track of refresh button enabled state
- when refresh button is pressed, disable button
- when feedback is changed, enable button
- when change between awaiting feedback and student name sort, disable button
- hide button if in student name sort mode

The next step will be to have the button click update the sort.  This will require feedbacks keeping track of if they have been modified since the last sort.