### PR TITLE
Removes second colon in class-nav

### DIFF
--- a/js/components/portal-dashboard/class-nav.tsx
+++ b/js/components/portal-dashboard/class-nav.tsx
@@ -29,7 +29,7 @@ export class ClassNav extends React.PureComponent<IProps> {
       <div className={css.classNav} data-cy="class-nav">
         { this.renderClassSelect() }
         <AnonymizeStudents anonymous={anonymous} setAnonymous={setAnonymous} />
-        <CountContainer numItems={studentCount} containerLabel={"Class: "} containerLabelType={"students"} />
+        <CountContainer numItems={studentCount} containerLabel={"Class"} containerLabelType={"students"} />
         { this.renderStudentSort() }
       </div>
     );


### PR DESCRIPTION
Removes a redundant colon from class nav student label
<img width="402" alt="Screen Shot 2021-03-02 at 10 20 13 AM" src="https://user-images.githubusercontent.com/7716653/109723121-85fe9e80-7b62-11eb-9b0f-4da6a65bb80d.png">
