### PR TITLE
Handle errors in image question documents

### DIFF
--- a/cypress/integration/geode-dashboard-smoke-test.spec.js
+++ b/cypress/integration/geode-dashboard-smoke-test.spec.js
@@ -50,7 +50,7 @@ context("Geode Dashboard Smoke Test", () => {
                 .should("be.visible");
             dashboard.getStudentNames().eq(0)
                 .should("contain", "Crosby, Kate" );
-            dashboard.getStudentAnswersRow().eq(1)
+            dashboard.getStudentAnswersRow().eq(0)
                 .within(() => {
                     dashboard.getProgressBar().eq(0)
                         .should("not.be.visible");

--- a/cypress/integration/geode-dashboard-smoke-test.spec.js
+++ b/cypress/integration/geode-dashboard-smoke-test.spec.js
@@ -49,7 +49,7 @@ context("Geode Dashboard Smoke Test", () => {
                 .select("Least Progress")
                 .should("be.visible");
             dashboard.getStudentNames().eq(0)
-                .should("contain", "Galloway, Amy" );
+                .should("contain", "Crosby, Kate" );
             dashboard.getStudentAnswersRow().eq(1)
                 .within(() => {
                     dashboard.getProgressBar().eq(0)

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -163,5 +163,11 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy="modal-header"] [data-cy="close-button"]').should('be.visible').click();
       cy.get('[data-cy="answer-lightbox"]').should('not.exist');
     });
+    it('verify invalid image answer',()=>{
+      cy.get('[data-cy=previous-student-button]').click();
+      cy.get('[data-cy=previous-student-button]').click();
+      cy.get('[data-cy=previous-student-button]').click();
+      cy.get('[data-cy=student-answer]').should('contain', "Error");
+    });
   });
 });

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
@@ -11,7 +11,7 @@ context("Portal Dashboard Response Table",()=>{
   it('verify we display the correct student progress',()=>{
     cy.get('[data-cy=student-answers-row]')
       .eq(2)
-      .should("contain", "1/7");
+      .should("contain", "2/7");
     cy.get('[data-cy=student-answers-row]')
       .eq(5)
       .should("contain", "5/7");

--- a/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-student-sort.spec.js
@@ -19,15 +19,15 @@ context("Portal Dashboard Student Sort",() =>{
       cy.get('[data-cy=student-name]').eq(1).should("contain", "Wu, Jerome");
       cy.get('[data-cy=student-name]').eq(2).should("contain", "Ross, John");
       cy.get('[data-cy=student-name]').eq(3).should("contain", "Armstrong, Jenna");
-      cy.get('[data-cy=student-name]').eq(4).should("contain", "Crosby, Kate");
-      cy.get('[data-cy=student-name]').eq(5).should("contain", "Galloway, Amy");
+      cy.get('[data-cy=student-name]').eq(4).should("contain", "Galloway, Amy");
+      cy.get('[data-cy=student-name]').eq(5).should("contain", "Crosby, Kate");
     });
 
     it('verify we sort by least progress',()=>{
       cy.get('[data-cy=sort-students]').click();
       cy.get('[data-cy="list-item-least-progress"]').click({force:true});
-      cy.get('[data-cy=student-name]').eq(0).should("contain", "Galloway, Amy");
-      cy.get('[data-cy=student-name]').eq(1).should("contain", "Crosby, Kate");
+      cy.get('[data-cy=student-name]').eq(0).should("contain", "Crosby, Kate");
+      cy.get('[data-cy=student-name]').eq(1).should("contain", "Galloway, Amy");
       cy.get('[data-cy=student-name]').eq(2).should("contain", "Armstrong, Jenna");
       cy.get('[data-cy=student-name]').eq(3).should("contain", "Ross, John");
       cy.get('[data-cy=student-name]').eq(4).should("contain", "Wu, Jerome");

--- a/cypress/integration/portal-report-smoke-test.spec.js
+++ b/cypress/integration/portal-report-smoke-test.spec.js
@@ -66,6 +66,12 @@ context("Portal Report Sequence Smoke Test", () => {
       cy.get('.answers-table').should('be.visible');
       cy.get('.answers-table').should('contain', '[the selected choice has been deleted by question author]');
     });
+
+    it('handles image questions including invalid ones', () => {
+      body.openAnswersForQuestion('question-image_question_2');
+      cy.get('.answers-table').should('be.visible');
+      cy.get('.answers-table').should('contain', 'Error');
+    });
   });
 
   context("Portal Report Settings", () => {

--- a/js/components/portal-dashboard/answers/image-answer.tsx
+++ b/js/components/portal-dashboard/answers/image-answer.tsx
@@ -3,6 +3,7 @@ import { AnswerModal } from "./answer-modal";
 import { MagnifyIcon } from "./magnify-icon";
 import useResizeObserver from "@react-hook/resize-observer";
 import { TrackEventFunction } from "../../../actions";
+import { renderInvalidAnswer } from "../../../util/answer-utils";
 
 import css from "../../../../css/portal-dashboard/answers/image-answer.less";
 
@@ -41,7 +42,10 @@ export const ImageAnswer: React.FC<IProps> = (props) => {
   const useSize = (target: any) => {
     const [size, setSize] = React.useState(new DOMRect(0, 0, 0, 0));
     React.useLayoutEffect(() => {
-      setSize(target.current.getBoundingClientRect());
+      if (target.current) {
+        // target.current can be null in the case of an invalid answer
+        setSize(target.current.getBoundingClientRect());
+      }
     }, [target]);
     useResizeObserver(target, (entry: any) => setSize(entry.contentRect));
     return size;
@@ -58,6 +62,14 @@ export const ImageAnswer: React.FC<IProps> = (props) => {
   const constrainX = naturalWidth / containerWidth >= naturalHeight / containerHeight;
   const imgWidth = aspectRatio > 0 ? (constrainX ? containerWidth : containerHeight / aspectRatio) : 0;
   const imgHeight = aspectRatio > 0 ? (constrainX ? containerWidth / aspectRatio : containerHeight) : 0;
+
+  if (!imgAnswer) {
+    // There are broken answer documents that do not include an answer field
+    // Don't crash, just provide a error message to the teacher
+    // This needs to happen after all of the useState calls otherwise React will get
+    // messed up
+    return renderInvalidAnswer(answer, "response is missing answer field");
+  }
 
   return (
     <React.Fragment>

--- a/js/components/report/answer.js
+++ b/js/components/report/answer.js
@@ -4,6 +4,7 @@ import MultipleChoiceAnswer from "./multiple-choice-answer";
 import ImageAnswer from "./image-answer";
 import IframeAnswer from "./iframe-answer";
 import NoAnswer from "./no-answer";
+import { renderInvalidAnswer } from "../../util/answer-utils";
 
 const AnswerComponent = {
   "open_response": OpenResponseAnswer,
@@ -23,7 +24,7 @@ export default class Answer extends PureComponent {
     }
     const AComponent = AnswerComponent[answer.get("questionType")];
     if (!AComponent) {
-      return <div>Answer type not supported.</div>;
+      return renderInvalidAnswer("Answer type not supported");
     }
     return <AComponent answer={answer} alwaysOpen={alwaysOpen} question={question} data-cy="answer"/>;
   }

--- a/js/components/report/image-answer.js
+++ b/js/components/report/image-answer.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react";
 import ImageAnswerModal from "./image-answer-modal";
 
 import "../../../css/report/image-answer.less";
+import { renderInvalidAnswer } from "../../util/answer-utils";
 
 export default class ImageAnswer extends PureComponent {
   constructor(props) {
@@ -14,6 +15,11 @@ export default class ImageAnswer extends PureComponent {
   render() {
     const { answer } = this.props;
     const imgAnswer = answer.get("answer");
+    if (!imgAnswer) {
+      // There are broken answer documents that do not include an answer field
+      // Don't crash, just provide a
+      return renderInvalidAnswer(answer, "response is missing answer field");
+    }
     return (
       <div>
         <div className="image-answer">

--- a/js/components/report/image-answer.js
+++ b/js/components/report/image-answer.js
@@ -17,7 +17,7 @@ export default class ImageAnswer extends PureComponent {
     const imgAnswer = answer.get("answer");
     if (!imgAnswer) {
       // There are broken answer documents that do not include an answer field
-      // Don't crash, just provide a
+      // Don't crash, just provide a error message to the teacher
       return renderInvalidAnswer(answer, "response is missing answer field");
     }
     return (

--- a/js/components/report/image-question-details.js
+++ b/js/components/report/image-question-details.js
@@ -46,6 +46,8 @@ export default class ImageQuestionDetails extends PureComponent {
     this.setState({selectedAnswer: index});
   }
 
+  // If the answer has no answer field, a.getIn(["answer", "imageUrl"]) returns undefined
+  // which then is !== null, so these invalid answers get included in this list
   get answersWithImage() {
     const { answers } = this.props;
     return answers.filter(a => a.getIn(["answer", "imageUrl"]) !== null);

--- a/js/data/answers.json
+++ b/js/data/answers.json
@@ -35,7 +35,7 @@
     "resource_url": "http://app.lara.docker/sequences/1",
     "report_state": "This is an example of a broken answer, it has a type of image_question but has no answer field. This report_state is also not normal, but it should be ignored",
     "type": "image_question_answer",
-    "platform_user_id": "2",
+    "platform_user_id": "3",
     "version": "1"
   },
   {

--- a/js/data/answers.json
+++ b/js/data/answers.json
@@ -28,6 +28,17 @@
     "version": "1"
   },
   {
+    "created": "2019-06-06 14:53:28 UTC",
+    "id": "image_question_answer_5",
+    "question_id": "image_question_2",
+    "question_type": "image_question",
+    "resource_url": "http://app.lara.docker/sequences/1",
+    "report_state": "This is an example of a broken answer, it has a type of image_question but has no answer field. This report_state is also not normal, but it should be ignored",
+    "type": "image_question_answer",
+    "platform_user_id": "2",
+    "version": "1"
+  },
+  {
     "answer": "{\"version\":1,\"mode\":\"report\",\"authoredState\":\"{\\\"columns\\\":[{\\\"heading\\\":\\\"Read-only value\\\",\\\"readOnly\\\":true,\\\"average\\\":false,\\\"chart\\\":false,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Test value\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":false,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Value 1 (m)\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":true,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Value 2 (s)\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":true,\\\"chartColor\\\":\\\"green\\\"}],\\\"labels\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"chartWidth\\\":295,\\\"chartHeight\\\":240,\\\"rowLines\\\":1,\\\"chartAvgs\\\":false}\",\"interactiveState\":\"{\\\"data\\\":[[\\\"a\\\",\\\"1\\\",\\\"2\\\",\\\"3\\\"],[\\\"b\\\",\\\"4\\\",\\\"5\\\",\\\"6\\\"],[\\\"c\\\",\\\"7\\\",\\\"8\\\",\\\"9\\\"]]}\"}",
     "created": "2019-06-06 14:53:26 UTC",
     "id": "interactive_run_state_16",

--- a/js/util/answer-utils.tsx
+++ b/js/util/answer-utils.tsx
@@ -13,6 +13,7 @@ import QMCScoredCorrectIcon from "../../img/svg-icons/q-mc-scored-correct-icon.s
 import QMCScoredIncorrectIcon from "../../img/svg-icons/q-mc-scored-incorrect-icon.svg";
 import QOpenResponseCompletedIcon from "../../img/svg-icons/q-open-response-completed-icon.svg";
 import { TrackEventFunction } from "../actions";
+import React from "react";
 
 export interface AnswerType {
   name: string;
@@ -128,3 +129,15 @@ export const getAnswerIconId = (answerType: any) => {
   return iconId;
 };
 
+export const renderInvalidAnswer = (answer: any, errorMessage = "unknown") => {
+  return (
+    <div>
+      <b>Error: {errorMessage}</b>
+      <div>
+        Details:<br/>
+        id: {answer.get("id")}<br/>
+        questionId: {answer.get("questionId")}
+      </div>
+    </div>
+  );
+};

--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -25,8 +25,23 @@ export const compareStudentsByName = (student1: Map<string, any>, student2: Map<
   }
 };
 
+// A fake MD5 hash that we'll use whenever the answer field is
+const MD5_FOR_UNDEFINED = "0def0def0def0def0def0def0def0def";
+
 export const answerHash = (answer: Map<string, any>) => {
   let answerContent = answer.get("answer");
+  if (answerContent === undefined) {
+    // There are error cases where the answer property is not defined
+    // JSON.stringify of undefined is undefined and undefined breaks the md5 function
+    // Rather than throwing an exception, we return a fixed value this way if the answer
+    // get repaired the hash will change.
+    // In theory, this also means the teacher can provide feedback to the student even in
+    // these error cases.
+    // However in the standard report some other code is preventing this feedback.
+    // In the portal dashboard this feedback is working for these error cases.
+    return MD5_FOR_UNDEFINED;
+  }
+
   if (typeof answerContent !== "string") {
     // the non-Map case likely doesn't hit at present, but this adds protection
     // in case future answerContent has non-string/non-Map value

--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -26,7 +26,7 @@ export const compareStudentsByName = (student1: Map<string, any>, student2: Map<
 };
 
 // A fake MD5 hash that we'll use whenever the answer field is
-const MD5_FOR_UNDEFINED = "0def0def0def0def0def0def0def0def";
+export const MD5_FOR_UNDEFINED = "0def0def0def0def0def0def0def0def";
 
 export const answerHash = (answer: Map<string, any>) => {
   let answerContent = answer.get("answer");

--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -25,7 +25,7 @@ export const compareStudentsByName = (student1: Map<string, any>, student2: Map<
   }
 };
 
-// A fake MD5 hash that we'll use whenever the answer field is
+// A fake MD5 hash that we'll use whenever the answer field is undefined
 export const MD5_FOR_UNDEFINED = "0def0def0def0def0def0def0def0def";
 
 export const answerHash = (answer: Map<string, any>) => {

--- a/test/util/misc_spec.ts
+++ b/test/util/misc_spec.ts
@@ -1,5 +1,5 @@
 import { Map } from "immutable";
-import { answerHash } from "../../js/util/misc";
+import { answerHash, MD5_FOR_UNDEFINED } from "../../js/util/misc";
 
 describe("misc util functions", () => {
   it("determines if answer hash is properly generated", () => {
@@ -47,5 +47,12 @@ describe("misc util functions", () => {
     expect(arrayAnswer1Hash).toEqual(arrayAnswer2Hash);
     expect(arrayAnswer2Hash).not.toEqual(arrayAnswer3Hash);
     expect(arrayAnswer1Hash).not.toEqual(simpleAnswer3Hash);
+  });
+
+  it("handles answer document without an answer field", () => {
+    const answerDoc = Map({ otherField: "foo" });
+    const hash = answerHash(answerDoc);
+
+    expect(hash).toEqual(MD5_FOR_UNDEFINED);
   });
 });


### PR DESCRIPTION
The AP is occasionally saving image question documents that don't have an answer field. This was breaking the portal-report.

The changes in this PR handle this case by showing and error message for this particular student answer. The once case that isn't handled well is in the standard report image carousel. In that case with a broken answer just a blank image is shown. Because we are trying to move away from the standard report, and this should only happen in error cases it seems fine to leave this broken.  If a teacher is curious and then show the responses then they will see the error message.

Here is what the standard report looks like:
![image](https://user-images.githubusercontent.com/86016/131398956-9857bd26-c39b-4a65-bafd-1e954a0e9f53.png)

In the portal dashboard "progress dashboard"
![image](https://user-images.githubusercontent.com/86016/131399074-8c17cbae-c172-436a-88ef-eb806f090830.png)

In the portal dashboard "response details":
![image](https://user-images.githubusercontent.com/86016/131399219-8cffe8f1-5523-4b29-b10e-e6c2bf9c670f.png)

https://www.pivotaltracker.com/story/show/179406265