### PR TITLE
Fix audio responses no longer displayed in reports

### DIFF
--- a/js/reducers/report-reducer.ts
+++ b/js/reducers/report-reducer.ts
@@ -253,7 +253,7 @@ export default function report(state = new ReportState({}), action?: any) {
       return processReportItemRequests(state);
     case SET_REPORT_ITEM_ANSWER:
       const answer = getAnswer(state, action.questionId, action.reportItemAnswer.platformUserId);
-      const storageName = action.reportItemAnswer.itemsType === "fullAnswer" ? "reportItemAnswersFull" : "reportItemAnswersCompact";
+      const storageName = action.reportItemAnswer.itemsType === "compactAnswer" ? "reportItemAnswersCompact" : "reportItemAnswersFull";
       const currentReportItemAnswer = (answer && state.getIn([storageName, answer.get("id")])) || null;
       const reportItemAnswerChanged = JSON.stringify(currentReportItemAnswer) !== JSON.stringify(action.reportItemAnswer);
       if (answer && reportItemAnswerChanged) {

--- a/test/components/report/iframe-answer-report-item_spec.js
+++ b/test/components/report/iframe-answer-report-item_spec.js
@@ -3,11 +3,6 @@ import { shallow } from "enzyme";
 import { Map } from "immutable";
 import { IframeAnswerReportItem } from "../../../js/components/report/iframe-answer-report-item";
 
-jest.mock("../../../js/components/report/iframe-answer-report-item-attachment", () => ({
-  IframeAnswerReportItemAttachment: () => {
-    return <div>MockIframeAnswerReportItemAttachment</div>;
-  }
-}));
 const renderLinkMock = jest.fn();
 
 const answerText = "testing 123";
@@ -36,7 +31,7 @@ const htmlItem = {
   type: "html"
 };
 
-const attachmentAnswer = Map([
+const audioAttachmentAnswer = Map([
   ["answer", answerText],
   ["answerText", answerText],
   ["attachments", {
@@ -45,8 +40,8 @@ const attachmentAnswer = Map([
     }
   }]
 ]);
-const attachmentItem = {
-  name: "answerAttachment",
+const audioAttachmentItem = {
+  name: "test_attachment",
   type: "attachment"
 };
 
@@ -73,9 +68,9 @@ describe("<IframeAnswerReportItem />", () => {
     expect(wrapper.find("iframe")).toBeDefined();
     expect(wrapper.find("iframe").props().srcDoc).toEqual(answerHtml);
   });
-  it("should render an attachment component for an item of type attachment", () => {
-    const wrapper = shallow(<IframeAnswerReportItem answer={attachmentAnswer} item={attachmentItem} answerText={answerText} renderLink={renderLinkMock} />);
-    expect(wrapper.html()).toEqual(expect.stringContaining("MockIframeAnswerReportItemAttachment"));
+  it("should render a 'Play audio response' button for an audio attachment response", () => {
+    const wrapper = shallow(<IframeAnswerReportItem answer={audioAttachmentAnswer} item={audioAttachmentItem} answerText={answerText} renderLink={renderLinkMock} />);
+    expect(wrapper.html()).toEqual(expect.stringContaining("Play audio response"));
   });
   it("should call renderLinks for an item of type links", () => {
     shallow(<IframeAnswerReportItem answer={linksAnswer} item={linksItem} answerText={answerText} renderLink={renderLinkMock} />);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183101947

[#183101947]

`storageName` was incorrectly being set to "reportItemAnswersCompact" when `itemsType` was undefined. 

I think an additional wrinkle is that the Open Response library interactive on authoring.concord.org doesn't currently have a Report Item value set.

The spec test changes are a slight improvement, but would not have caught the issue with audio responses not showing up in reports. I'll work on improving the tests in that regard after requesting some advice. More comments to come.