### PR TITLE
Fix drag-and-drop and side-by-side scaling in reports.

### DIFF
--- a/css/report/iframe-answer.less
+++ b/css/report/iframe-answer.less
@@ -24,7 +24,7 @@
   }
   .iframe-answer-content {
     &>iframe {
-      max-width: 450px;
+      max-width: 395px;
     }
     &.responsive {
       flex: 1;

--- a/js/components/report/interactive-iframe.js
+++ b/js/components/report/interactive-iframe.js
@@ -90,7 +90,8 @@ export default class InteractiveIframe extends PureComponent {
         width={width || "300px"}
         height={requestedHeight || height || "300px"}
         style={style || {border: "none", marginTop: "0.5em"}}
-        allow={"fullscreen"} />
+        allow={"fullscreen"}
+        scrolling={"no"} />
     );
   }
 }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181220233

[#181220233]

A couple more tweaks to fix issues uncovered by QA:

1) Prevent superfluous scrollbars in full-size view of interactives

2) Reduce max width of scaled interactives to prevent parts of interactive being hidden in the dashboard's Feedback Report view when browser window is narrow.