### PR TITLE
Fix drag-and-drop interactive does not look correct in report/dashboard.

### DIFF
--- a/css/report/iframe-answer.less
+++ b/css/report/iframe-answer.less
@@ -5,6 +5,16 @@
     width: 100%;
     display: flex;
     flex-direction: column;
+
+    &.scaled {
+      height: 100%;
+      max-height: 100%;
+    }
+  }
+  &.scaled {
+    height: auto;
+    max-height: 300px;
+    overflow: hidden;
   }
 
   .iframe-answer-header {

--- a/cypress/integration/standalone-iframe.spec.js
+++ b/cypress/integration/standalone-iframe.spec.js
@@ -25,7 +25,7 @@ describe("Opening stand-alone iframe question with saved state", function() {
   it("should show an iframe with the base url", function() {
     getByCypressTag("standaloneIframe").should("be.visible");
     cy.get("iframe").should("exist")
-      .and('have.attr', 'src', 'https://models-resources.concord.org/table-interactive/index.html');
+      .and('have.attr', 'src', 'https://models-resources.concord.org/table-interactive/index.html?view=standalone');
   });
 });
 
@@ -40,7 +40,7 @@ describe("Opening stand-alone open response answer", function() {
         .should("be.visible")
         .should("have.text", "test answer 1");
     });
-  })
+  });
 
   describe("When specifying an anonymous user answer run via runKey", () => {
     beforeEach(() => {
@@ -52,7 +52,7 @@ describe("Opening stand-alone open response answer", function() {
         .should("be.visible")
         .should("have.text", "test answer 1");
     });
-  })
+  });
 });
 
 describe("Opening stand-alone multiple choice answer", function() {
@@ -77,7 +77,6 @@ describe("Opening stand-alone image question answer", function() {
       .should("be.visible")
       .find("img")
       .should("have.attr", "src", "https://ccshutterbug.s3.amazonaws.com/1559832112573-671081.png");
-
   });
 });
 
@@ -89,7 +88,7 @@ describe("Opening stand-alone iframe question with saved learner url", function(
   it("should show an iframe with the saved url", function() {
     getByCypressTag("standaloneIframe").should("be.visible");
     cy.get("iframe").should("exist")
-      .and('have.attr', 'src', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19');
+      .and('have.attr', 'src', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19?view=standalone');
   });
 });
 

--- a/cypress/integration/standalone-iframe.spec.js
+++ b/cypress/integration/standalone-iframe.spec.js
@@ -25,7 +25,7 @@ describe("Opening stand-alone iframe question with saved state", function() {
   it("should show an iframe with the base url", function() {
     getByCypressTag("standaloneIframe").should("be.visible");
     cy.get("iframe").should("exist")
-      .and('have.attr', 'src', 'https://models-resources.concord.org/table-interactive/index.html?view=standalone');
+      .and('have.attr', 'src', 'https://models-resources.concord.org/table-interactive/index.html');
   });
 });
 
@@ -88,7 +88,7 @@ describe("Opening stand-alone iframe question with saved learner url", function(
   it("should show an iframe with the saved url", function() {
     getByCypressTag("standaloneIframe").should("be.visible");
     cy.get("iframe").should("exist")
-      .and('have.attr', 'src', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html?view=standalone#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19');
+      .and('have.attr', 'src', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19');
   });
 });
 

--- a/cypress/integration/standalone-iframe.spec.js
+++ b/cypress/integration/standalone-iframe.spec.js
@@ -88,7 +88,7 @@ describe("Opening stand-alone iframe question with saved learner url", function(
   it("should show an iframe with the saved url", function() {
     getByCypressTag("standaloneIframe").should("be.visible");
     cy.get("iframe").should("exist")
-      .and('have.attr', 'src', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19?view=standalone');
+      .and('have.attr', 'src', 'https://codap.concord.org/releases/staging/static/dg/en/cert/index.html?view=standalone#file=lara:eyJyZWNvcmRpZCI6MzM3MDQsImFjY2Vzc0tleXMiOnsicmVhZE9ubHkiOiJhMDFmNzAxZWY3MDQ3YjczNDllODRkMjdiZWMwYzk5YzliZjg5ODM2In19');
   });
 });
 

--- a/js/components/report/iframe-answer.tsx
+++ b/js/components/report/iframe-answer.tsx
@@ -123,6 +123,7 @@ class IframeAnswer extends PureComponent<IProps, IState> {
       url = question.get("url");
       state = answer.get("answer");
     }
+
     return (
       <div className={`iframe-answer-content ${responsive ? "responsive" : ""}`}>
         <InteractiveIframe src={url} state={state} answer={answer} width={question.get("width")} height={question.get("height")} />
@@ -145,6 +146,7 @@ class IframeAnswer extends PureComponent<IProps, IState> {
     const { alwaysOpen, answer, responsive, question, reportItemAnswer, answerOrientation } = this.props;
     const { reportItemHTMLHeight } = this.state;
     const answerText = answer.get("answerText");
+    const questionType = answer.get("questionType");
     const hasReportItemUrl = !!question.get("reportItemUrl");
     const displayTall = answerOrientation === "tall";
     let reportItemHTML: string | undefined;
@@ -187,7 +189,7 @@ class IframeAnswer extends PureComponent<IProps, IState> {
     }
 
     return (
-      <div className={`iframe-answer ${responsive ? "responsive" : ""}`} data-cy="iframe-answer">
+      <div className={`iframe-answer ${responsive ? "responsive" : ""} ${questionType === "iframe_interactive" ? "scaled" : ""}`} data-cy="iframe-answer">
         <div className={`iframe-answer-header ${responsive ? "responsive" : ""}`}>
           { answerText
               ? <div>{ renderHTML(answerText) }</div>

--- a/js/containers/report/iframe-standalone-app.js
+++ b/js/containers/report/iframe-standalone-app.js
@@ -60,6 +60,13 @@ class IframeStandaloneApp extends PureComponent {
         url = question.get("url");
         state = answer.get("answer");
       }
+
+      const iFrameUrl = new URL(url);
+      const urlParams = new URLSearchParams(iFrameUrl.search);
+      urlParams.set("view", "standalone");
+      iFrameUrl.search = urlParams.toString();
+      url = iFrameUrl;
+
       return (
         <InteractiveIframe src={url} state={state} answer={answer} style={{border: "none"}} width="100%" height="100%" />
       );

--- a/js/containers/report/iframe-standalone-app.js
+++ b/js/containers/report/iframe-standalone-app.js
@@ -58,9 +58,9 @@ class IframeStandaloneApp extends PureComponent {
         // URL field is provided by question. Answer field is a state that will be passed
         // to the iframe using iframe-phone.
         url = question.get("url");
-        const stateObj = JSON.parse(answer.get("answer"));
-        stateObj.view = "standalone";
-        state = JSON.stringify(stateObj);
+        const answerVal = answer.get("answer");
+        state = typeof answerVal === "string" ? JSON.parse(answerVal) : answerVal;
+        state.view = "standalone";
       }
 
       return (

--- a/js/containers/report/iframe-standalone-app.js
+++ b/js/containers/report/iframe-standalone-app.js
@@ -58,14 +58,10 @@ class IframeStandaloneApp extends PureComponent {
         // URL field is provided by question. Answer field is a state that will be passed
         // to the iframe using iframe-phone.
         url = question.get("url");
-        state = answer.get("answer");
+        const stateObj = JSON.parse(answer.get("answer"));
+        stateObj.view = "standalone";
+        state = JSON.stringify(stateObj);
       }
-
-      const iFrameUrl = new URL(url);
-      const urlParams = new URLSearchParams(iFrameUrl.search);
-      urlParams.set("view", "standalone");
-      iFrameUrl.search = urlParams.toString();
-      url = iFrameUrl;
 
       return (
         <InteractiveIframe src={url} state={state} answer={answer} style={{border: "none"}} width="100%" height="100%" />


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181154848

[#181154848]

Adds a URL param for standalone iframes that can be used by question interactives to determine whether they should or shouldn't be scaled to fit the confines of the report/dashboard. Also makes some CSS adjustments to help handle scaled interactives.

These changes go along with [these related changes in question-interactives](https://github.com/concord-consortium/question-interactives/pull/163) and [these changes in LARA](https://github.com/concord-consortium/lara/pull/909).