### PR TITLE
Fix Playback Audio Answers in Class Dashboard

### DIFF
--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Map } from "immutable";
 import { getAnswersByQuestion } from "../../selectors/report-tree";
 import { connect } from "react-redux";
-import { getAnswerType, getAnswerIconId, AnswerProps } from "../../util/answer-utils";
+import { getAnswerType, getAnswerIconId, AnswerProps, hasValidResponse } from "../../util/answer-utils";
 import { feedbackValidForAnswer } from "../../util/misc";
 import { getHideFeedbackBadges } from "../../selectors/dashboard-selectors";
 import QuestionFeedbackBadge from "../../../img/svg-icons/feedback-question-badge-icon.svg";
@@ -25,7 +25,7 @@ class AnswerCompact extends React.PureComponent<IProps> {
 
     return (
       <div className={css.answerCompact} data-cy="student-answer">
-        { answer && (!question.get("required") || answer.get("submitted"))
+        { answer && hasValidResponse(answer, question)
           ? this.renderAnswer(answerType?.icon, iconId)
           : this.renderNoAnswer()
         }

--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Map } from "immutable";
 import { getAnswersByQuestion } from "../../selectors/report-tree";
 import { connect } from "react-redux";
-import { getAnswerType, getAnswerIconId, AnswerProps, hasValidResponse } from "../../util/answer-utils";
+import { getAnswerType, getAnswerIconId, AnswerProps, hasResponse } from "../../util/answer-utils";
 import { feedbackValidForAnswer } from "../../util/misc";
 import { getHideFeedbackBadges } from "../../selectors/dashboard-selectors";
 import QuestionFeedbackBadge from "../../../img/svg-icons/feedback-question-badge-icon.svg";
@@ -25,7 +25,7 @@ class AnswerCompact extends React.PureComponent<IProps> {
 
     return (
       <div className={css.answerCompact} data-cy="student-answer">
-        { answer && hasValidResponse(answer, question)
+        { answer && hasResponse(answer, question)
           ? this.renderAnswer(answerType?.icon, iconId)
           : this.renderNoAnswer()
         }

--- a/js/containers/portal-dashboard/answer.tsx
+++ b/js/containers/portal-dashboard/answer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { getAnswersByQuestion } from "../../selectors/report-tree";
 import { connect } from "react-redux";
-import { AnswerProps } from "../../util/answer-utils";
+import { AnswerProps, hasValidResponse } from "../../util/answer-utils";
 import { getQuestionIcon } from "../../util/question-utils";
 import MultipleChoiceAnswer from "../../components/portal-dashboard/multiple-choice-answer";
 import OpenResponseAnswer from "../../components/dashboard/open-response-answer";
@@ -70,10 +70,7 @@ class Answer extends React.PureComponent<AnswerProps> {
     const key = `student-${student ? student.get("id") : "NA"}-question-${question ? question.get("id") : "NA"}`;
     return (
       <div className={css.answer} data-cy="student-answer" key={key}>
-        {answer && (!question.get("required") || answer.get("submitted"))
-          ? this.renderAnswer()
-          : this.renderNoAnswer()
-        }
+        { answer && hasValidResponse(answer, question) ? this.renderAnswer() : this.renderNoAnswer() }
       </div>
     );
   }

--- a/js/containers/portal-dashboard/answer.tsx
+++ b/js/containers/portal-dashboard/answer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { getAnswersByQuestion } from "../../selectors/report-tree";
 import { connect } from "react-redux";
-import { AnswerProps, hasValidResponse } from "../../util/answer-utils";
+import { AnswerProps, hasResponse } from "../../util/answer-utils";
 import { getQuestionIcon } from "../../util/question-utils";
 import MultipleChoiceAnswer from "../../components/portal-dashboard/multiple-choice-answer";
 import OpenResponseAnswer from "../../components/dashboard/open-response-answer";
@@ -70,7 +70,7 @@ class Answer extends React.PureComponent<AnswerProps> {
     const key = `student-${student ? student.get("id") : "NA"}-question-${question ? question.get("id") : "NA"}`;
     return (
       <div className={css.answer} data-cy="student-answer" key={key}>
-        { answer && hasValidResponse(answer, question) ? this.renderAnswer() : this.renderNoAnswer() }
+        { answer && hasResponse(answer, question) ? this.renderAnswer() : this.renderNoAnswer() }
       </div>
     );
   }

--- a/js/util/answer-utils.tsx
+++ b/js/util/answer-utils.tsx
@@ -144,21 +144,23 @@ export const renderInvalidAnswer = (answer: any, errorMessage = "unknown") => {
 };
 
 export const hasResponse = (answer: any, question: any) => {
-  const isNotRequired = !question.get("required");
-  const isSubmitted = answer.get("submitted");
+  if (question.get("required") && !answer.get("submitted")) {
+    return false;
+  }
+
   const hasAttachment = answer.get("attachments") && answer.get("attachments").size > 0;
-  // It is better if interactives don't save an empty interactive state when there is no response,
-  // but there are cases where they may. So we need to check for that.
   let answerReportState;
   try {
     answerReportState = answer.get("reportState") ? JSON.parse(answer.get("reportState")) : undefined;
   } catch (e) {
     answerReportState = undefined;
   }
+  // It is better if interactives don't save an empty interactive state when there is no response,
+  // but there are cases where they may. So we need to check for that.
   const interactiveState = answerReportState ? JSON.parse(answerReportState.interactiveState) : {};
   const isNotInteractiveStateAnswer = answer.get("type") !== "interactive_state";
   const hasInteractiveStateKeys = Object.keys(interactiveState).length !== 0;
   const isNotEmptyResponse = hasAttachment || isNotInteractiveStateAnswer || hasInteractiveStateKeys;
 
-  return (isNotRequired || isSubmitted) && isNotEmptyResponse;
+  return isNotEmptyResponse;
 };

--- a/js/util/answer-utils.tsx
+++ b/js/util/answer-utils.tsx
@@ -142,3 +142,16 @@ export const renderInvalidAnswer = (answer: any, errorMessage = "unknown") => {
     </div>
   );
 };
+
+export const hasValidResponse = (answer: any, question: any) => {
+  let answerReportState;
+  try {
+    answerReportState = answer.get("reportState") ? JSON.parse(answer.get("reportState")) : undefined;
+  } catch (e) {
+    answerReportState = undefined;
+  }
+  const interactiveState = answerReportState ? JSON.parse(answerReportState.interactiveState) : {};
+
+  return (!question.get("required") || answer.get("submitted")) &&
+         (answer.get("type") !== "interactive_state" || Object.keys(interactiveState).length !== 0);
+};

--- a/js/util/answer-utils.tsx
+++ b/js/util/answer-utils.tsx
@@ -143,7 +143,12 @@ export const renderInvalidAnswer = (answer: any, errorMessage = "unknown") => {
   );
 };
 
-export const hasValidResponse = (answer: any, question: any) => {
+export const hasResponse = (answer: any, question: any) => {
+  const isNotRequired = !question.get("required");
+  const isSubmitted = answer.get("submitted");
+  const hasAttachment = answer.get("attachments") && answer.get("attachments").size > 0;
+  // It is better if interactives don't save an empty interactive state when there is no response,
+  // but there are cases where they may. So we need to check for that.
   let answerReportState;
   try {
     answerReportState = answer.get("reportState") ? JSON.parse(answer.get("reportState")) : undefined;
@@ -151,7 +156,9 @@ export const hasValidResponse = (answer: any, question: any) => {
     answerReportState = undefined;
   }
   const interactiveState = answerReportState ? JSON.parse(answerReportState.interactiveState) : {};
+  const isNotInteractiveStateAnswer = answer.get("type") !== "interactive_state";
+  const hasInteractiveStateKeys = Object.keys(interactiveState).length !== 0;
+  const isNotEmptyResponse = hasAttachment || isNotInteractiveStateAnswer || hasInteractiveStateKeys;
 
-  return (!question.get("required") || answer.get("submitted")) &&
-         (answer.get("type") !== "interactive_state" || Object.keys(interactiveState).length !== 0);
+  return (isNotRequired || isSubmitted) && isNotEmptyResponse;
 };


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181223927

[#181223927]

The dashboard should always show "No response" when a student has left neither audio nor a written response to an open response question with audio enabled. If a student leaves only an audio response, the dashboard should show a button/link to play the audio, and the text "No written response". If a student only leaves a written response, the dashboard should show only the text response (no playback button, no message about there being no audio).

Without these changes, the dashboard would show "No written response" when a student left neither audio nor a written response. This is because open response questions with audio enabled will still have an answer set even when the student didn't provide a written or audio response. The answer's type will `interactive_state` and its `answer` property is essentially a state with an empty `interactiveState`. We may want to change that on the question-interactives side, but we should still continue to check for empty answers even if we do.