### PR TITLE
Fix view work/open in new tab links disappearing [#182562269]

### DIFF
--- a/css/report/iframe-answer.less
+++ b/css/report/iframe-answer.less
@@ -12,9 +12,11 @@
     }
   }
   &.scaled {
-    height: auto;
-    max-height: 355px;
-    overflow: hidden;
+    .iframe-answer-content {
+      height: auto;
+      overflow: hidden;
+      max-height: 355px;
+    }
   }
 
   .iframe-answer-header {


### PR DESCRIPTION
This moves the max-height from the enclosing container to the iframe content.  Without this the links were being hidden by the expanded iframe content.