### PR TITLE
Fix handling of first question in response details when no question is selected

### DIFF
--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -76,14 +76,14 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
     const { selectedStudents, showSpotlightDialog, showSpotlightListDialog, feedbackLevel } = this.state;
 
     const firstActivity = activities.first();
-    const firstQuestion = questions?.first();
     const currentStudentIndex = students.findIndex((s: any) => s.get("id") === currentStudentId);
     const isSequence = activities.size > 1;
 
     const activityId = currentActivity ? currentActivity.get("id") : firstActivity.get("id");
     const currentActivityWithQuestions = activities.find(activity => activity.get("id") === activityId);
-    let qCount = 0;
+    const firstQuestion = currentActivityWithQuestions.get("questions").first();
 
+    let qCount = 0;
     activities.toArray().forEach((activity: Map<any, any>) => {
       if (activityId === activity.get("id")) {
         const questions = activity.get("questions");


### PR DESCRIPTION
This PR fixes the following bug:
- when the user opens the response details view, we check to see if there is a current activity and a current question.  If either is undefined, we get the first activity and/or the first question and display that to the user.  However, this neglects an important case.  A user can have a current activity (done by simply clicking on an activity in the level viewer) but NO current question.  In this case, it is not sufficient to simply get the first question, but instead we must get the first question _of the current activity_.  Otherwise, if, for example, the current activity was activity 2 and there was no current question, we would display the first question of activity 1.  This change ensures that we get a question that corresponds to the current activity.