### PR TITLE
Launch AP Teacher Edition with auth-domain param

### DIFF
--- a/js/api.ts
+++ b/js/api.ts
@@ -118,7 +118,7 @@ export const initializeAuthorization = () => {
   return false;
 };
 
-const getPortalBaseUrl = () => {
+export const getPortalBaseUrl = () => {
   const portalUrl = urlParam("class") || urlParam("offering");
   if (!portalUrl) {
     return null;

--- a/js/components/portal-dashboard/question-area.tsx
+++ b/js/components/portal-dashboard/question-area.tsx
@@ -37,11 +37,24 @@ export class QuestionArea extends React.PureComponent<IProps>{
             </span>
           </div>
           <div className={css.rightIcons}>
-            <a className={css.externalLinkButton} href={activityURL} target="_blank" data-cy="open-activity-button" onClick={() => trackEvent("Portal-Dashboard", "OpenExternalLink", {label: activityURL})}>
+            <a
+              className={css.externalLinkButton}
+              href={activityURL} target="_blank"
+              data-cy="open-activity-button"
+              title="Launch Activity"
+              onClick={() => trackEvent("Portal-Dashboard", "OpenExternalLink", {label: activityURL})}
+            >
               <LaunchIcon className={css.icon} />
             </a>
             {hasTeacherEdition &&
-              <a className={css.teacherEditionIcon} href={activityTeacherEditionURL} target="_blank" data-cy="open-teacher-edition-button" onClick={() => trackEvent("Portal-Dashboard", "OpenTeacherEdition", {label: `${activityURL}/?mode=teacher-edition`})}>
+              <a
+                className={css.teacherEditionIcon}
+                href={activityTeacherEditionURL}
+                target="_blank"
+                title="Launch Teacher Edition"
+                data-cy="open-teacher-edition-button"
+                onClick={() => trackEvent("Portal-Dashboard", "OpenTeacherEdition", {label: `${activityURL}/?mode=teacher-edition`})}
+              >
                 <div className={teacherEditionButtonClasses}>
                   <LaunchIcon className={css.icon} />
                 </div>

--- a/js/core/transform-json-response.ts
+++ b/js/core/transform-json-response.ts
@@ -1,6 +1,6 @@
 import { normalize, schema } from "normalizr";
 import humps from "humps";
-import { IPortalRawData } from "../api";
+import { getPortalBaseUrl, IPortalRawData } from "../api";
 import queryString from "query-string";
 
 export interface IResource {
@@ -128,9 +128,13 @@ export function normalizeResourceJSON(json: any) {
 }
 
 // This is used to add mode=teacher-edition
-export function addMode(url: string, mode: string) {
+export function addTeacherEditionMode(url: string) {
   const urlParts = queryString.parseUrl(url);
-  urlParts.query.mode = mode;
+  urlParts.query.mode = "teacher-edition";
+  const portalBaseUrl = getPortalBaseUrl();
+  if (portalBaseUrl) {
+    urlParts.query["auth-domain"] = portalBaseUrl;
+  }
   return queryString.stringifyUrl(urlParts);
 }
 
@@ -165,7 +169,7 @@ export function preprocessResourceJSON(resourceJson: IResource) {
           question.section = section.id;
           question.page = page.id;
           question.questionUrl = page.previewUrl;
-          question.questionTeacherEditionUrl = addMode(page.previewUrl, "teacher-edition");
+          question.questionTeacherEditionUrl = addTeacherEditionMode(page.previewUrl);
           // Nothing is selected by default.
           question.selected = false;
           if (question.type === "multiple_choice") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@concord-consortium/portal-report",
-      "version": "4.11.0",
+      "version": "4.13.0",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/interactive-api-host": "^0.9.0",

--- a/test/core/transforom-json-response_spec.js
+++ b/test/core/transforom-json-response_spec.js
@@ -1,6 +1,10 @@
 import { preprocessResourceJSON } from "../../js/core/transform-json-response";
 import queryString from "query-string";
 
+jest.mock("../../js/api", () => ({
+  getPortalBaseUrl: () => "https://test-portal.concord.org"
+}));
+
 describe("preprocessResourceJSON helper", () => {
   const activityJSON = {
     id: 1,
@@ -100,7 +104,7 @@ describe("preprocessResourceJSON helper", () => {
     it("should have a teacherEdition url", () => {
       const resource = preprocessResourceJSON(activityJSON);
       //                 activity     section        page    question
-      expect(resource.children[0].children[0].children[0].children[0].questionTeacherEditionUrl).toBe("http://example.com/pages/1?mode=teacher-edition");
+      expect(resource.children[0].children[0].children[0].children[0].questionTeacherEditionUrl).toBe("http://example.com/pages/1?auth-domain=https%3A%2F%2Ftest-portal.concord.org&mode=teacher-edition");
     });
   });
 


### PR DESCRIPTION
[#181821831]

This PR adds auth-domain URL param to AP Teache Editon links.
It's related to: https://github.com/concord-consortium/activity-player/pull/378

I've also added rollover text to this button, which is a separate story, but touches the same code.