### PR TITLE
add interactive question for report item

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
@@ -41,7 +41,7 @@ context("Portal Dashboard Activity Buttons",() =>{
         cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
         cy.get('[data-cy=collapsed-activity-button]').should('have.length', 1);
         cy.get('[data-cy=activity-question-button]').should('be.visible');
-        cy.get('[data-cy=activity-question-button]').should('have.length', 11);
+        cy.get('[data-cy=activity-question-button]').should('have.length', 12);
       });
     });
 });

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -58,11 +58,11 @@ context("Portal Dashboard Question Details Panel", () => {
     });
 
     it('verify the last question of the last activity is disabled', () => {
-      cy.get('[data-cy=activity-question-button]').eq(10).click({ force: true });
+      cy.get('[data-cy=activity-question-button]').eq(11).click({ force: true });
       cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
-      cy.get('[data-cy=question-overlay]').should("contain", "Question #11");
+      cy.get('[data-cy=question-overlay]').should("contain", "Question #12");
       cy.get('[data-cy=question-navigator-next-button]').click();
-      cy.get('[data-cy=question-overlay]').should("contain", "Question #11");
+      cy.get('[data-cy=question-overlay]').should("contain", "Question #12");
     });
 
     it('verify we can page back from the first question of a later activity', () => {

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
@@ -89,14 +89,14 @@ context("Portal Dashboard Response Table",()=>{
     cy.get('[data-cy=collapsed-activity-button]').first().click();
 
     const activity2Table = [
-    // P1                                      | P2
-    // Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10 | Q11
-      [__, __, IA, IA, IA, IA, IA, IA, __, __,   IA ],
-      [__, __, IA, __, IA, IA, IA, IA, __, IQ,   __ ],
-      [__, __, IA, __, __, IA, __, IA, __, __,   __ ],
-      [IA, IA, IA, IA, IA, IA, IA, __, IQ, IQ,   __ ],
-      [__, __, IA, __, IA, IA, IA, IA, __, __,   __ ],
-      [IA, IA, IA, __, __, __, __, IA, __, __,   __ ],
+    // P1                                           | P2
+    // Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11 | Q11
+      [__, __, IA, IA, IA, IA, IA, IA, __, __, __,    IA ],
+      [__, __, IA, __, IA, IA, IA, IA, __, IQ, __,    __ ],
+      [__, __, IA, __, __, IA, __, IA, __, __, __,    __ ],
+      [IA, IA, IA, IA, IA, IA, IA, __, IQ, IQ, IA,    __ ],
+      [__, __, IA, __, IA, IA, IA, IA, __, __, __,    __ ],
+      [IA, IA, IA, __, __, __, __, IA, __, __, __,    __ ],
     ];
 
     checkAnswerTable(activity2Table);

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
@@ -90,7 +90,7 @@ context("Portal Dashboard Response Table",()=>{
 
     const activity2Table = [
     // P1                                           | P2
-    // Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11 | Q11
+    // Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q11 | Q12
       [__, __, IA, IA, IA, IA, IA, IA, __, __, __,    IA ],
       [__, __, IA, __, IA, IA, IA, IA, __, IQ, __,    __ ],
       [__, __, IA, __, __, IA, __, IA, __, __, __,    __ ],

--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -49,7 +49,7 @@ export class AnswerCompact extends React.PureComponent<IProps> {
     const answerType = getAnswerType(answer, question);
     const iconId = getAnswerIconId(answerType);
 
-    // Early versions of reportItemAnswer did not have items. 
+    // Early versions of reportItemAnswer did not have items.
     // We believe that all report item interactives have been updated so
     // this code does not need to handle that case anymore
     const scoreItem: IReportItemAnswerItemScore | undefined =

--- a/js/containers/portal-dashboard/answer-compact.tsx
+++ b/js/containers/portal-dashboard/answer-compact.tsx
@@ -49,6 +49,9 @@ export class AnswerCompact extends React.PureComponent<IProps> {
     const answerType = getAnswerType(answer, question);
     const iconId = getAnswerIconId(answerType);
 
+    // Early versions of reportItemAnswer did not have items. 
+    // We believe that all report item interactives have been updated so
+    // this code does not need to handle that case anymore
     const scoreItem: IReportItemAnswerItemScore | undefined =
       reportItemAnswer?.items.find(item => item.type === "score") as IReportItemAnswerItemScore;
 

--- a/js/data/answers.json
+++ b/js/data/answers.json
@@ -691,5 +691,17 @@
     "platform_user_id": "2",
     "version": "1",
     "answer":""
+  },
+  {
+    "answer": "{\"version\":1,\"mode\":\"report\",\"authoredState\":\"{\\\"columns\\\":[{\\\"heading\\\":\\\"Read-only value\\\",\\\"readOnly\\\":true,\\\"average\\\":false,\\\"chart\\\":false,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Test value\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":false,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Value 1 (m)\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":true,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Value 2 (s)\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":true,\\\"chartColor\\\":\\\"green\\\"}],\\\"labels\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"chartWidth\\\":295,\\\"chartHeight\\\":240,\\\"rowLines\\\":1,\\\"chartAvgs\\\":false}\",\"interactiveState\":\"{\\\"data\\\":[[\\\"a\\\",\\\"1\\\",\\\"2\\\",\\\"3\\\"],[\\\"b\\\",\\\"4\\\",\\\"5\\\",\\\"6\\\"],[\\\"c\\\",\\\"7\\\",\\\"8\\\",\\\"9\\\"]]}\"}",
+    "reportState": "{\"version\":1,\"mode\":\"report\",\"authoredState\":\"{\\\"columns\\\":[{\\\"heading\\\":\\\"Read-only value\\\",\\\"readOnly\\\":true,\\\"average\\\":false,\\\"chart\\\":false,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Test value\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":false,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Value 1 (m)\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":true,\\\"chartColor\\\":\\\"\\\"},{\\\"heading\\\":\\\"Value 2 (s)\\\",\\\"readOnly\\\":false,\\\"average\\\":false,\\\"chart\\\":true,\\\"chartColor\\\":\\\"green\\\"}],\\\"labels\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"chartWidth\\\":295,\\\"chartHeight\\\":240,\\\"rowLines\\\":1,\\\"chartAvgs\\\":false}\",\"interactiveState\":\"{\\\"data\\\":[[\\\"a\\\",\\\"1\\\",\\\"2\\\",\\\"3\\\"],[\\\"b\\\",\\\"4\\\",\\\"5\\\",\\\"6\\\"],[\\\"c\\\",\\\"7\\\",\\\"8\\\",\\\"9\\\"]]}\"}",
+    "created": "2019-06-06 14:53:26 UTC",
+    "id": "interactive_run_state_52",
+    "question_id": "mw_interactive_32",
+    "question_type": "iframe_interactive",
+    "resource_url": "http://app.lara.docker/sequences/1",
+    "type": "interactive_state",
+    "platform_user_id": "1",
+    "version": "1"
   }
 ]

--- a/js/data/sequence-structure.json
+++ b/js/data/sequence-structure.json
@@ -157,19 +157,18 @@
                   "type": "iframe_interactive",
                   "url": "https://models-resources.concord.org/table-interactive/index.html",
                   "width": 576,
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
+                  "prompt": "Basic Table Interactive (no report item interactive)"
                 },
                 {
                   "display_in_iframe": false,
                   "height": 435,
                   "id": "mw_interactive_22",
-                  "name": "CODAP interactive",
+                  "name": "Old DocStore CODAP interactive",
                   "question_number": 2,
                   "show_in_featured_question_report": true,
                   "type": "iframe_interactive",
                   "url": "https://document-store.concord.org/v2/documents/107956/autolaunch?server=https%3A%2F%2Fcodap.concord.org%2Freleases%2Flatest%2F%3Fapp%3Dis&scaling",
-                  "width": 576,
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
+                  "width": 576
                 },
                 {
                   "display_in_iframe": true,
@@ -180,9 +179,7 @@
                   "show_in_featured_question_report": true,
                   "type": "iframe_interactive",
                   "url": "https://geocode-app.concord.org/",
-                  "width": 576,
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
-                },
+                  "width": 576                },
                 {
                   "display_in_iframe": true,
                   "height": 435,
@@ -192,8 +189,7 @@
                   "show_in_featured_question_report": true,
                   "type": "iframe_interactive",
                   "url": "https://models-resources.concord.org/question-interactives/version/v0.4.1/drawing-tool/",
-                  "width": 576,
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
+                  "width": 576
                 },
                 {
                   "display_in_iframe": true,
@@ -204,8 +200,7 @@
                   "show_in_featured_question_report": true,
                   "type": "iframe_interactive",
                   "url": "https://models-resources.concord.org/table-interactive/index.html",
-                  "width": 576,
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
+                  "width": 576
                 },
                 {
                   "display_in_iframe": true,
@@ -216,8 +211,7 @@
                   "show_in_featured_question_report": true,
                   "type": "iframe_interactive",
                   "url": "https://connected-bio-spaces.concord.org/?%7B%22curriculum%22%3A%22mouse%22%2C%22topBar%22%3Afalse%2C%22ui%22%3A%7B%22showPopulationSpace%22%3Afalse%2C%22showBreedingSpace%22%3Afalse%2C%22showOrganismSpace%22%3Atrue%2C%22showDNASpace%22%3Afalse%2C%22investigationPanelSpace%22%3A%22organism%22%7D%2C%22backpack%22%3A%7B%22collectedMice%22%3A%5B%7B%22sex%22%3A%22female%22%2C%22genotype%22%3A%22RR%22%7D%2C%7B%22sex%22%3A%22male%22%2C%22genotype%22%3A%22CC%22%7D%5D%7D%2C%22populations%22%3A%7B%22instructions%22%3A%22%22%2C%22environment%22%3A%22white%22%2C%22showSwitchEnvironmentsButton%22%3Atrue%2C%22includeNeutralEnvironment%22%3Atrue%2C%22initialPopulation%22%3A%7B%22white%22%3A33.33%2C%22tan%22%3A33.33%7D%2C%22numHawks%22%3A2%2C%22inheritance%22%3A%7B%22showStudentControlOfMutations%22%3Afalse%2C%22breedWithMutations%22%3Afalse%2C%22chanceOfMutations%22%3A2%2C%22showStudentControlOfInheritance%22%3Afalse%2C%22breedWithInheritance%22%3Atrue%2C%22randomOffspring%22%3A%7B%22white%22%3A33.33%2C%22tan%22%3A33.33%7D%7D%2C%22deadMice%22%3A%7B%22chanceOfShowingBody%22%3A50%2C%22timeToShowBody%22%3A50%7D%2C%22enableColorChart%22%3Atrue%2C%22enableGenotypeChart%22%3Atrue%2C%22enableAllelesChart%22%3Atrue%7D%2C%22organisms%22%3A%7B%22instructions%22%3A%22If%20you%20would%20like%20to%20compare%20the%20chromosomes%20of%20a%20male%20and%20female%20mouse%2C%20zoom%20in%20to%20the%20nucleus%20of%20each%20mouse.%20%22%2C%22useMysteryOrganelles%22%3Afalse%2C%22useMysterySubstances%22%3Afalse%2C%22showZoomToReceptor%22%3Afalse%2C%22showZoomToNucleus%22%3Atrue%7D%2C%22breeding%22%3A%7B%22instructions%22%3A%22%22%2C%22breedingType%22%3A%22litter%22%7D%7D",
-                  "width": 576,
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
+                  "width": 576
                 },
                 {
                   "display_in_iframe": true,
@@ -229,8 +223,7 @@
                   "type": "iframe_interactive",
                   "url": "https://models-resources.concord.org/question-interactives/version/v0.4.1/fill-in-the-blank/",
                   "width": 576,
-                  "prompt": "<p>The day I saw the Monkey King [blank-verb] (verb) was one of the mostinteresting days of the year.</p><p> After he did that, the king played chess on his brother&#x27;s [blank-noun] (noun) and then combed his [blank-adjective] (adjective) hair with a comb made out of old fish bones. Later that same day, I saw the Monkey King dance [blank-adverb] (adverb) in front of an audience of kangaroos and wombats.</p>",
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
+                  "prompt": "<p>The day I saw the Monkey King [blank-verb] (verb) was one of the mostinteresting days of the year.</p><p> After he did that, the king played chess on his brother&#x27;s [blank-noun] (noun) and then combed his [blank-adjective] (adjective) hair with a comb made out of old fish bones. Later that same day, I saw the Monkey King dance [blank-adverb] (adverb) in front of an audience of kangaroos and wombats.</p>"
                 },
                 {
                   "display_in_iframe": true,
@@ -242,8 +235,7 @@
                   "type": "iframe_interactive",
                   "url": "https://models-resources.concord.org/question-interactives/version/v0.4.1/scaffolded-question/",
                   "width": 576,
-                  "prompt": "<p>Clues to do what?</p>",
-                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/create-demo-report-item-interactive/report-item/index.html"
+                  "prompt": "<p>Clues to do what?</p>"
                 },
                 {
                   "id": "image_question_3",
@@ -258,6 +250,19 @@
                   "question_number": 10,
                   "show_in_featured_question_report": true,
                   "type": "image_question"
+                },
+                {
+                  "display_in_iframe": true,
+                  "height": 435,
+                  "id": "mw_interactive_32",
+                  "name": "Table with report item",
+                  "question_number": 11,
+                  "show_in_featured_question_report": true,
+                  "type": "iframe_interactive",
+                  "url": "https://models-resources.concord.org/table-interactive/index.html",
+                  "width": 576,
+                  "prompt": "This uses a generic report item interactive to provide info about the Table answer.                               This generic report item interactive used to provide a custom prompt in this location as well. You can see that working in this version https://portal-report.concord.org/version/v4.10.0/?portal-dashboard look at Activity2: Q1, Q2, Q3, Q4, Q5, Q6, Q7, or Q8",
+                  "report_item_url": "https://models-resources.concord.org/lara-example-interactives/branch/master/report-item/index.html"
                 }
               ]
             },
@@ -273,7 +278,7 @@
                   "height": 435,
                   "id": "mw_interactive_40",
                   "name": "Broken Table Interactive",
-                  "question_number": 11,
+                  "question_number": 12,
                   "show_in_featured_question_report": true,
                   "type": "type_not_known_by_report",
                   "url": "https://models-resources.concord.org/table-interactive/index.html",

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -3,10 +3,6 @@
 # Typically this is the Project name
 # The portal report has its own bucket and deploys to the root of it
 S3_BUCKET_PREFIX=''
-# AWS CloudFront distribution ID
-DISTRIBUTION_ID='E19KBL7INSABNU'
-# AWS CloudFront distribution domain
-DISTRIBUTION_DOMAIN='portal-report.concord.org'
 # name of branch to deploy to root of site
 ROOT_BRANCH='production'
 # Bucket to deploy to, typically this is 'model-resources', but some projects
@@ -83,8 +79,6 @@ fi
 # used by s3_website.yml
 export S3_BUCKET_PREFIX
 export IGNORE_ON_SERVER
-export DISTRIBUTION_ID
-export DISTRIBUTION_DOMAIN
 export S3_BUCKET
 
 # copy files to destination
@@ -93,7 +87,3 @@ mv $SRC_DIR $DEPLOY_DEST
 # deploy the site contents
 echo Deploying "$BRANCH_OR_TAG" to "$S3_BUCKET:$S3_BUCKET_PREFIX$S3_DEPLOY_DIR"...
 s3_website push --site _site
-
-# explicit CloudFront invalidation to workaround s3_website gem invalidation bug
-# with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).
-aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths $INVAL_PATH

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -8,18 +8,9 @@ s3_key_prefix: <%= ENV['S3_BUCKET_PREFIX'].sub(/\\/$/, '') %>
 s3_endpoint: us-east-1
 gzip: true
 
-cloudfront_distribution_id: <%= ENV['DISTRIBUTION_ID'] %>
-cloudfront_invalidate_root: true
-cloudfront_wildcard_invalidation: true
-
 ignore_on_server: <%= ENV['IGNORE_ON_SERVER'] %>
 max_age:
   "<%= ENV['S3_BUCKET_PREFIX'] %>*": 600 # 10 minutes
+  "<%= ENV['S3_BUCKET_PREFIX'] %>index.html": 0 # don't cache the top level index file
   "<%= ENV['S3_BUCKET_PREFIX'] %>version/*": 31536000 # 1 year
   "<%= ENV['S3_BUCKET_PREFIX'] %>branch/*": 0
-
-cloudfront_distribution_config:
-  aliases:
-    quantity: 1
-    items:
-      - <%= ENV['DISTRIBUTION_DOMAIN'] %>


### PR DESCRIPTION
This removes the report item urls from the other interactives.
This makes it possible to test the other interactives the normal way.
It also updates the version of the generic report item interactive. Old version of the report item interactive didn't handle the update API.
So this fixes a crash that happened when viewing the student work of many of the interactives in the demo data in A2.