### PR TITLE
Order map keys when generating answer hash to ensure repeatable hash results

### DIFF
--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -27,7 +27,9 @@ export const compareStudentsByName = (student1: Map<string, any>, student2: Map<
 export const answerHash = (answer: Map<string, any>) => {
   let answerContent = answer.get("answer");
   if (typeof answerContent !== "string") {
-    answerContent = JSON.stringify(answerContent.toJS());
+    answerContent = Map.isMap(answerContent)
+      ? JSON.stringify(answerContent.sortBy((v: any, k: any) => k).toJS())
+      : JSON.stringify(answerContent.toJS());
   }
   return md5(answerContent);
 };

--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -27,9 +27,11 @@ export const compareStudentsByName = (student1: Map<string, any>, student2: Map<
 export const answerHash = (answer: Map<string, any>) => {
   let answerContent = answer.get("answer");
   if (typeof answerContent !== "string") {
+    // the non-Map case likely doesn't hit at present, but this adds protection
+    // in case future answerContent has non-string/non-Map value
     answerContent = Map.isMap(answerContent)
       ? JSON.stringify(answerContent.sortBy((v: any, k: any) => k).toJS())
-      : JSON.stringify(answerContent.toJS());
+      : JSON.stringify(answerContent);
   }
   return md5(answerContent);
 };

--- a/test/util/misc_spec.ts
+++ b/test/util/misc_spec.ts
@@ -1,0 +1,36 @@
+import { Map } from "immutable";
+import { answerHash } from "../../js/util/misc";
+
+describe("misc util functions", () => {
+  it("determines if answer hash is properly generated", () => {
+
+    const simpleAnswer1 = Map({ answer: "foo" });
+    const simpleAnswer2 = Map({ answer: "foo" });
+    const simpleAnswer3 = Map({ answer: "bar" });
+
+    const simpleAnswer1Hash = answerHash(simpleAnswer1);
+    const simpleAnswer2Hash = answerHash(simpleAnswer2);
+    const simpleAnswer3Hash = answerHash(simpleAnswer3);
+
+    expect(simpleAnswer1Hash).toEqual(simpleAnswer2Hash);
+    expect(simpleAnswer1Hash).not.toEqual(simpleAnswer3Hash);
+    expect(simpleAnswer2Hash).not.toEqual(simpleAnswer3Hash);
+
+    const complexAnswerContent1 = Map({ image: "www.test.com/image.jpg", text: "foo" });
+    const complexAnswerContent2 = Map({ text: "foo", image: "www.test.com/image.jpg" });
+    const complexAnswerContent3 = Map({ image: "www.test.com/image.jpg", text: "bar" });
+    const complexAnswer1 = Map({ answer: complexAnswerContent1 });
+    const complexAnswer2 = Map({ answer: complexAnswerContent2 });
+    const complexAnswer3 = Map({ answer: complexAnswerContent3 });
+
+    const complexAnswer1Hash = answerHash(complexAnswer1);
+    const complexAnswer2Hash = answerHash(complexAnswer2);
+    const complexAnswer3Hash = answerHash(complexAnswer3);
+
+    // this tests the case where the map keys are in different orders, but the content is the same
+    expect(complexAnswer1Hash).toEqual(complexAnswer2Hash);
+
+    expect(complexAnswer1Hash).not.toEqual(complexAnswer3Hash);
+    expect(complexAnswer2Hash).not.toEqual(complexAnswer3Hash);
+  });
+});

--- a/test/util/misc_spec.ts
+++ b/test/util/misc_spec.ts
@@ -4,6 +4,7 @@ import { answerHash } from "../../js/util/misc";
 describe("misc util functions", () => {
   it("determines if answer hash is properly generated", () => {
 
+    // test string answer content
     const simpleAnswer1 = Map({ answer: "foo" });
     const simpleAnswer2 = Map({ answer: "foo" });
     const simpleAnswer3 = Map({ answer: "bar" });
@@ -16,6 +17,7 @@ describe("misc util functions", () => {
     expect(simpleAnswer1Hash).not.toEqual(simpleAnswer3Hash);
     expect(simpleAnswer2Hash).not.toEqual(simpleAnswer3Hash);
 
+    // test map answer content
     const complexAnswerContent1 = Map({ image: "www.test.com/image.jpg", text: "foo" });
     const complexAnswerContent2 = Map({ text: "foo", image: "www.test.com/image.jpg" });
     const complexAnswerContent3 = Map({ image: "www.test.com/image.jpg", text: "bar" });
@@ -32,5 +34,18 @@ describe("misc util functions", () => {
 
     expect(complexAnswer1Hash).not.toEqual(complexAnswer3Hash);
     expect(complexAnswer2Hash).not.toEqual(complexAnswer3Hash);
+
+    // test non-map, non-string answer content
+    const arrayAnswer1 = Map({ answer: [1, 2, 3] });
+    const arrayAnswer2 = Map({ answer: [1, 2, 3] });
+    const arrayAnswer3 = Map({ answer: [4, 5, 6] });
+
+    const arrayAnswer1Hash = answerHash(arrayAnswer1);
+    const arrayAnswer2Hash = answerHash(arrayAnswer2);
+    const arrayAnswer3Hash = answerHash(arrayAnswer3);
+
+    expect(arrayAnswer1Hash).toEqual(arrayAnswer2Hash);
+    expect(arrayAnswer2Hash).not.toEqual(arrayAnswer3Hash);
+    expect(arrayAnswer1Hash).not.toEqual(simpleAnswer3Hash);
   });
 });


### PR DESCRIPTION
This PR fixes a bug that caused valid image question feedback to sporadically be hidden.  This was caused by a mismatch between the answer hash stored with the feedback and the answer hash created in the dashboard from the current image question answer - this mismatch caused us to hide the feedback (thinking that it was out of date because the answer had changed).  Even when the user-facing image question answer has not changed, the stored structure of the answer can change.  Most answers are simple text strings.  However, the image question answer is stored as an Immutable JS `Map` with two keys: `image` and `text`.  Depending on how that `Map` was created, we would sometimes get the `image` key first and sometimes get the `text` key first.  In other words, the key order was not predictable.  We then stringified the `Map`, ran it through the `md5` hash function, and saved the results.  But because the key order was not stable, we could actually get two different hash values from a single user-facing answer.  
The solution is to detect if we have an answer in the form of a `Map`, order the keys in alpha-numeric order, and then stringify the key-ordered structure.  This guarantees the same hash each time.  I don't think we need to go deeper than looking at the top-level answer itself since answers do not typically have much complexity (they are  usually a simple string - the image question was the only example I found so far that required anything beyond a string).  But I am willing to dig into looking for a `Map` within a `Map` if folks think that we will have answers with that complexity.