### PR TITLE
Fix question nav height

### DIFF
--- a/css/portal-dashboard/response-details/response-details.less
+++ b/css/portal-dashboard/response-details/response-details.less
@@ -14,10 +14,11 @@
     .contentNavigatorArea {
       background: @cc-teal-light6;
       min-height: 250px;
-      height: calc(100% - 50px);
+      height: 100%;
 
       &.short {
         min-height: 200px;
+        height: calc(100% - 51px);
       }
     }
   }


### PR DESCRIPTION
This PR fixes the question nav height in the response details view when there is only a single activity.

![image](https://user-images.githubusercontent.com/5126913/116921722-3e030300-ac09-11eb-9922-a2db614c6d4f.png)
