### PR TITLE
176492325 feedback fixes

### DIFF
--- a/css/portal-dashboard/response-details/response-details.less
+++ b/css/portal-dashboard/response-details/response-details.less
@@ -14,6 +14,7 @@
     .contentNavigatorArea {
       background: @cc-teal-light6;
       min-height: 250px;
+      height: calc(100% - 50px);
 
       &.short {
         min-height: 200px;

--- a/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
@@ -42,11 +42,11 @@ context("Portal Dashboard Student Sort",() =>{
       // TODO: The order below will need to be changed once sorting by awaiting feedback works
       // note that we offset the index by 6 to skip the student names in the progress view
       cy.get('[data-cy=student-name]').eq(6).should("contain", "Jenkins, John");
-      cy.get('[data-cy=student-name]').eq(7).should("contain", "Armstrong, Jenna");
-      cy.get('[data-cy=student-name]').eq(8).should("contain", "Galloway, Amy");
-      cy.get('[data-cy=student-name]').eq(9).should("contain", "Ross, John");
-      cy.get('[data-cy=student-name]').eq(10).should("contain", "Crosby, Kate");
-      cy.get('[data-cy=student-name]').eq(11).should("contain", "Wu, Jerome");
+      cy.get('[data-cy=student-name]').eq(7).should("contain", "Galloway, Amy");
+      cy.get('[data-cy=student-name]').eq(8).should("contain", "Ross, John");
+      cy.get('[data-cy=student-name]').eq(9).should("contain", "Wu, Jerome");
+      cy.get('[data-cy=student-name]').eq(10).should("contain", "Armstrong, Jenna");
+      cy.get('[data-cy=student-name]').eq(11).should("contain", "Crosby, Kate");
     });
 
 });

--- a/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
+++ b/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
@@ -62,6 +62,7 @@ export const ActivityLevelFeedbackStudentRows: React.FC<IProps> = (props) => {
               rubric={rubric}
               student={student}
               rubricFeedback={rubricFeedback}
+              setFeedbackSortRefreshEnabled={setFeedbackSortRefreshEnabled}
               updateActivityFeedback={updateActivityFeedback}
             />
           }

--- a/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
+++ b/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
@@ -5,6 +5,7 @@ import { getFormattedStudentName } from "../../../util/student-utils";
 import { RubricTableContainer } from "./rubric-table";
 import AwaitingFeedbackActivityBadgeIcon from "../../../../img/svg-icons/awaiting-feedback-activity-badge-icon.svg";
 import GivenFeedbackActivityBadgeIcon from "../../../../img/svg-icons/given-feedback-activity-badge-icon.svg";
+import { SORT_BY_FEEDBACK_PROGRESS } from "../../../actions/dashboard";
 import { TrackEventFunction } from "../../../actions";
 
 import css from "../../../../css/portal-dashboard/feedback/feedback-rows.less";
@@ -14,18 +15,25 @@ interface IProps {
   activityIndex: number;
   feedbacks: Map<any, any>;
   feedbacksNeedingReview: Map<any, any>;
+  feedbackSortByMethod: string;
   isAnonymous: boolean;
   rubric: any;
   setFeedbackSortRefreshEnabled: (value: boolean) => void;
+  students: Map<any, any>;
   updateActivityFeedback: (activityId: string, activityIndex: number, platformStudentId: string, feedback: any) => void;
   trackEvent: TrackEventFunction;
 }
 
 export const ActivityLevelFeedbackStudentRows: React.FC<IProps> = (props) => {
-  const { activityId, activityIndex, feedbacks, isAnonymous, rubric, setFeedbackSortRefreshEnabled, updateActivityFeedback,
-          trackEvent } = props;
-
-  const feedbackRows = feedbacks.map((feedbackData: Map<any, any>) => {
+  const { activityId, activityIndex, feedbacks, feedbackSortByMethod, isAnonymous, rubric, setFeedbackSortRefreshEnabled,
+          students, trackEvent, updateActivityFeedback } = props;
+  const displayedFeedbacks = feedbackSortByMethod !== SORT_BY_FEEDBACK_PROGRESS
+    ? feedbacks
+    : students.map((student: any) => {
+        const feedback = feedbacks.find((f) => f.get("platformStudentId") === student.get("id"));
+        return feedback;
+      });
+  const feedbackRows = displayedFeedbacks.map((feedbackData: Map<any, any>) => {
     const student = feedbackData.get("student");
     const studentId = student.get("id");
     const formattedName = getFormattedStudentName(isAnonymous, student);

--- a/js/components/portal-dashboard/feedback/rubric-table.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-table.tsx
@@ -11,6 +11,7 @@ interface IProps {
   rubricFeedback: any;
   activityId: string;
   activityIndex: number;
+  setFeedbackSortRefreshEnabled: (value: boolean) => void;
   updateActivityFeedback: (activityId: string, activityIndex: number, platformStudentId: string, feedback: any) => void;
 }
 export class RubricTableContainer extends React.PureComponent<IProps> {
@@ -105,7 +106,7 @@ export class RubricTableContainer extends React.PureComponent<IProps> {
     };
 
     const updateSelection = (critId: any, ratingId: string, deselect: boolean) => {
-      const { rubric, rubricFeedback, student } = this.props;
+      const { rubric, rubricFeedback, student, setFeedbackSortRefreshEnabled } = this.props;
       const newSelection: any = {};
       const rating = rubric.ratings.find((r: any) => r.id === ratingId);
       const criteria = rubric.criteria.find((c: any) => c.id === critId);
@@ -127,6 +128,7 @@ export class RubricTableContainer extends React.PureComponent<IProps> {
                 };
       const newFeedback = Object.assign({}, rubricFeedback, newSelection);
       this.rubricChange(newFeedback, studentId);
+      setFeedbackSortRefreshEnabled(true);
     };
 
     return (

--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -193,6 +193,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
                   activity={currentActivityWithQuestions}
                   activities={activities}
                   currentStudentId={currentStudentId}
+                  feedbackSortByMethod={feedbackSortByMethod}
                   isAnonymous={isAnonymous}
                   listViewMode={listViewMode}
                   students={students}

--- a/js/containers/portal-dashboard/feedback/activity-feedback-panel.tsx
+++ b/js/containers/portal-dashboard/feedback/activity-feedback-panel.tsx
@@ -16,6 +16,7 @@ interface IProps {
   feedbacks: Map<any, any>;
   feedbacksNeedingReview: Map<any, any>;
   feedbacksNotAnswered: number;
+  feedbackSortByMethod: string;
   isAnonymous: boolean;
   listViewMode: ListViewMode;
   numFeedbacksGivenReview: number;
@@ -45,8 +46,8 @@ class ActivityFeedbackPanel extends React.PureComponent<IProps> {
   }
 
   render() {
-    const { activity, activityIndex, feedbacks, feedbacksNeedingReview, isAnonymous, rubric, updateActivityFeedback,
-            trackEvent } = this.props;
+    const { activity, activityIndex, feedbacks, feedbacksNeedingReview, feedbackSortByMethod, isAnonymous, rubric, students,
+            updateActivityFeedback, trackEvent } = this.props;
     const currentActivityId = activity?.get("id");
 
     return (
@@ -56,9 +57,11 @@ class ActivityFeedbackPanel extends React.PureComponent<IProps> {
           activityIndex={activityIndex}
           feedbacks={feedbacks}
           feedbacksNeedingReview={feedbacksNeedingReview}
+          feedbackSortByMethod={feedbackSortByMethod}
           isAnonymous={isAnonymous}
           rubric={rubric}
           setFeedbackSortRefreshEnabled={this.props.setFeedbackSortRefreshEnabled}
+          students={students}
           updateActivityFeedback={updateActivityFeedback}
           trackEvent={trackEvent}
         />

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -5,6 +5,10 @@ import { SORT_BY_NAME, SORT_BY_MOST_PROGRESS, SORT_BY_LEAST_PROGRESS,
 import { compareStudentsByName } from "../util/misc";
 import { fromJS } from "immutable";
 
+const kSortGroupFirst = 1;
+const kSortGroupSecond = 2;
+const kSortGroupThird = 3;
+
 // Inputs
 const getActivities = state => state.getIn(["report", "activities"]);
 export const getAnonymous = state => state.getIn(["report", "anonymous"]);
@@ -162,8 +166,8 @@ export const getFeedbackSortedStudents = createSelector(
           const student2HasFeedback = student2Feedback !== undefined;
           const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
           const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);
-          const student1SortGroup = student1Progress === 0 ? 3 : student1HasFeedback ? 2 : 1;
-          const student2SortGroup = student2Progress === 0 ? 3 : student2HasFeedback ? 2 : 1;
+          const student1SortGroup = student1Progress === 0 ? kSortGroupThird : student1HasFeedback ? kSortGroupSecond : kSortGroupFirst;
+          const student2SortGroup = student2Progress === 0 ? kSortGroupThird : student2HasFeedback ? kSortGroupSecond : kSortGroupFirst;
           const feedbackComp = student1SortGroup === student2SortGroup ? 0 : student1SortGroup > student2SortGroup ? 1 : -1;
           return feedbackComp;
         });

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -90,6 +90,27 @@ export const getStudentAverageProgress = createSelector(
   },
 );
 
+export const getCurrentActivity = createSelector(
+  [ getActivities, getCurrentActivityId ],
+  (activities, currentActivityId) => {
+    return activities.find(activity => activity.get("id") === currentActivityId);
+  }
+);
+
+export const getFirstActivity = createSelector(
+  [ getActivities ],
+  (activities) => {
+    return activities.first();
+  }
+);
+
+export const getCurrentQuestion = createSelector(
+  [ getQuestions, getCurrentQuestionId ],
+  (questions, currentQuestionId) => {
+    return questions.find(activity => activity.get("id") === currentQuestionId);
+  }
+);
+
 // Returns sorted students
 export const getSortedStudents = createSelector(
   [ getStudents, getDashboardSortBy, getStudentAverageProgress ],
@@ -121,8 +142,8 @@ export const getSortedStudents = createSelector(
 
 // Returns sorted students in feedback view
 export const getFeedbackSortedStudents = createSelector(
-  [ getStudents, getDashboardFeedbackSortBy, getFeedback ],
-  (students, feedbackSortBy, feedback) => {
+  [ getStudents, getDashboardFeedbackSortBy, getFeedback, getStudentProgress, getCurrentActivity, getFirstActivity ],
+  (students, feedbackSortBy, feedback, studentProgress, currentActivity, firstActivity) => {
     switch (feedbackSortBy) {
       case SORT_BY_FEEDBACK_NAME:
         return students.toList().sort((student1, student2) =>
@@ -130,13 +151,20 @@ export const getFeedbackSortedStudents = createSelector(
         );
       case SORT_BY_FEEDBACK_PROGRESS:
         return students.toList().sort((student1, student2) => {
-          // TODO: add support for question feedback, also determine if student has started activity or answered question
+          // TODO: add support for question feedback
           const activityFeedbacks = feedback.get("activityFeedbacks");
-          const student1Feedback = activityFeedbacks.find(function(f) { return f.get('platformStudentId') === student1.get("id"); });
-          const student2Feedback = activityFeedbacks.find(function(f) { return f.get('platformStudentId') === student2.get("id"); });
-          const student1HasFeedback = student1Feedback !== undefined ? true : false;
-          const student2HasFeedback = student2Feedback !== undefined ? true : false;
-          const feedbackComp = (student1HasFeedback === student2HasFeedback) ? 0 : student1HasFeedback ? 1 : -1;
+          const currentActivityId = currentActivity ? currentActivity.get("id") : firstActivity.get("id");
+          const student1Feedback = activityFeedbacks.find(function(f) { return f.get("platformStudentId") === student1.get("id")
+                                                                          && f.get("activityId") === currentActivityId; });
+          const student2Feedback = activityFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
+                                                                          && f.get("activityId") === currentActivityId; });
+          const student1HasFeedback = student1Feedback !== undefined;
+          const student2HasFeedback = student2Feedback !== undefined;
+          const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
+          const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);
+          const student1SortGroup = student1Progress === 0 ? 3 : student1HasFeedback ? 2 : 1;
+          const student2SortGroup = student2Progress === 0 ? 3 : student2HasFeedback ? 2 : 1;
+          const feedbackComp = student1SortGroup === student2SortGroup ? 0 : student1SortGroup > student2SortGroup ? 1 : -1;
           return feedbackComp;
         });
       default:
@@ -145,16 +173,3 @@ export const getFeedbackSortedStudents = createSelector(
   },
 );
 
-export const getCurrentActivity = createSelector(
-  [ getActivities, getCurrentActivityId ],
-  (activities, currentActivityId) => {
-    return activities.find(activity => activity.get("id") === currentActivityId);
-  }
-);
-
-export const getCurrentQuestion = createSelector(
-  [ getQuestions, getCurrentQuestionId ],
-  (questions, currentQuestionId) => {
-    return questions.find(activity => activity.get("id") === currentQuestionId);
-  }
-);


### PR DESCRIPTION
This PR adds the following changes and fixes to the activity feedback sort:
- display sorted activity feedback when awaiting feedback sort is used
- fix bug in activity awaiting feedback sort where all activities were checked for feedback, need to use current or first
- fix bug in activity awaiting feedback sort where unstarted activities were not sorted properly
- update refresh button state when rubric is selected
- update container height
NOTE that with these changes as soon as activity feedback is entered, the feedback will be sorted to the bottom of the list. This will be fixed in upcoming work.