### PR TITLE
Fix response details height (179810273)

### DIFF
--- a/css/portal-dashboard/feedback/feedback-rows.less
+++ b/css/portal-dashboard/feedback/feedback-rows.less
@@ -62,7 +62,7 @@
       border-bottom: 1.5px solid @cc-charcoal-light2;
       flex: 1 1 50%;
       min-width: 349px;
-      padding: 10px 20px 26px;
+      padding: 10px 12px 26px;
 
       p {
         margin-top: 7.5px;

--- a/css/portal-dashboard/portal-dashboard-app.less
+++ b/css/portal-dashboard/portal-dashboard-app.less
@@ -34,7 +34,6 @@
     background-color: #ffffff;
     transition: all 0.5s ease;
     width: 100%;
-    height: 100%;
     font-weight: bold;
     z-index: 1;
     display: flex;

--- a/css/portal-dashboard/response-details/response-details.less
+++ b/css/portal-dashboard/response-details/response-details.less
@@ -37,4 +37,5 @@
   flex: 1;
   min-width: 1100px;
   overflow: auto;
+  margin-top: 3px;
 }


### PR DESCRIPTION
This fixes the response details container height so that all of the student response and feedback rows can be accessed with scrollbars when the content doesn't fit vertically.

PT Story:
https://www.pivotaltracker.com/story/show/179810273

![feedbacl-height](https://user-images.githubusercontent.com/5126913/145451490-8d4ffd1e-e01e-4d18-a8d8-8f9537dff8f3.gif)

