### PR TITLE
Fix drag-and-drop and side-by-side scaling in reports.

### DIFF
--- a/css/report/iframe-answer.less
+++ b/css/report/iframe-answer.less
@@ -13,7 +13,7 @@
   }
   &.scaled {
     height: auto;
-    max-height: 300px;
+    max-height: 355px;
     overflow: hidden;
   }
 
@@ -23,6 +23,9 @@
     }
   }
   .iframe-answer-content {
+    &>iframe {
+      max-width: 450px;
+    }
     &.responsive {
       flex: 1;
       iframe {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181154848

[#181154848]

Tweaks style rules to ensure proper scaling of interactive and that the entire scaled interactive is visible in the Response Details view in the dashboard. Without these changes, the drag-and-drop interactive was cut off a little at the bottom, and the side-by-side interactive wasn't being scaled down properly.