### PR TITLE
move question icon logic to question-utils

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
@@ -41,7 +41,7 @@ context("Portal Dashboard Activity Buttons",() =>{
         cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
         cy.get('[data-cy=collapsed-activity-button]').should('have.length', 1);
         cy.get('[data-cy=activity-question-button]').should('be.visible');
-        cy.get('[data-cy=activity-question-button]').should('have.length', 8);
+        cy.get('[data-cy=activity-question-button]').should('have.length', 9);
       });
     });
 });

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -58,11 +58,11 @@ context("Portal Dashboard Question Details Panel", () => {
     });
 
     it('verify the last question of the last activity is disabled', () => {
-      cy.get('[data-cy=activity-question-button]').eq(7).click({ force: true });
+      cy.get('[data-cy=activity-question-button]').eq(8).click({ force: true });
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
-      cy.get('[data-cy=question-overlay]').should("contain", "Question #8");
+      cy.get('[data-cy=question-overlay]').should("contain", "Question #9");
       cy.get('[data-cy=question-navigator-next-button]').click();
-      cy.get('[data-cy=question-overlay]').should("contain", "Question #8");
+      cy.get('[data-cy=question-overlay]').should("contain", "Question #9");
     });
 
     it('verify we can page back from the first question of a later activity', () => {

--- a/js/components/portal-dashboard/answers/answer-modal.tsx
+++ b/js/components/portal-dashboard/answers/answer-modal.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import { Modal } from "react-bootstrap";
 import SmallCloseIcon from "../../../../img/svg-icons/small-close-icon.svg";
-import { QuestionTypes } from "../../../util/question-utils";
+import { getQuestionIcon } from "../../../util/question-utils";
 import striptags from "striptags";
 
 import css from "../../../../css/portal-dashboard/answers/answer-modal.less";
@@ -19,9 +19,7 @@ export class AnswerModal extends PureComponent<IProps> {
   render() {
     const { answer, show, onHide, question } = this.props;
     const isQuestion = false;
-    const type = answer?.get("questionType");
-    const questionType = QuestionTypes.find(qt => qt.type === type);
-    const QuestionIcon = questionType?.icon;
+    const QuestionIcon = getQuestionIcon(question);
     const prompt = question? striptags((question.get("drawingPrompt")).replace(/&nbsp;/g,' ')) + striptags((question.get("prompt")).replace(/&nbsp;/g,' ')) : "";
 
     if (!answer) { return null; }

--- a/js/components/portal-dashboard/answers/answer-modal.tsx
+++ b/js/components/portal-dashboard/answers/answer-modal.tsx
@@ -3,6 +3,7 @@ import { Modal } from "react-bootstrap";
 import SmallCloseIcon from "../../../../img/svg-icons/small-close-icon.svg";
 import { getQuestionIcon } from "../../../util/question-utils";
 import striptags from "striptags";
+import { Map } from "immutable";
 
 import css from "../../../../css/portal-dashboard/answers/answer-modal.less";
 
@@ -10,7 +11,7 @@ interface IProps {
   answer: Map<any, any>;
   show: boolean;
   onHide: (value: boolean) => void;
-  question?: Map<any, any>;
+  question?: Map<string, any>;
   studentName: string;
 }
 

--- a/js/components/portal-dashboard/answers/image-answer.tsx
+++ b/js/components/portal-dashboard/answers/image-answer.tsx
@@ -4,13 +4,14 @@ import { MagnifyIcon } from "./magnify-icon";
 import useResizeObserver from "@react-hook/resize-observer";
 import { TrackEventFunction } from "../../../actions";
 import { renderInvalidAnswer } from "../../../util/answer-utils";
+import { Map } from "immutable";
 
 import css from "../../../../css/portal-dashboard/answers/image-answer.less";
 
 interface IProps {
   answer: Map<any, any>;
   responsive?: boolean;
-  question?: Map<any, any>;
+  question?: Map<string, any>;
   studentName: string;
   trackEvent: TrackEventFunction;
 }

--- a/js/components/portal-dashboard/level-viewer.tsx
+++ b/js/components/portal-dashboard/level-viewer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Map } from "immutable";
 import { ProgressLegendContainer } from "./legend-container";
-import { QuestionTypes } from "../../util/question-utils";
+import { getQuestionIcon } from "../../util/question-utils";
 import CorrectIcon from "../../../img/svg-icons/q-mc-scored-correct-icon.svg";
 import LaunchIcon from "../../../img/svg-icons/launch-icon.svg";
 import LinesEllipsis from "react-lines-ellipsis";
@@ -164,8 +164,7 @@ export class LevelViewer extends React.PureComponent<IProps> {
 
   private renderQuestion = (question: Map<string, any>) => {
     let questionClass = css.question;
-    const questionType = QuestionTypes.find(qt => qt.type === question.get("type") && qt.scored === question.get("scored"));
-    const QuestionIcon = questionType?.icon;
+    const QuestionIcon = getQuestionIcon(question);
     if (question.get("id") === this.props.currentQuestion?.get("id")) {
       questionClass += " " + css.active;
     }

--- a/js/components/portal-dashboard/question-area.tsx
+++ b/js/components/portal-dashboard/question-area.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Map } from "immutable";
-import { getQuetionIcon } from "../../util/question-utils";
+import { getQuestionIcon } from "../../util/question-utils";
 import LaunchIcon from "../../../img/svg-icons/launch-icon.svg";
 import { Question } from "./questions/question";
 import { TrackEventFunction } from "../../actions";

--- a/js/components/portal-dashboard/question-area.tsx
+++ b/js/components/portal-dashboard/question-area.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Map } from "immutable";
-import { QuestionTypes } from "../../util/question-utils";
+import { getQuetionIcon } from "../../util/question-utils";
 import LaunchIcon from "../../../img/svg-icons/launch-icon.svg";
 import { Question } from "./questions/question";
 import { TrackEventFunction } from "../../actions";
@@ -21,11 +21,9 @@ export class QuestionArea extends React.PureComponent<IProps>{
     const teacherEditionButtonClasses = css.teacherEditionButton;
     const teacherEditionBadge = css.teacherEditionBadge;
     const type = currentQuestion?.get("type");
-    const scored = currentQuestion?.get("scored");
     const typeText = type?.replace(/_/gm, ' ');
     const interactiveName = type === "iframe_interactive" && currentQuestion?.get("name");
-    const questionType = QuestionTypes.find(qt => qt.type === type && qt.scored === scored);
-    const QuestionIcon = questionType?.icon;
+    const QuestionIcon = getQuestionIcon(currentQuestion);
     const activityURL = currentQuestion?.get("questionUrl");
     const activityTeacherEditionURL = currentQuestion?.get("questionTeacherEditionUrl");
 

--- a/js/components/portal-dashboard/response-details/spotlight-student-list-dialog.tsx
+++ b/js/components/portal-dashboard/response-details/spotlight-student-list-dialog.tsx
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import striptags from "striptags";
 import { renderHTML } from "../../../util/render-html";
 import { AnonymizeStudents } from "../anonymize-students";
-import { QuestionTypes } from "../../../util/question-utils";
+import { getQuestionIcon } from "../../../util/question-utils";
 import Answer from "../../../containers/portal-dashboard/answer";
 import { getFormattedStudentName } from "../../../util/student-utils";
 import SpotlightIcon from "../../../../img/svg-icons/spotlight-icon.svg";
@@ -74,8 +74,7 @@ export class SpotlightStudentListDialog extends React.PureComponent<IProps>{
   private renderColumnHeaders = () => {
     const { anonymous, setAnonymous, currentQuestion } = this.props;
     const type = currentQuestion?.get("type");
-    const questionType = QuestionTypes.find(qt => qt.type === type);
-    const QuestionIcon = questionType?.icon;
+    const QuestionIcon = getQuestionIcon(currentQuestion);
     const typeText = type?.replace(/_/gm, ' ');
     const interactiveName = type === "iframe_interactive" ? currentQuestion?.get("name") : typeText;
     const prompt = currentQuestion?.get("prompt");

--- a/js/containers/portal-dashboard/answer.tsx
+++ b/js/containers/portal-dashboard/answer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { getAnswersByQuestion } from "../../selectors/report-tree";
 import { connect } from "react-redux";
 import { AnswerProps } from "../../util/answer-utils";
-import { QuestionTypes } from "../../util/question-utils";
+import { getQuestionIcon } from "../../util/question-utils";
 import MultipleChoiceAnswer from "../../components/portal-dashboard/multiple-choice-answer";
 import OpenResponseAnswer from "../../components/dashboard/open-response-answer";
 import { ImageAnswer } from "../../components/portal-dashboard/answers/image-answer";
@@ -18,15 +18,13 @@ class Answer extends React.PureComponent<AnswerProps> {
   render() {
     const { answer, question, student } = this.props;
     const atype = answer && answer.get("type");
-    const qtype = question && question.get("type");
-    const scored = question && question.get("scored");
-    const questionType = QuestionTypes.find(qt => qt.type === qtype && qt.scored === scored);
+    const QuestionIcon = getQuestionIcon(question);
     const key = `student-${student ? student.get("id") : "NA"}-question-${question ? question.get("id") : "NA"}`;
     return (
       <div className={css.answer} data-cy="student-answer" key={key}>
         {answer && (!question.get("required") || answer.get("submitted"))
           ? this.renderAnswer(atype)
-          : this.renderNoAnswer(questionType?.icon)
+          : this.renderNoAnswer(QuestionIcon)
         }
       </div>
     );

--- a/js/data/sequence-structure.json
+++ b/js/data/sequence-structure.json
@@ -238,6 +238,26 @@
                   "prompt": "<p>Clues to do what?</p>"
                 }
               ]
+            },
+            {
+              "id": "page-29",
+              "name": "Broken interactives",
+              "type": "page",
+              "url": "http://app.lara.docker/pages/28",
+              "preview_url": "http://activity-player.concord.org?activity=http://app.lara.docker/activities/10&page=1&preview",
+              "children": [
+                {
+                  "display_in_iframe": true,
+                  "height": 435,
+                  "id": "mw_interactive_40",
+                  "name": "Broken Table Interactive",
+                  "question_number": 9,
+                  "show_in_featured_question_report": true,
+                  "type": "type_not_known_by_report",
+                  "url": "https://models-resources.concord.org/table-interactive/index.html",
+                  "width": 576
+                }
+              ]
             }
           ]
         }

--- a/js/util/question-utils.ts
+++ b/js/util/question-utils.ts
@@ -9,6 +9,7 @@ import QMAScoredIcon from "../../img/svg-icons/q-ma-scored-type-icon.svg";
 import QMCNonScoredIcon from "../../img/svg-icons/q-mc-nonscored-type-icon.svg";
 import QMCScoredIcon from "../../img/svg-icons/q-mc-scored-type-icon.svg";
 import QOpenResponseIcon from "../../img/svg-icons/q-open-response-type-icon.svg";
+import { Map } from "immutable";
 
 export interface QuestionType {
   name: string;
@@ -86,3 +87,18 @@ export const QuestionTypes: QuestionType[] = [
   },
 
 ];
+
+export const getQuestionIcon = (question?: Map<string, any>): any => {
+  if (!question) {
+    console.warn("No question given, using default iframe interactive icon");
+    return QInteractiveIcon;
+  }
+
+  const questionType = QuestionTypes.find(qt => qt.type === question.get("type") && qt.scored === question.get("scored"));
+  if (!questionType) {
+    console.warn(`Cannot find icon for question type ${question.get("type")} and scored value: ${question.get("scored")}`);
+    return QInteractiveIcon;
+  }
+
+  return questionType.icon;
+};


### PR DESCRIPTION
This also fixes an issue where the question has an unknown type.
in that case it uses the iframe_interactive icon.

There are couple of logic changes here that I'm not sure about:
- in answer-modal, it was using the answer's questionType, the types seem to imply that sometimes the question can be undefined. So this might be why the answer's questionType is used. However it makes no sense to me that there'd be an answer without a question. So this case of an undefined question seems like an error edge condition. I didn't try to track down when that case happens, so possible it is a common case and should be handled better
- in spotlight-student-list-dialog, the fact that the question is scored or not, was being ignored when looking up the icon. I assumed this was an oversight, but perhaps it was on purpose.