### PR TITLE
176492325 question sort refresh button

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
@@ -43,9 +43,9 @@ context("Portal Dashboard Student Sort",() =>{
       // note that we offset the index by 6 to skip the student names in the progress view
       cy.get('[data-cy=student-name]').eq(6).should("contain", "Jenkins, John");
       cy.get('[data-cy=student-name]').eq(7).should("contain", "Galloway, Amy");
-      cy.get('[data-cy=student-name]').eq(8).should("contain", "Ross, John");
-      cy.get('[data-cy=student-name]').eq(9).should("contain", "Wu, Jerome");
-      cy.get('[data-cy=student-name]').eq(10).should("contain", "Armstrong, Jenna");
+      cy.get('[data-cy=student-name]').eq(8).should("contain", "Wu, Jerome");
+      cy.get('[data-cy=student-name]').eq(9).should("contain", "Armstrong, Jenna");
+      cy.get('[data-cy=student-name]').eq(10).should("contain", "Ross, John");
       cy.get('[data-cy=student-name]').eq(11).should("contain", "Crosby, Kate");
     });
 

--- a/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
@@ -41,7 +41,7 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
         trackEvent("Portal-Dashboard", "AddActivityLevelFeedback", { label: feedback, parameters: { activityId, studentId }});
       }
       props.setFeedbackSortRefreshEnabled(true);
-      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value, hasBeenReviewed, deletedSinceLastSort: feedback === "" ? true : undefined});
+      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value, hasBeenReviewed});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
@@ -38,7 +38,7 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
         trackEvent("Portal-Dashboard", "AddActivityLevelFeedback", { label: feedback, parameters: { activityId, studentId }});
       }
       props.setFeedbackSortRefreshEnabled(true);
-      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value, hasBeenReviewed});
+      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value, hasBeenReviewed, deletedSinceLastSort: feedback === "" ? true : undefined});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
@@ -25,9 +25,12 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
     }
   }, [textareaRef]);
 
+  const [ feedbackChanged, setFeedbackChanged ] = useState(false);
+
   const handleActivityFeedbackChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
     const target = event.currentTarget as HTMLTextAreaElement;
     setHeight(target.scrollHeight);
+    setFeedbackChanged(true);
     updateFeedbackThrottledAndNotLogged();
   };
 
@@ -53,7 +56,7 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
       <textarea
         data-cy="feedback-textarea"
         defaultValue={feedback}
-        onBlur={updateFeedbackLogged}
+        onBlur={feedbackChanged ? updateFeedbackLogged : undefined}
         onChange={handleActivityFeedbackChange}
         placeholder="Enter feedback"
         ref={textareaRef}

--- a/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
@@ -39,7 +39,8 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
       }
       props.setFeedbackSortRefreshEnabled(true);
       updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value,
-                                                                    hasBeenReviewed});
+                                                                    hasBeenReviewed,
+                                                                    ignoreFeedbackWhenSorting: props.feedback === "" ? true: undefined});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/activity-feedback-textarea.tsx
@@ -38,9 +38,7 @@ export const ActivityFeedbackTextarea: React.FC<IProps> = (props) => {
         trackEvent("Portal-Dashboard", "AddActivityLevelFeedback", { label: feedback, parameters: { activityId, studentId }});
       }
       props.setFeedbackSortRefreshEnabled(true);
-      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value,
-                                                                    hasBeenReviewed,
-                                                                    ignoreFeedbackWhenSorting: props.feedback === "" ? true: undefined});
+      updateActivityFeedback(activityId, activityIndex, studentId, {feedback: textareaRef.current?.value, hasBeenReviewed});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
@@ -41,7 +41,9 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
         trackEvent("Portal-Dashboard", "AddQuestionLevelFeedback", { label: feedback, parameters: { activityId, studentId, questionId, answerId }});
       }
       props.setFeedbackSortRefreshEnabled(true);
-      updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer)});
+      updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer), deletedSinceLastSort: feedback === "" ? true : undefined });
+      console.log("new feedback:" + feedback);
+      console.log("original feedback props:" + props.feedback);
     }
   };
 

--- a/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
@@ -41,9 +41,7 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
         trackEvent("Portal-Dashboard", "AddQuestionLevelFeedback", { label: feedback, parameters: { activityId, studentId, questionId, answerId }});
       }
       props.setFeedbackSortRefreshEnabled(true);
-      updateQuestionFeedback(answerId, {feedback,
-                                        hasBeenReviewedForAnswerHash: answerHash(answer),
-                                        ignoreFeedbackWhenSorting: props.feedback === "" ? true: undefined});
+      updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer)});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
@@ -44,7 +44,7 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
         trackEvent("Portal-Dashboard", "AddQuestionLevelFeedback", { label: feedback, parameters: { activityId, studentId, questionId, answerId }});
       }
       props.setFeedbackSortRefreshEnabled(true);
-      updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer), deletedSinceLastSort: feedback === "" ? true : undefined });
+      updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer)});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
@@ -28,9 +28,12 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
     }
   }, [textareaRef]);
 
+  const [ feedbackChanged, setFeedbackChanged ] = useState(false);
+
   const handleQuestionFeedbackChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
     const target = event.currentTarget as HTMLTextAreaElement;
     setHeight(target.scrollHeight);
+    setFeedbackChanged(true);
     updateFeedbackThrottledAndNotLogged();
   };
 
@@ -42,8 +45,6 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
       }
       props.setFeedbackSortRefreshEnabled(true);
       updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer), deletedSinceLastSort: feedback === "" ? true : undefined });
-      console.log("new feedback:" + feedback);
-      console.log("original feedback props:" + props.feedback);
     }
   };
 
@@ -61,7 +62,7 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
       onChange={handleQuestionFeedbackChange}
       style={{ height: height + "px" }}
       data-cy="feedback-textarea"
-      onBlur={updateFeedbackLogged}
+      onBlur={feedbackChanged ? updateFeedbackLogged : undefined}
     />
   );
 };

--- a/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
+++ b/js/components/portal-dashboard/feedback/question-feedback-textarea.tsx
@@ -41,7 +41,9 @@ export const QuestionFeedbackTextarea: React.FC<IProps> = (props) => {
         trackEvent("Portal-Dashboard", "AddQuestionLevelFeedback", { label: feedback, parameters: { activityId, studentId, questionId, answerId }});
       }
       props.setFeedbackSortRefreshEnabled(true);
-      updateQuestionFeedback(answerId, {feedback, hasBeenReviewedForAnswerHash: answerHash(answer)});
+      updateQuestionFeedback(answerId, {feedback,
+                                        hasBeenReviewedForAnswerHash: answerHash(answer),
+                                        ignoreFeedbackWhenSorting: props.feedback === "" ? true: undefined});
     }
   };
 

--- a/js/components/portal-dashboard/feedback/rubric-table.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-table.tsx
@@ -151,8 +151,7 @@ export class RubricTableContainer extends React.PureComponent<IProps> {
 
     const hasBeenReviewed = numFeedback !== 0;
     if (activityId && studentId) {
-      updateActivityFeedback(activityId, activityIndex, studentId,
-        { rubricFeedback, hasBeenReviewed, ignoreFeedbackWhenSorting: this.props.rubricFeedback === undefined ? true: undefined });
+      updateActivityFeedback(activityId, activityIndex, studentId, { rubricFeedback, hasBeenReviewed });
     }
   };
 }

--- a/js/components/portal-dashboard/feedback/rubric-table.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-table.tsx
@@ -149,8 +149,10 @@ export class RubricTableContainer extends React.PureComponent<IProps> {
       }
     });
 
-    const hasBeenReviewed  = numFeedback !== 0;
-    activityId && studentId
-      && updateActivityFeedback(activityId, activityIndex, studentId, { rubricFeedback, hasBeenReviewed });
+    const hasBeenReviewed = numFeedback !== 0;
+    if (activityId && studentId) {
+      updateActivityFeedback(activityId, activityIndex, studentId,
+        { rubricFeedback, hasBeenReviewed, ignoreFeedbackWhenSorting: this.props.rubricFeedback === undefined ? true: undefined });
+    }
   };
 }

--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -129,7 +129,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
               ? <StudentNavigator
                   students={students}
                   isAnonymous={isAnonymous}
-                  currentStudentIndex={currentStudentIndex>=0 ? currentStudentIndex : 0}
+                  currentStudentIndex={currentStudentIndex >= 0 ? currentStudentIndex : 0}
                   setCurrentStudent={setCurrentStudent}
                   currentStudentId={currentStudentId}
                   nameFirst={false}
@@ -185,7 +185,6 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
                   isAnonymous={isAnonymous}
                   listViewMode={listViewMode}
                   feedbackLevel={feedbackLevel}
-                  students={students}
                 />
               </div>
             : <div className={css.feedbackRowsContainer} data-cy="activity-feedback-panel">
@@ -196,7 +195,6 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
                   feedbackSortByMethod={feedbackSortByMethod}
                   isAnonymous={isAnonymous}
                   listViewMode={listViewMode}
-                  students={students}
                 />
               </div>
         }

--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -29,7 +29,7 @@ class AnswerCompact extends React.PureComponent<IProps> {
           ? this.renderAnswer(answerType?.icon, iconId)
           : this.renderNoAnswer()
         }
-        {(feedback && !hideFeedbackBadges &&
+        {(feedback && feedback.get("feedback") !== "" && !hideFeedbackBadges &&
           (feedbackValidForAnswer(feedback, answer)
            ? <QuestionFeedbackBadge className={css.feedbackBadge} data-cy="question-feedback-badge" />
            : <FeedbackAnswerUpdatedBadge className={css.feedbackBadge} data-cy="answer-updated-feedback-badge" />)

--- a/js/containers/portal-dashboard/feedback/activity-feedback-panel.tsx
+++ b/js/containers/portal-dashboard/feedback/activity-feedback-panel.tsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { trackEvent, TrackEventCategory, TrackEventFunction, TrackEventFunctionOptions, updateActivityFeedback, updateActivityFeedbackSettings } from "../../../actions/index";
 import { makeGetStudentFeedbacks, makeGetAutoScores, makeGetComputedMaxScore } from "../../../selectors/activity-feedback-selectors";
 import { setFeedbackSortRefreshEnabled } from "../../../actions/dashboard";
+import { getActivityFeedbackSortedStudents } from "../../../selectors/dashboard-selectors";
 import { ActivityLevelFeedbackStudentRows } from "../../../components/portal-dashboard/feedback/activity-level-feedback-student-rows";
 import { FeedbackLevel, ListViewMode } from "../../../util/misc";
 
@@ -24,8 +25,9 @@ interface IProps {
   rubric: any;
   setFeedbackSortRefreshEnabled: (value: boolean) => void;
   settings: any;
-  students: Map<any, any>;
+  activityFeedbackStudents: Map<any, any>;
   updateActivityFeedback: (activityId: string, activityIndex: number, platformStudentId: string, feedback: any) => void;
+  updateQuestionFeedback: (answerId: string, feedback: any) => void;
   updateActivityFeedbackSettings: (activityId: string, activityIndex: number, feedbackFlags: any) => void;
   trackEvent: TrackEventFunction;
 }
@@ -46,8 +48,8 @@ class ActivityFeedbackPanel extends React.PureComponent<IProps> {
   }
 
   render() {
-    const { activity, activityIndex, feedbacks, feedbacksNeedingReview, feedbackSortByMethod, isAnonymous, rubric, students,
-            updateActivityFeedback, trackEvent } = this.props;
+    const { activity, activityIndex, feedbacks, feedbacksNeedingReview, feedbackSortByMethod, isAnonymous, rubric,
+            updateActivityFeedback, trackEvent, activityFeedbackStudents } = this.props;
     const currentActivityId = activity?.get("id");
 
     return (
@@ -61,7 +63,7 @@ class ActivityFeedbackPanel extends React.PureComponent<IProps> {
           isAnonymous={isAnonymous}
           rubric={rubric}
           setFeedbackSortRefreshEnabled={this.props.setFeedbackSortRefreshEnabled}
-          students={students}
+          students={activityFeedbackStudents}
           updateActivityFeedback={updateActivityFeedback}
           trackEvent={trackEvent}
         />
@@ -96,6 +98,7 @@ function mapStateToProps() {
     const autoScores = getAutoscores(state, ownProps);
     const rubric = state.getIn(["feedback", "settings", "rubric"]);
     return {
+      activityFeedbackStudents: getActivityFeedbackSortedStudents(state),
       feedbacks, feedbacksNeedingReview, numFeedbacksNeedingReview, numFeedbacksGivenReview,
       feedbacksNotAnswered, computedMaxScore, autoScores,
       settings: state.getIn(["feedback", "settings"]),

--- a/js/containers/portal-dashboard/feedback/question-feedback-panel.tsx
+++ b/js/containers/portal-dashboard/feedback/question-feedback-panel.tsx
@@ -3,6 +3,7 @@ import { Map } from "immutable";
 import { connect } from "react-redux";
 import { trackEvent, TrackEventCategory, TrackEventFunction, TrackEventFunctionOptions, updateQuestionFeedback, updateQuestionFeedbackSettings } from "../../../actions/index";
 import { setFeedbackSortRefreshEnabled } from "../../../actions/dashboard";
+import { getQuestionFeedbackSortedStudents } from "../../../selectors/dashboard-selectors";
 import { QuestionLevelFeedbackStudentRows } from "../../../components/portal-dashboard/feedback/question-level-feedback-student-rows";
 import { FeedbackQuestionRows } from "../../../components/portal-dashboard/feedback/feedback-question-rows";
 import { FeedbackLevel, ListViewMode } from "../../../util/misc";
@@ -23,7 +24,7 @@ interface IProps {
   questionFeedbacks: Map<any, any>;
   setFeedbackSortRefreshEnabled: (value: boolean) => void;
   settings: any;
-  students: Map<any, any>;
+  questionFeedbackStudents: Map<any, any>;
   updateQuestionFeedback: (answerId: string, feedback: any) => void;
   updateQuestionFeedbackSettings: (embeddableKey: string, feedbackFlags: any) => void;
   trackEvent: TrackEventFunction;
@@ -46,7 +47,7 @@ class QuestionFeedbackPanel extends React.PureComponent<IProps> {
 
   render() {
     const { activity, activityIndex, answers, currentQuestion, currentStudentId, feedbacksNeedingReview,
-            isAnonymous, listViewMode, questionFeedbacks, students, trackEvent } = this.props;
+            isAnonymous, listViewMode, questionFeedbacks, questionFeedbackStudents, trackEvent } = this.props;
     const currentActivityId = activity?.get("id");
 
     return (
@@ -61,7 +62,7 @@ class QuestionFeedbackPanel extends React.PureComponent<IProps> {
               feedbacksNeedingReview={feedbacksNeedingReview}
               isAnonymous={isAnonymous}
               setFeedbackSortRefreshEnabled={this.props.setFeedbackSortRefreshEnabled}
-              students={students}
+              students={questionFeedbackStudents}
               updateQuestionFeedback={this.props.updateQuestionFeedback}
               trackEvent={trackEvent}
             />
@@ -71,7 +72,7 @@ class QuestionFeedbackPanel extends React.PureComponent<IProps> {
               currentStudentId={currentStudentId}
               feedbacks={questionFeedbacks}
               setFeedbackSortRefreshEnabled={this.props.setFeedbackSortRefreshEnabled}
-              students={students}
+              students={questionFeedbackStudents}
               updateQuestionFeedback={this.props.updateQuestionFeedback}
               trackEvent={trackEvent}
             />
@@ -93,8 +94,9 @@ class QuestionFeedbackPanel extends React.PureComponent<IProps> {
 
 function mapStateToProps(state: any, ownProps: any): Partial<IProps> {
   return {
-      questionFeedbacks: state.getIn(["feedback", "questionFeedbacks"]),
-      settings: state.getIn(["feedback", "settings"])
+    questionFeedbackStudents: getQuestionFeedbackSortedStudents(state),
+    questionFeedbacks: state.getIn(["feedback", "questionFeedbacks"]),
+    settings: state.getIn(["feedback", "settings"])
   };
 }
 

--- a/js/containers/portal-dashboard/popup-class-nav.tsx
+++ b/js/containers/portal-dashboard/popup-class-nav.tsx
@@ -194,14 +194,14 @@ class PopupClassNav extends React.PureComponent<IProps>{
 
   private updateFeedbackSortIgnoreFlag = () => {
     this.props.questionFeedbacks?.forEach((feedback: any) => {
-      if (feedback.get("ignoreFeedbackWhenSorting")) {
-        this.props.updateQuestionFeedback(feedback.get("answerId"), {ignoreFeedbackWhenSorting: false});
+      if (!feedback.get("existingFeedbackSinceLastSort")) {
+        this.props.updateQuestionFeedback(feedback.get("answerId"), {existingFeedbackSinceLastSort: true});
       }
     });
     this.props.activityFeedbacks?.forEach((feedback: any) => {
-      if (feedback.get("ignoreFeedbackWhenSorting")) {
+      if (!feedback.get("existingFeedbackSinceLastSort")) {
         this.props.updateActivityFeedback(feedback.get("activityId"),
-         feedback.get("activityIndex"), feedback.get("platformStudentId"), {ignoreFeedbackWhenSorting: false});
+         feedback.get("activityIndex"), feedback.get("platformStudentId"), {existingFeedbackSinceLastSort: true});
       }
     });
   }

--- a/js/containers/portal-dashboard/popup-class-nav.tsx
+++ b/js/containers/portal-dashboard/popup-class-nav.tsx
@@ -194,14 +194,14 @@ class PopupClassNav extends React.PureComponent<IProps>{
 
   private updateFeedbackSortIgnoreFlag = () => {
     this.props.questionFeedbacks?.forEach((feedback: any) => {
-      if (!feedback.get("existingFeedbackSinceLastSort")) {
-        this.props.updateQuestionFeedback(feedback.get("answerId"), {existingFeedbackSinceLastSort: true});
+      if (!feedback.get("existingFeedbackSinceLastSort") || feedback.get("deletedSinceLastSort")) {
+        this.props.updateQuestionFeedback(feedback.get("answerId"), {existingFeedbackSinceLastSort: true, deletedSinceLastSort: false});
       }
     });
     this.props.activityFeedbacks?.forEach((feedback: any) => {
-      if (!feedback.get("existingFeedbackSinceLastSort")) {
+      if (!feedback.get("existingFeedbackSinceLastSort") || feedback.get("deletedSinceLastSort")) {
         this.props.updateActivityFeedback(feedback.get("activityId"),
-         feedback.get("activityIndex"), feedback.get("platformStudentId"), {existingFeedbackSinceLastSort: true});
+         feedback.get("activityIndex"), feedback.get("platformStudentId"), {existingFeedbackSinceLastSort: true, deletedSinceLastSort: false});
       }
     });
   }

--- a/js/containers/portal-dashboard/popup-class-nav.tsx
+++ b/js/containers/portal-dashboard/popup-class-nav.tsx
@@ -193,16 +193,21 @@ class PopupClassNav extends React.PureComponent<IProps>{
   }
 
   private updateFeedbackSortIgnoreFlag = () => {
+    // TODO: this could be more efficient and only update feedbacks if needed
     this.props.questionFeedbacks?.forEach((feedback: any) => {
-      if (!feedback.get("existingFeedbackSinceLastSort") || feedback.get("deletedSinceLastSort")) {
-        this.props.updateQuestionFeedback(feedback.get("answerId"), {existingFeedbackSinceLastSort: true, deletedSinceLastSort: false});
-      }
+      const existingFeeback = !!feedback.get("feedback");
+      this.props.updateQuestionFeedback(feedback.get("answerId"), {existingFeedbackSinceLastSort: existingFeeback});
     });
     this.props.activityFeedbacks?.forEach((feedback: any) => {
-      if (!feedback.get("existingFeedbackSinceLastSort") || feedback.get("deletedSinceLastSort")) {
-        this.props.updateActivityFeedback(feedback.get("activityId"),
-         feedback.get("activityIndex"), feedback.get("platformStudentId"), {existingFeedbackSinceLastSort: true, deletedSinceLastSort: false});
-      }
+      const existingFeeback = !!feedback.get("feedback");
+      let existingRubricFeeback = false;
+      feedback.get("rubricFeedback")?.forEach((rf: any) => {
+        if (rf.get("id") && rf.get("id") !== "") {
+          existingRubricFeeback = true;
+        }
+      });
+      this.props.updateActivityFeedback(feedback.get("activityId"),
+        feedback.get("activityIndex"), feedback.get("platformStudentId"), {existingFeedbackSinceLastSort: existingFeeback || existingRubricFeeback});
     });
   }
 

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import { connect } from "react-redux";
 import { fetchAndObserveData, trackEvent, setAnonymous, TrackEventFunction, TrackEventFunctionOptions, TrackEventCategory, setExtraEventLoggingParameters } from "../../actions/index";
 import { getSortedStudents, getCurrentActivity, getCurrentQuestion, getCurrentStudentId, getDashboardFeedbackSortBy,
-         getStudentProgress, getCompactReport, getAnonymous, getDashboardSortBy, getHideFeedbackBadges, getFeedbackSortedStudents
+         getStudentProgress, getCompactReport, getAnonymous, getDashboardSortBy, getHideFeedbackBadges
        } from "../../selectors/dashboard-selectors";
 import { Header } from "../../components/portal-dashboard/header";
 import { ClassNav } from "../../components/portal-dashboard/class-nav";
@@ -35,7 +35,6 @@ interface IProps {
   currentStudentId: string | null;
   error: IResponse;
   expandedActivities: Map<any, any>;
-  feedbackStudents: any;
   hasTeacherEdition: boolean;
   isFetching: boolean;
   questions?: Map<string, any>;
@@ -103,7 +102,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
       sequenceTree, setAnonymous, setStudentSort, studentProgress, students, sortedQuestionIds, questions, expandedActivities,
       setCurrentActivity, setCurrentQuestion, setCurrentStudent, sortByMethod, toggleCurrentActivity, toggleCurrentQuestion,
       trackEvent, hasTeacherEdition, questionFeedbacks, hideFeedbackBadges, feedbackSortByMethod, setStudentFeedbackSort,
-      feedbackStudents } = this.props;
+      } = this.props;
     const { initialLoading, viewMode, listViewMode } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
@@ -260,7 +259,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                   sortByMethod={sortByMethod}
                   sortedQuestionIds={sortedQuestionIds}
                   studentCount={students.size}
-                  students={viewMode === "ResponseDetails" ? students : feedbackStudents}
+                  students={students}
                   toggleCurrentQuestion={trackToggleCurrentQuestion}
                   trackEvent={trackEvent}
                   viewMode={viewMode}
@@ -345,7 +344,6 @@ function mapStateToProps(state: RootState): Partial<IProps> {
     error,
     expandedActivities: state.getIn(["dashboard", "expandedActivities"]),
     feedbackSortByMethod: getDashboardFeedbackSortBy(state),
-    feedbackStudents: dataDownloaded && getFeedbackSortedStudents(state),
     hasTeacherEdition: dataDownloaded ? state.getIn(["report", "hasTeacherEdition"]) : undefined,
     isFetching: data.get("isFetching"),
     questionFeedbacks: state.getIn(["feedback", "questionFeedbacks"]),

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -170,7 +170,7 @@ export const getActivityFeedbackSortedStudents = createSelector(
                                                                           && f.get("activityId") === currentActivityId; });
           const student1HasFeedback = student1Feedback !== undefined && student1Feedback !== ""
             && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
-          const student2HasFeedback = student2Feedback !== undefined && student1Feedback !== ""
+          const student2HasFeedback = student2Feedback !== undefined && student2Feedback !== ""
             && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
           const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
           const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -169,9 +169,9 @@ export const getActivityFeedbackSortedStudents = createSelector(
           const student2Feedback = activityFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("activityId") === currentActivityId; });
           const student1HasFeedback = student1Feedback !== undefined && student1Feedback !== ""
-            && !(student1Feedback.get("ignoreFeedbackWhenSorting") === true);
+            && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
           const student2HasFeedback = student2Feedback !== undefined && student1Feedback !== ""
-            && !(student2Feedback.get("ignoreFeedbackWhenSorting") === true);
+            && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
           const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
           const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);
           const student1SortGroup = student1Progress === 0 ? kSortGroupThird : student1HasFeedback ? kSortGroupSecond : kSortGroupFirst;
@@ -205,9 +205,9 @@ export const getQuestionFeedbackSortedStudents = createSelector(
           const student2Feedback = questionFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("questionId") === questionId; });
           const student1HasFeedback = student1Feedback !== undefined && student1Feedback !== ""
-            && !(student1Feedback.get("ignoreFeedbackWhenSorting") === true);
+            && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
           const student2HasFeedback = student2Feedback !== undefined && student2Feedback !== ""
-            && !(student2Feedback.get("ignoreFeedbackWhenSorting") === true);
+            && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
 
           const student1Answer = answers.getIn([questionId, student1.get("id")]);
           const student2Answer = answers.getIn([questionId, student2.get("id")]);

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -168,17 +168,12 @@ export const getActivityFeedbackSortedStudents = createSelector(
                                                                           && f.get("activityId") === currentActivityId; });
           const student2Feedback = activityFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("activityId") === currentActivityId; });
-          // TODO: need to handle case where feedback is empty string. This happens when feedback is deleted.
-          // In this case feedback must retain sort position with the completed feedback until refresh is pressed
-          // and it returns to awaiting feedback sort position at top of list. deletedSinceLastSort flag is used to determine this.
-          const student1HasFeedback = student1Feedback !== undefined
-            && (student1Feedback.get("feedback") !== "" || student1Feedback.get("deletedSinceLastSort") === true)
-            && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
-          const student2HasFeedback = student2Feedback !== undefined
-            && (student2Feedback.get("feedback") !== "" || student2Feedback.get("deletedSinceLastSort") === true)
-            && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
+          const student1HasFeedback = !!student1Feedback?.get("existingFeedbackSinceLastSort");
+          const student2HasFeedback = !!student2Feedback?.get("existingFeedbackSinceLastSort");
+
           const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
           const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);
+
           const student1SortGroup = student1Progress === 0 ? kSortGroupThird : student1HasFeedback ? kSortGroupSecond : kSortGroupFirst;
           const student2SortGroup = student2Progress === 0 ? kSortGroupThird : student2HasFeedback ? kSortGroupSecond : kSortGroupFirst;
           const feedbackComp = student1SortGroup === student2SortGroup ? 0 : student1SortGroup > student2SortGroup ? 1 : -1;
@@ -209,15 +204,8 @@ export const getQuestionFeedbackSortedStudents = createSelector(
                                                                           && f.get("questionId") === questionId; });
           const student2Feedback = questionFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("questionId") === questionId; });
-          // Handle case where feedback is empty string. This happens when feedback is deleted.
-          // In this case feedback must retain sort position with the completed feedback until refresh is pressed
-          // and it returns to awaiting feedback sort position at top of list. deletedSinceLastSort flag is used to determine this.
-          const student1HasFeedback = student1Feedback !== undefined
-            && (student1Feedback.get("feedback") !== "" || student1Feedback.get("deletedSinceLastSort") === true)
-            && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
-          const student2HasFeedback = student2Feedback !== undefined
-            && (student2Feedback.get("feedback") !== "" || student2Feedback.get("deletedSinceLastSort") === true)
-            && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
+          const student1HasFeedback = !!student1Feedback?.get("existingFeedbackSinceLastSort");
+          const student2HasFeedback = !!student2Feedback?.get("existingFeedbackSinceLastSort");
 
           const student1Answer = answers.getIn([questionId, student1.get("id")]);
           const student2Answer = answers.getIn([questionId, student2.get("id")]);

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -115,6 +115,13 @@ export const getCurrentQuestion = createSelector(
   }
 );
 
+export const getFirstQuestion = createSelector(
+  [ getQuestions ],
+  (questions) => {
+    return questions.first();
+  }
+);
+
 // Returns sorted students
 export const getSortedStudents = createSelector(
   [ getStudents, getDashboardSortBy, getStudentAverageProgress ],
@@ -144,8 +151,8 @@ export const getSortedStudents = createSelector(
   },
 );
 
-// Returns sorted students in feedback view
-export const getFeedbackSortedStudents = createSelector(
+// Returns sorted students in activity feedback view
+export const getActivityFeedbackSortedStudents = createSelector(
   [ getStudents, getDashboardFeedbackSortBy, getFeedback, getStudentProgress, getCurrentActivity, getFirstActivity ],
   (students, feedbackSortBy, feedback, studentProgress, currentActivity, firstActivity) => {
     switch (feedbackSortBy) {
@@ -155,19 +162,60 @@ export const getFeedbackSortedStudents = createSelector(
         );
       case SORT_BY_FEEDBACK_PROGRESS:
         return students.toList().sort((student1, student2) => {
-          // TODO: add support for question feedback
           const activityFeedbacks = feedback.get("activityFeedbacks");
           const currentActivityId = currentActivity ? currentActivity.get("id") : firstActivity.get("id");
           const student1Feedback = activityFeedbacks.find(function(f) { return f.get("platformStudentId") === student1.get("id")
                                                                           && f.get("activityId") === currentActivityId; });
           const student2Feedback = activityFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("activityId") === currentActivityId; });
-          const student1HasFeedback = student1Feedback !== undefined;
-          const student2HasFeedback = student2Feedback !== undefined;
+          const student1HasFeedback = student1Feedback !== undefined && student1Feedback !== ""
+            && !(student1Feedback.get("ignoreFeedbackWhenSorting") === true);
+          const student2HasFeedback = student2Feedback !== undefined && student1Feedback !== ""
+            && !(student2Feedback.get("ignoreFeedbackWhenSorting") === true);
           const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
           const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);
           const student1SortGroup = student1Progress === 0 ? kSortGroupThird : student1HasFeedback ? kSortGroupSecond : kSortGroupFirst;
           const student2SortGroup = student2Progress === 0 ? kSortGroupThird : student2HasFeedback ? kSortGroupSecond : kSortGroupFirst;
+          const feedbackComp = student1SortGroup === student2SortGroup ? 0 : student1SortGroup > student2SortGroup ? 1 : -1;
+          return feedbackComp;
+        });
+      default:
+        return students.toList();
+    }
+  },
+);
+
+// Returns sorted students in question feedback view
+export const getQuestionFeedbackSortedStudents = createSelector(
+  [ getStudents, getDashboardFeedbackSortBy, getFeedback, getCurrentQuestion, getFirstQuestion, getAnswersByQuestion ],
+  (students, feedbackSortBy, feedback, currentQuestion, firstQuestion, answers ) => {
+    switch (feedbackSortBy) {
+      case SORT_BY_FEEDBACK_NAME:
+        return students.toList().sort((student1, student2) =>
+          compareStudentsByName(student1, student2),
+        );
+      case SORT_BY_FEEDBACK_PROGRESS:
+        // TODO: change to sort by question feedback
+        return students.toList().sort((student1, student2) => {
+          const questionFeedbacks = feedback.get("questionFeedbacks");
+          const question = currentQuestion ? currentQuestion : firstQuestion;
+          const questionId = question.get("id");
+          const student1Feedback = questionFeedbacks.find(function(f) { return f.get("platformStudentId") === student1.get("id")
+                                                                          && f.get("questionId") === questionId; });
+          const student2Feedback = questionFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
+                                                                          && f.get("questionId") === questionId; });
+          const student1HasFeedback = student1Feedback !== undefined && student1Feedback !== ""
+            && !(student1Feedback.get("ignoreFeedbackWhenSorting") === true);
+          const student2HasFeedback = student2Feedback !== undefined && student2Feedback !== ""
+            && !(student2Feedback.get("ignoreFeedbackWhenSorting") === true);
+
+          const student1Answer = answers.getIn([questionId, student1.get("id")]);
+          const student2Answer = answers.getIn([questionId, student2.get("id")]);
+          const student1Answered = student1Answer && (!question.get("required") || student1Answer.get("submitted"));
+          const student2Answered = student2Answer && (!question.get("required") || student2Answer.get("submitted"));
+
+          const student1SortGroup = !student1Answered ? kSortGroupThird : student1HasFeedback ? kSortGroupSecond : kSortGroupFirst;
+          const student2SortGroup = !student2Answered ? kSortGroupThird : student2HasFeedback ? kSortGroupSecond : kSortGroupFirst;
           const feedbackComp = student1SortGroup === student2SortGroup ? 0 : student1SortGroup > student2SortGroup ? 1 : -1;
           return feedbackComp;
         });

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -168,9 +168,12 @@ export const getActivityFeedbackSortedStudents = createSelector(
                                                                           && f.get("activityId") === currentActivityId; });
           const student2Feedback = activityFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("activityId") === currentActivityId; });
-          const student1HasFeedback = student1Feedback !== undefined && student1Feedback !== ""
+          // TODO: need to handle case where feedback is empty string. This happens when feedback is deleted.
+          // In this case feedback must retain sort position with the completed feedback until refresh is pressed
+          // and it returns to awaiting feedback sort position at top of list.
+          const student1HasFeedback = student1Feedback !== undefined // && student1Feedback.get("feedback") !== ""
             && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
-          const student2HasFeedback = student2Feedback !== undefined && student2Feedback !== ""
+          const student2HasFeedback = student2Feedback !== undefined // && student2Feedback.get("feedback") !== ""
             && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
           const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
           const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);
@@ -204,9 +207,12 @@ export const getQuestionFeedbackSortedStudents = createSelector(
                                                                           && f.get("questionId") === questionId; });
           const student2Feedback = questionFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("questionId") === questionId; });
-          const student1HasFeedback = student1Feedback !== undefined && student1Feedback !== ""
+          // TODO: need to handle case where feedback is empty string. This happens when feedback is deleted.
+          // In this case feedback must retain sort position with the completed feedback until refresh is pressed
+          // and it returns to awaiting feedback sort position at top of list.
+          const student1HasFeedback = student1Feedback !== undefined // && student1Feedback.get("feedback") !== ""
             && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
-          const student2HasFeedback = student2Feedback !== undefined && student2Feedback !== ""
+          const student2HasFeedback = student2Feedback !== undefined // && student2Feedback.get("feedback") !== ""
             && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
 
           const student1Answer = answers.getIn([questionId, student1.get("id")]);

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -170,10 +170,12 @@ export const getActivityFeedbackSortedStudents = createSelector(
                                                                           && f.get("activityId") === currentActivityId; });
           // TODO: need to handle case where feedback is empty string. This happens when feedback is deleted.
           // In this case feedback must retain sort position with the completed feedback until refresh is pressed
-          // and it returns to awaiting feedback sort position at top of list.
-          const student1HasFeedback = student1Feedback !== undefined // && student1Feedback.get("feedback") !== ""
+          // and it returns to awaiting feedback sort position at top of list. deletedSinceLastSort flag is used to determine this.
+          const student1HasFeedback = student1Feedback !== undefined
+            && (student1Feedback.get("feedback") !== "" || student1Feedback.get("deletedSinceLastSort") === true)
             && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
-          const student2HasFeedback = student2Feedback !== undefined // && student2Feedback.get("feedback") !== ""
+          const student2HasFeedback = student2Feedback !== undefined
+            && (student2Feedback.get("feedback") !== "" || student2Feedback.get("deletedSinceLastSort") === true)
             && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
           const student1Progress = studentProgress.getIn([student1.get("id"), currentActivityId]);
           const student2Progress = studentProgress.getIn([student2.get("id"), currentActivityId]);
@@ -207,12 +209,14 @@ export const getQuestionFeedbackSortedStudents = createSelector(
                                                                           && f.get("questionId") === questionId; });
           const student2Feedback = questionFeedbacks.find(function(f) { return f.get("platformStudentId") === student2.get("id")
                                                                           && f.get("questionId") === questionId; });
-          // TODO: need to handle case where feedback is empty string. This happens when feedback is deleted.
+          // Handle case where feedback is empty string. This happens when feedback is deleted.
           // In this case feedback must retain sort position with the completed feedback until refresh is pressed
-          // and it returns to awaiting feedback sort position at top of list.
-          const student1HasFeedback = student1Feedback !== undefined // && student1Feedback.get("feedback") !== ""
+          // and it returns to awaiting feedback sort position at top of list. deletedSinceLastSort flag is used to determine this.
+          const student1HasFeedback = student1Feedback !== undefined
+            && (student1Feedback.get("feedback") !== "" || student1Feedback.get("deletedSinceLastSort") === true)
             && (student1Feedback.get("existingFeedbackSinceLastSort") === true);
-          const student2HasFeedback = student2Feedback !== undefined // && student2Feedback.get("feedback") !== ""
+          const student2HasFeedback = student2Feedback !== undefined
+            && (student2Feedback.get("feedback") !== "" || student2Feedback.get("deletedSinceLastSort") === true)
             && (student2Feedback.get("existingFeedbackSinceLastSort") === true);
 
           const student1Answer = answers.getIn([questionId, student1.get("id")]);


### PR DESCRIPTION
This PR updates the awaiting feedback search.  Changes include:
- add question sort, implemented in `getQuestionFeedbackSortedStudents`
- when refresh button is pressed or sort is changed, mark existing feedback since last sort with `existingFeedbackSinceLastSort` flag so sort knows which feedback has been added since the last sort (and can treat the feedback as if it were empty)
- improve handling of empty string feedbacks (most likely caused by deletion)
- fix Cypress tests