### PR TITLE
Fix checkbox position under response details [#181037903]

### DIFF
--- a/css/portal-dashboard/response-details/popup-student-response-list.less
+++ b/css/portal-dashboard/response-details/popup-student-response-list.less
@@ -31,6 +31,12 @@
         padding: 0 20px 5px 20px;
       }
 
+      .checkboxListItem {
+        display: flex;
+        flex-direction: row;
+        width: 100%;
+      }
+
       .spotlightSelectionCheckbox {
         flex-shrink: 0;
         width: 20px;

--- a/js/components/portal-dashboard/response-details/popup-all-student-response-list.tsx
+++ b/js/components/portal-dashboard/response-details/popup-all-student-response-list.tsx
@@ -50,10 +50,12 @@ export class PopupStudentResponseList extends React.PureComponent<IProps> {
   private renderStudentNameWrapper(studentId: string, formattedName: string, selected: boolean, spotlightAllowed: boolean) {
     return (
       <div className={`${css.itemWrapper} ${selected ? css.selected : ""}`}>
-        <div onClick={this.handleSelect(studentId)} className={`${css.spotlightSelectionCheckbox} ${!spotlightAllowed ? css.disabled : ""}`} data-cy="spotlight-selection-checkbox">
-          <div className={`${css.check} ${selected ? css.selected : ""}`} />
+        <div className={css.checkboxListItem}>
+          <div onClick={this.handleSelect(studentId)} className={`${css.spotlightSelectionCheckbox} ${!spotlightAllowed ? css.disabled : ""}`} data-cy="spotlight-selection-checkbox">
+            <div className={`${css.check} ${selected ? css.selected : ""}`} />
+          </div>
+          <div className={css.studentName} data-cy="student-name">{formattedName}</div>
         </div>
-        <div className={css.studentName} data-cy="student-name">{formattedName}</div>
       </div>
     );
   }


### PR DESCRIPTION
This was broken when the flex direction was changed to support the report-item interactives.