### PR TITLE
Add researcher support

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -319,6 +319,14 @@ function watchCollection(db: firebase.firestore.Firestore, path: string, receive
     // "context_id" is theoretically redundant here, since we already filter by resource_link_id,
     // but that lets us use context_id value in the Firestore security rules.
     query = query.where(correctKey("context_id", receiveMsg), "==", rawPortalData.contextId);
+
+    // If there is a studentId url param add that as a platform_user_id filter too
+    // This optimizes the query when looking at a single student
+    // It is also necessary when a researcher is looking at a single student's data
+    const studentId = urlParam("studentId");
+    if (studentId) {
+      query = query.where(correctKey("platform_user_id", receiveMsg), "==", studentId);
+    }
   }
 
   addSnapshotDispatchListener(query, receiveMsg, dispatch,

--- a/js/api.ts
+++ b/js/api.ts
@@ -130,7 +130,7 @@ const getPortalBaseUrl = () => {
   return `${protocol}//${hostname}`;
 };
 
-export const getPortalFirebaseJWTUrl = (classHash: string, resourceLinkId: string | null, firebaseApp: string | undefined ) => {
+export const getPortalFirebaseJWTUrl = (classHash: string, resourceLinkId: string | null, targetUserId: string | null, firebaseApp: string | undefined ) => {
   if(!firebaseApp){
     firebaseApp = getFirebaseAppName();
   }
@@ -139,7 +139,8 @@ export const getPortalFirebaseJWTUrl = (classHash: string, resourceLinkId: strin
     return null;
   }
   const resourceLinkParam = resourceLinkId ? `&resource_link_id=${resourceLinkId}` : "";
-  return `${baseUrl}/api/v1/jwt/firebase?firebase_app=${firebaseApp}&class_hash=${classHash}${resourceLinkParam}`;
+  const targetUserParam = targetUserId ? `&target_user_id=${targetUserId}` : "";
+  return `${baseUrl}/api/v1/jwt/firebase?firebase_app=${firebaseApp}&class_hash=${classHash}${resourceLinkParam}${targetUserParam}`;
 };
 
 const gePortalReportAPIUrl = () => {
@@ -184,8 +185,8 @@ export function fetchClassData() {
   }
 }
 
-export function fetchFirestoreJWT(classHash: string, resourceLinkId: string | null = null, firebaseApp?: string) {
-  const firestoreJWTUrl = getPortalFirebaseJWTUrl(classHash, resourceLinkId, firebaseApp );
+export function fetchFirestoreJWT(classHash: string, resourceLinkId: string | null = null, targetUserId: string | null = null, firebaseApp?: string) {
+  const firestoreJWTUrl = getPortalFirebaseJWTUrl(classHash, resourceLinkId, targetUserId, firebaseApp );
   if (firestoreJWTUrl) {
     return fetch(firestoreJWTUrl, {headers: {Authorization: getAuthHeader()}})
       .then(checkStatus)
@@ -227,7 +228,8 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
     // only pass resourceLinkId if there is a studentId
     // FIXME: if this is a teacher viewing the report of a student there will be a studentId
     // but the token will be for a teacher, so then the resourceLinkId should be null
-    const firestoreJWTPromise = fetchFirestoreJWT(classData.class_hash, urlParam("studentId") ? resourceLinkId : null);
+    // I don't understand this comment anymore.
+    const firestoreJWTPromise = fetchFirestoreJWT(classData.class_hash, urlParam("studentId") ? resourceLinkId : null, urlParam("studentId"));
     return firestoreJWTPromise.then((result: any) => {
       const rawFirestoreJWT = result.token;
       if (rawFirestoreJWT !== FAKE_FIRESTORE_JWT) {

--- a/js/api.ts
+++ b/js/api.ts
@@ -227,7 +227,7 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
     const resourceLinkId = offeringData.id.toString();
     // only pass resourceLinkId if there is a studentId
     // This could be a teacher or researcher viewing the report of a student
-    // The studentId is also passed as the target_user_id 
+    // The studentId is sent in the firestore JWT request as the target_user_id
     const firestoreJWTPromise = fetchFirestoreJWT(classData.class_hash, urlParam("studentId") ? resourceLinkId : null, urlParam("studentId"));
     return firestoreJWTPromise.then((result: any) => {
       const rawFirestoreJWT = result.token;

--- a/js/api.ts
+++ b/js/api.ts
@@ -226,9 +226,8 @@ export function fetchPortalDataAndAuthFirestore(): Promise<IPortalRawData> {
   return Promise.all([offeringPromise, classPromise]).then(([offeringData, classData]: [any, any]) => {
     const resourceLinkId = offeringData.id.toString();
     // only pass resourceLinkId if there is a studentId
-    // FIXME: if this is a teacher viewing the report of a student there will be a studentId
-    // but the token will be for a teacher, so then the resourceLinkId should be null
-    // I don't understand this comment anymore.
+    // This could be a teacher or researcher viewing the report of a student
+    // The studentId is also passed as the target_user_id 
     const firestoreJWTPromise = fetchFirestoreJWT(classData.class_hash, urlParam("studentId") ? resourceLinkId : null, urlParam("studentId"));
     return firestoreJWTPromise.then((result: any) => {
       const rawFirestoreJWT = result.token;

--- a/js/components/report/interactive-iframe.js
+++ b/js/components/report/interactive-iframe.js
@@ -39,9 +39,8 @@ export default class InteractiveIframe extends PureComponent {
       .then(([offeringData, classData]) => {
         const resourceLinkId = offeringData.id.toString();
         // only pass resourceLinkId if there is a studentId
-        // FIXME: if this is a teacher viewing the report of a student there will be a studentId
-        // but the token will be for a teacher, so then the resourceLinkId should be null
-        // I don't understand this comment anymore
+        // This could be a teacher or researcher viewing the report of a student
+        // The studentId is sent in the firestore JWT request as the target_user_id
         return fetchFirestoreJWT(classData.class_hash, urlParam("studentId") ? resourceLinkId : null, urlParam("studentId"), options.firebase_app);
       })
       .then(json => {

--- a/js/components/report/interactive-iframe.js
+++ b/js/components/report/interactive-iframe.js
@@ -41,7 +41,8 @@ export default class InteractiveIframe extends PureComponent {
         // only pass resourceLinkId if there is a studentId
         // FIXME: if this is a teacher viewing the report of a student there will be a studentId
         // but the token will be for a teacher, so then the resourceLinkId should be null
-        return fetchFirestoreJWT(classData.class_hash, urlParam("studentId") ? resourceLinkId : null, options.firebase_app);
+        // I don't understand this comment anymore
+        return fetchFirestoreJWT(classData.class_hash, urlParam("studentId") ? resourceLinkId : null, urlParam("studentId"), options.firebase_app);
       })
       .then(json => {
         this.iframePhone.post("firebaseJWT", json);


### PR DESCRIPTION
This uses the new portal researcher JWT support,
and the new report-service researcher support.

It does this by passing a target_user_id parameter to the portal's firebase JWT endpoint.

And it now passes the studentId param into the firestore queries.
This is needed so the firestore rules can only allow access to a specific student
based on the JWT issued by the portal.
This might also speed up the per student report since it will limit the number of answers returned.