### PR TITLE
fix crash when there is no feedback

### DIFF
--- a/js/containers/portal-dashboard/popup-class-nav.tsx
+++ b/js/containers/portal-dashboard/popup-class-nav.tsx
@@ -236,7 +236,7 @@ function mapStateToProps(state: any, ownProps?: any) {
       const questionFeedbacks = state.getIn(["feedback", "questionFeedbacks"]);
       const feedbacksGiven = [];
       questionFeedbacks.toArray().forEach((feedback: any) => {
-        if (feedback.get("questionId") === questionId && feedback.get("feedback").trim() !== "") {
+        if (feedback.get("questionId") === questionId && feedback.get("feedback")?.trim() !== "") {
           feedbacksGiven.push(feedback);
         }
       });


### PR DESCRIPTION
When feedback is turned on, opening the response details or feedback report crashes portal report when some students have not received feedback for a question. We were trying to trim a feedback that didn't exist. 
This adds a check to see if feedback existed before trying to trim it.