### PR TITLE
Fix activity level feedback view when there is no rubric

### DIFF
--- a/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
+++ b/js/components/portal-dashboard/feedback/activity-level-feedback-student-rows.tsx
@@ -42,7 +42,7 @@ export const ActivityLevelFeedbackStudentRows: React.FC<IProps> = (props) => {
     const feedback = feedbackData.get("feedback");
     const hasRubric = rubric;
     const { rubricFeedback } = feedbackData.toJS();
-    const hasFeedbacks = feedback || hasRubricFeedback(rubric, rubricFeedback);
+    const hasFeedbacks = feedback || (hasRubric && hasRubricFeedback(rubric, rubricFeedback));
     const feedbackBadge = hasFeedbacks ? <GivenFeedbackActivityBadgeIcon /> : <AwaitingFeedbackActivityBadgeIcon />;
 
     return (


### PR DESCRIPTION
Bug was when user clicked on Activity toggle in feedback view, the page would turn blank. This was because it would fail when there was no rubric feedback.
This PR adds a check to see if there is rubric feedback before trying to check if rubric feedback had been given.