### PR TITLE
tell firebase to store auth in session storage

### DIFF
--- a/js/db.ts
+++ b/js/db.ts
@@ -111,6 +111,8 @@ export const signInWithToken = (rawFirestoreJWT: string) => {
   const signOutPromise = firebase.auth().signOut();
   if (!SKIP_SIGN_IN) {
     return signOutPromise.then(() => {
+      return firebase.auth().setPersistence(firebase.auth.Auth.Persistence.SESSION);
+    }).then(() => {
       return firebase.auth().signInWithCustomToken(rawFirestoreJWT);
     });
   } else {


### PR DESCRIPTION
this fixes a bug with multiple reports being open for different assignments
at the same time. When the second report is opened it logs into Firebase
with a different JWT. Without the change in this branch firebase applies the new
JWT to the first tab too.
If the two assignments are in the same class, in theory, new JWT should
give the teacher permission to view the report data from both tabs.
But for some reason it doesn't behave that way.

In any case using session persistence keeps the auth separate for each
tab, so it fixes the problem

[#179369645]