### PR TITLE
support preview_url in report-structure

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
@@ -10,6 +10,20 @@ context("Portal Dashboard Activity Buttons",() =>{
       cy.get('[data-cy=collapsed-activity-button]').should('have.length', 2);
     });
 
+    it('verify the preview (external link) buttons are working',() =>{
+      cy.get('[data-cy=collapsed-activity-button]')
+        .eq(0)
+        .find('[data-cy=external-link-button]')
+        .should('have.attr', 'href')
+        .and('include', 'http://app.lara.docker/activities/9');
+
+      cy.get('[data-cy=collapsed-activity-button]')
+        .eq(1)
+        .find('[data-cy=external-link-button]')
+        .should('have.attr', 'href')
+        .and('include', 'http://activity-player.concord.org?activity=http://app.lara.docker/activities/10&preview');
+    });
+
     describe('when clicking on activity buttons', () =>{
       it('verify we can click to open an activity button and see it expanded',() =>{
         cy.get('[data-cy=collapsed-activity-button]').first().click();

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
@@ -130,8 +130,7 @@ context("Portal Dashboard Question Details Panel", () => {
       });
       it('verify activity button opens teacher edition page', function() {
         cy.get("[data-cy=response-details-container] [data-cy=open-teacher-edition-button]").should('have.attr', 'href')
-        // FIXME: This will break for a correctly formed activity player preview url
-        .and('include', '?mode=teacher-edition');
+        .and('include', "http://activity-player.concord.org?activity=http%3A%2F%2Fapp.lara.docker%2Factivities%2F10&mode=teacher-edition&page=1&preview");
       });
     });
   });

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
@@ -86,6 +86,9 @@ context("Portal Dashboard Question Details Panel", () => {
   });
   context('Question nav area',()=>{
     before( function() {
+      // Start from a known location
+      cy.visit("/?portal-dashboard");
+      cy.get('[data-cy=collapsed-activity-button]').first().click();
       cy.get('[data-cy=activity-question-button]').eq(3).click();
       cy.get('[data-cy=question-overlay] [data-cy=question-overlay-title]').invoke('text').as('questionOverlayTitle');
       cy.get('[data-cy=question-overlay] [data-cy=question-title]').invoke('text').as('questionTitle');
@@ -111,8 +114,37 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get("[data-cy=response-details-container] [data-cy=open-teacher-edition-button]").should('have.attr', 'href')
       .and('include', '?mode=teacher-edition');
     });
+    context('Question nav of second activity with preview urls', ()=>{
+      before( function() {
+        // Start from a known location
+        cy.visit("/?portal-dashboard");
+        cy.get('[data-cy=collapsed-activity-button]').eq(1).click();
+        // open sidebar focused on the first question
+        cy.get('[data-cy=activity-question-button]').first().click();
+        // go into response details
+        cy.get('[data-cy=view-all-student-responses-button]').should('be.visible').click();
+      });
+      it('verify activity button opens preview_url page', function() {
+        cy.get("[data-cy=response-details-container] [data-cy=open-activity-button]").should('have.attr', 'href')
+        .and('include', "http://activity-player.concord.org?activity=http://app.lara.docker/activities/10&page=1&preview");
+      });
+      it('verify activity button opens teacher edition page', function() {
+        cy.get("[data-cy=response-details-container] [data-cy=open-teacher-edition-button]").should('have.attr', 'href')
+        // FIXME: This will break for a correctly formed activity player preview url
+        .and('include', '?mode=teacher-edition');
+      });
+    });
   });
   context('Student list and responses area', () => {
+    before( function() {
+      // Start from a known location
+      cy.visit("/?portal-dashboard");
+      cy.get('[data-cy=collapsed-activity-button]').first().click();
+      // open sidebar focused on the 4th question
+      cy.get('[data-cy=activity-question-button]').eq(3).click();
+      // go into response details
+      cy.get('[data-cy=view-all-student-responses-button]').should('be.visible').click();
+    });
     it('verify student names are listed',()=>{
       cy.get('[data-cy=student-name]').eq(0).should("contain", "Armstrong, Jenna");
       cy.get('[data-cy=student-name]').eq(1).should("contain", "Crosby, Kate");

--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -70,7 +70,8 @@ export class LevelViewer extends React.PureComponent<IProps> {
             <div className={`${css.activityImage} ${this.activityColorClass(idx)}`} />
           </div>
           <div className={css.externalLink}>
-            <a className={css.externalLinkButton} href={activity.get("previewUrl")} target="_blank">
+            <a className={css.externalLinkButton} data-cy="external-link-button"
+              href={activity.get("previewUrl")} target="_blank">
               <LaunchIcon className={css.icon} />
             </a>
           </div>

--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -70,7 +70,7 @@ export class LevelViewer extends React.PureComponent<IProps> {
             <div className={`${css.activityImage} ${this.activityColorClass(idx)}`} />
           </div>
           <div className={css.externalLink}>
-            <a className={css.externalLinkButton} href={activity.get("url")} target="_blank">
+            <a className={css.externalLinkButton} href={activity.get("previewUrl")} target="_blank">
               <LaunchIcon className={css.icon} />
             </a>
           </div>

--- a/js/components/portal-dashboard/question-area.tsx
+++ b/js/components/portal-dashboard/question-area.tsx
@@ -27,6 +27,7 @@ export class QuestionArea extends React.PureComponent<IProps>{
     const questionType = QuestionTypes.find(qt => qt.type === type && qt.scored === scored);
     const QuestionIcon = questionType?.icon;
     const activityURL = currentQuestion?.get("questionUrl");
+    const activityTeacherEdtionURL = currentQuestion?.get("questionTeacherEditionUrl");
 
     return (
       <div className={`${css.questionContentArea} ${hideQuestion ? css.hidden : ""}`}>
@@ -41,10 +42,8 @@ export class QuestionArea extends React.PureComponent<IProps>{
             <a className={css.externalLinkButton} href={activityURL} target="_blank" data-cy="open-activity-button" onClick={() => trackEvent("Portal-Dashboard", "OpenExternalLink", {label: activityURL})}>
               <LaunchIcon className={css.icon} />
             </a>
-            { // FIXME: notice how the 'teacher-edition' url is setup, this will not work with the activity player
-            }
             {hasTeacherEdition &&
-              <a className={css.teacherEditionIcon} href={`${activityURL}/?mode=teacher-edition`} target="_blank" data-cy="open-teacher-edition-button" onClick={() => trackEvent("Portal-Dashboard", "OpenTeacherEdition", {label: `${activityURL}/?mode=teacher-edition`})}>
+              <a className={css.teacherEditionIcon} href={activityTeacherEdtionURL} target="_blank" data-cy="open-teacher-edition-button" onClick={() => trackEvent("Portal-Dashboard", "OpenTeacherEdition", {label: `${activityURL}/?mode=teacher-edition`})}>
                 <div className={teacherEditionButtonClasses}>
                   <LaunchIcon className={css.icon} />
                 </div>

--- a/js/components/portal-dashboard/question-area.tsx
+++ b/js/components/portal-dashboard/question-area.tsx
@@ -27,7 +27,7 @@ export class QuestionArea extends React.PureComponent<IProps>{
     const questionType = QuestionTypes.find(qt => qt.type === type && qt.scored === scored);
     const QuestionIcon = questionType?.icon;
     const activityURL = currentQuestion?.get("questionUrl");
-    const activityTeacherEdtionURL = currentQuestion?.get("questionTeacherEditionUrl");
+    const activityTeacherEditionURL = currentQuestion?.get("questionTeacherEditionUrl");
 
     return (
       <div className={`${css.questionContentArea} ${hideQuestion ? css.hidden : ""}`}>
@@ -43,7 +43,7 @@ export class QuestionArea extends React.PureComponent<IProps>{
               <LaunchIcon className={css.icon} />
             </a>
             {hasTeacherEdition &&
-              <a className={css.teacherEditionIcon} href={activityTeacherEdtionURL} target="_blank" data-cy="open-teacher-edition-button" onClick={() => trackEvent("Portal-Dashboard", "OpenTeacherEdition", {label: `${activityURL}/?mode=teacher-edition`})}>
+              <a className={css.teacherEditionIcon} href={activityTeacherEditionURL} target="_blank" data-cy="open-teacher-edition-button" onClick={() => trackEvent("Portal-Dashboard", "OpenTeacherEdition", {label: `${activityURL}/?mode=teacher-edition`})}>
                 <div className={teacherEditionButtonClasses}>
                   <LaunchIcon className={css.icon} />
                 </div>

--- a/js/components/portal-dashboard/question-area.tsx
+++ b/js/components/portal-dashboard/question-area.tsx
@@ -41,6 +41,8 @@ export class QuestionArea extends React.PureComponent<IProps>{
             <a className={css.externalLinkButton} href={activityURL} target="_blank" data-cy="open-activity-button" onClick={() => trackEvent("Portal-Dashboard", "OpenExternalLink", {label: activityURL})}>
               <LaunchIcon className={css.icon} />
             </a>
+            { // FIXME: notice how the 'teacher-edition' url is setup, this will not work with the activity player
+            }
             {hasTeacherEdition &&
               <a className={css.teacherEditionIcon} href={`${activityURL}/?mode=teacher-edition`} target="_blank" data-cy="open-teacher-edition-button" onClick={() => trackEvent("Portal-Dashboard", "OpenTeacherEdition", {label: `${activityURL}/?mode=teacher-edition`})}>
                 <div className={teacherEditionButtonClasses}>

--- a/js/components/report/page.js
+++ b/js/components/report/page.js
@@ -9,19 +9,19 @@ export default class Page extends PureComponent {
     const { page, reportFor } = this.props;
     const pageName = page.get("name");
     const showLinks = reportFor === "class";
-    const url = showLinks ? page.get("url") : null;
+    const previewUrl = showLinks ? page.get("previewUrl") : null;
     return (
       <div className={`page ${page.get("visible") ? "" : "hidden"}`}>
         <Sticky top={100}>
           <h4>
-            <MaybeLink url={url}>
+            <MaybeLink url={previewUrl}>
               <span>Page: {pageName}</span>
             </MaybeLink>
           </h4>
         </Sticky>
         <div>
           {page.get("children").map((question) => {
-            return <Question key={question.get("id")} question={question} reportFor={reportFor} url={url} />;
+            return <Question key={question.get("id")} question={question} reportFor={reportFor} url={previewUrl} />;
           })}
         </div>
       </div>

--- a/js/core/transform-json-response.ts
+++ b/js/core/transform-json-response.ts
@@ -38,6 +38,7 @@ export interface IQuestion extends IResource {
   section: string;
   page: string;
   questionUrl: string;
+  questionTeacherEditionUrl: string;
   prompt: string;
   selected: boolean;
   scored?: boolean; // multiple choice only
@@ -126,6 +127,13 @@ export function normalizeResourceJSON(json: any) {
   return normalize(camelizedJson, sequence);
 }
 
+// This is used to add mode=teacher-edition
+export function addMode(url: string, mode: string) {
+  const urlParts = queryString.parseUrl(url);
+  urlParts.query.mode = mode;
+  return queryString.stringifyUrl(urlParts);
+}
+
 export function preprocessResourceJSON(resourceJson: IResource) {
   // Provide fake sequence if it's not present to simplify app logic.
   if (resourceJson.type === "activity") {
@@ -157,6 +165,7 @@ export function preprocessResourceJSON(resourceJson: IResource) {
           question.section = section.id;
           question.page = page.id;
           question.questionUrl = page.previewUrl;
+          question.questionTeacherEditionUrl = addMode(page.previewUrl, "teacher-edition");
           // Nothing is selected by default.
           question.selected = false;
           if (question.type === "multiple_choice") {

--- a/js/core/transform-json-response.ts
+++ b/js/core/transform-json-response.ts
@@ -12,6 +12,11 @@ export interface IResource {
 
 export interface IActivity extends IResource {
   activityIndex: number;
+  url: string;
+  // Note that when the data comes down this field is optional
+  // But this interface is really intended for users of this data
+  // after it has been transformed by the function below
+  previewUrl: string;
 }
 
 export interface ISection extends IResource {
@@ -22,6 +27,10 @@ export interface IPage extends IResource {
   activity: string;
   section: string;
   url: string;
+  // Note that when the data comes down this field is optional
+  // But this interface is really intended for users of this data
+  // after it has been transformed by the function below
+  previewUrl: string;
 }
 
 export interface IQuestion extends IResource {
@@ -130,16 +139,24 @@ export function preprocessResourceJSON(resourceJson: IResource) {
   // Add some question properties, e.g. question numbers, selection, visibility.
   resourceJson.children.forEach((activity: IActivity, idx: number) => {
     activity.activityIndex = idx;
+    if (!activity.previewUrl) {
+      activity.previewUrl = activity.url;
+    }
     activity.children.forEach((section: ISection) => {
       section.activity = activity.id;
       section.children.forEach((page: IPage) => {
         page.activity = activity.id;
         page.section = section.id;
+        // Note the incoming field is 'preview_url', but this gets camelized
+        // before being sent to preprocessResourceJSON
+        if (!page.previewUrl) {
+          page.previewUrl = page.url;
+        }
         page.children.forEach((question: IQuestion) => {
           question.activity = activity.id;
           question.section = section.id;
           question.page = page.id;
-          question.questionUrl = page.url;
+          question.questionUrl = page.previewUrl;
           // Nothing is selected by default.
           question.selected = false;
           if (question.type === "multiple_choice") {

--- a/js/data/sequence-structure.json
+++ b/js/data/sequence-structure.json
@@ -132,6 +132,7 @@
       "name": "Report Test Activity 2",
       "type": "activity",
       "url": "http://app.lara.docker/activities/10",
+      "preview_url": "http://activity-player.concord.org?activity=http://app.lara.docker/activities/10&preview",
       "children": [
         {
           "id": "section-10",
@@ -144,6 +145,7 @@
               "name": "State-saving interactives",
               "type": "page",
               "url": "http://app.lara.docker/pages/27",
+              "preview_url": "http://activity-player.concord.org?activity=http://app.lara.docker/activities/10&page=1&preview",
               "children": [
                 {
                   "display_in_iframe": true,

--- a/test/core/transforom-json-response_spec.js
+++ b/test/core/transforom-json-response_spec.js
@@ -39,7 +39,7 @@ describe("preprocessResourceJSON helper", () => {
     ]
   };
 
-  // Note the incoming data would be use preview_url, but that gets
+  // Note the incoming data uses preview_url, but that gets
   // camelized before being sent to preprocessResourceJSON
   const activityJSONWithPreviewUrls = {
     id: 1,

--- a/test/core/transforom-json-response_spec.js
+++ b/test/core/transforom-json-response_spec.js
@@ -1,4 +1,5 @@
 import { preprocessResourceJSON } from "../../js/core/transform-json-response";
+import queryString from "query-string";
 
 describe("preprocessResourceJSON helper", () => {
   const activityJSON = {
@@ -46,7 +47,7 @@ describe("preprocessResourceJSON helper", () => {
     type: "activity",
     name: "Test activity",
     url: "http://example.com/activities/1",
-    previewUrl: "http://example.com/preview/activities/1",
+    previewUrl: "http://example.com/activities/1?preview",
     children: [
       {
         id: 1,
@@ -56,7 +57,7 @@ describe("preprocessResourceJSON helper", () => {
             id: 1,
             type: "page",
             url: "http://example.com/pages/1",
-            previewUrl: "http://example.com/preview/pages/1",
+            previewUrl: "http://example.com/pages/1?preview",
             children: [
               {
                 id: 1,
@@ -96,6 +97,11 @@ describe("preprocessResourceJSON helper", () => {
       expect(resource.children[0].children[0].children[0].children[0].type).toBe("multiple_choice");
       expect(resource.children[0].children[0].children[0].children[0].scored).toBe(true);
     });
+    it("should have a teacherEdition url", () => {
+      const resource = preprocessResourceJSON(activityJSON);
+      //                 activity     section        page    question
+      expect(resource.children[0].children[0].children[0].children[0].questionTeacherEditionUrl).toBe("http://example.com/pages/1?mode=teacher-edition");
+    });
   });
 
   describe("when there is no previewUrl on a page", () => {
@@ -117,13 +123,24 @@ describe("preprocessResourceJSON helper", () => {
     it("shouldn't be modified", () => {
       const resource = preprocessResourceJSON(activityJSONWithPreviewUrls);
       //                 activity     section        page
-      expect(resource.children[0].children[0].children[0].previewUrl).toBe("http://example.com/preview/pages/1");
+      expect(resource.children[0].children[0].children[0].previewUrl).toBe("http://example.com/pages/1?preview");
     });
 
     it("should set the questionUrl to match the page previewUrl", () => {
       const resource = preprocessResourceJSON(activityJSONWithPreviewUrls);
       //                 activity     section        page    question
-      expect(resource.children[0].children[0].children[0].children[0].questionUrl).toBe("http://example.com/preview/pages/1");
+      expect(resource.children[0].children[0].children[0].children[0].questionUrl).toBe("http://example.com/pages/1?preview");
+    });
+
+    describe("and there is a question", () => {
+      it("should have a teacherEdition url", () => {
+        const resource = preprocessResourceJSON(activityJSONWithPreviewUrls);
+        //                                    activity     section        page    question
+        const teacherEditionUrl = resource.children[0].children[0].children[0].children[0].questionTeacherEditionUrl;
+        const urlParts = queryString.parseUrl(teacherEditionUrl);
+        expect(urlParts.url).toBe("http://example.com/pages/1");
+        expect(urlParts.query).toMatchObject({mode: "teacher-edition", preview: null});
+      });
     });
 
   });
@@ -141,7 +158,7 @@ describe("preprocessResourceJSON helper", () => {
     it("shouldn't be modified", () => {
       const resource = preprocessResourceJSON(activityJSONWithPreviewUrls);
       //                 activity
-      expect(resource.children[0].previewUrl).toBe("http://example.com/preview/activities/1");
+      expect(resource.children[0].previewUrl).toBe("http://example.com/activities/1?preview");
     });
   });
 

--- a/test/core/transforom-json-response_spec.js
+++ b/test/core/transforom-json-response_spec.js
@@ -5,6 +5,7 @@ describe("preprocessResourceJSON helper", () => {
     id: 1,
     type: "activity",
     name: "Test activity",
+    url: "http://example.com/activities/1",
     children: [
       {
         id: 1,
@@ -13,6 +14,49 @@ describe("preprocessResourceJSON helper", () => {
           {
             id: 1,
             type: "page",
+            url: "http://example.com/pages/1",
+            children: [
+              {
+                id: 1,
+                type: "multiple_choice",
+                choices: [
+                  {
+                    id: 1,
+                    content: "a",
+                    correct: true
+                  },
+                  {
+                    id: 2,
+                    content: "b",
+                    correct: false
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  // Note the incoming data would be use preview_url, but that gets
+  // camelized before being sent to preprocessResourceJSON
+  const activityJSONWithPreviewUrls = {
+    id: 1,
+    type: "activity",
+    name: "Test activity",
+    url: "http://example.com/activities/1",
+    previewUrl: "http://example.com/preview/activities/1",
+    children: [
+      {
+        id: 1,
+        type: "section",
+        children: [
+          {
+            id: 1,
+            type: "page",
+            url: "http://example.com/pages/1",
+            previewUrl: "http://example.com/preview/pages/1",
             children: [
               {
                 id: 1,
@@ -48,8 +92,57 @@ describe("preprocessResourceJSON helper", () => {
   describe("when there is a multiple_choice question", () => {
     it("should compute `scored` property", () => {
       const resource = preprocessResourceJSON(activityJSON);
+      //                 activity     section        page    question
       expect(resource.children[0].children[0].children[0].children[0].type).toBe("multiple_choice");
       expect(resource.children[0].children[0].children[0].children[0].scored).toBe(true);
     });
   });
+
+  describe("when there is no previewUrl on a page", () => {
+    it("should add one", () => {
+      const resource = preprocessResourceJSON(activityJSON);
+      //                 activity     section        page
+      expect(resource.children[0].children[0].children[0].previewUrl).toBe("http://example.com/pages/1");
+    });
+
+    it("should set the questionUrl to match the page url", () => {
+      const resource = preprocessResourceJSON(activityJSON);
+      //                 activity     section        page    question
+      expect(resource.children[0].children[0].children[0].children[0].questionUrl).toBe("http://example.com/pages/1");
+    });
+
+  });
+
+  describe("when there is a previewUrl on a page", () => {
+    it("shouldn't be modified", () => {
+      const resource = preprocessResourceJSON(activityJSONWithPreviewUrls);
+      //                 activity     section        page
+      expect(resource.children[0].children[0].children[0].previewUrl).toBe("http://example.com/preview/pages/1");
+    });
+
+    it("should set the questionUrl to match the page previewUrl", () => {
+      const resource = preprocessResourceJSON(activityJSONWithPreviewUrls);
+      //                 activity     section        page    question
+      expect(resource.children[0].children[0].children[0].children[0].questionUrl).toBe("http://example.com/preview/pages/1");
+    });
+
+  });
+
+
+  describe("when there is no previewUrl on a activity", () => {
+    it("should add one", () => {
+      const resource = preprocessResourceJSON(activityJSON);
+      //                 activity
+      expect(resource.children[0].previewUrl).toBe("http://example.com/activities/1");
+    });
+  });
+
+  describe("when there is a previewUrl on a activity", () => {
+    it("shouldn't be modified", () => {
+      const resource = preprocessResourceJSON(activityJSONWithPreviewUrls);
+      //                 activity
+      expect(resource.children[0].previewUrl).toBe("http://example.com/preview/activities/1");
+    });
+  });
+
 });


### PR DESCRIPTION
the preview_url was added to support activity player runtime activities
the url of the activity in the resource structure needed to stay pointing at the LARA runtime
so the resource structure document could be found during Firestore queries,

the preview_url is optional so we don't need to go and update existing report-structures that
have already been published to Firestore.

TODO

- [x] handle the teacher edition links for activity player activities correctly
- [x] add a cypress test to verify the the preview_url is making it into the UI