### PR TITLE
Bar graphs in reports / class dashboard

### DIFF
--- a/js/components/report/iframe-answer.tsx
+++ b/js/components/report/iframe-answer.tsx
@@ -37,6 +37,7 @@ export class IframeAnswer extends PureComponent<IProps, IState> {
       iframeVisible: false
     };
     this.toggleIframe = this.toggleIframe.bind(this);
+    this.renderLink = this.renderLink.bind(this);
   }
 
   toggleIframe() {
@@ -93,10 +94,10 @@ export class IframeAnswer extends PureComponent<IProps, IState> {
       const toggleText = iframeVisible ? "Hide" : "View Work";
       const standaloneLinkUrl = this.getStandaloneLinkUrl(question, answer);
       return (
-        <React.Fragment>
+        <div>
           <a onClick={this.toggleIframe} target="_blank" data-cy="toggleIframe">{toggleText}</a> |{" "}
           <a href={standaloneLinkUrl} target="_blank" data-cy="standaloneIframe">Open in new tab {externalLinkIcon}</a>
-        </React.Fragment>
+        </div>
       );
     } else {
       return <a href={linkUrl} target="_blank" data-cy="externalIframe">View work in new tab {externalLinkIcon}</a>;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182994863

[#182994863]

These changes address issues revealed when adding bar graph sparklines to the Sensor Interactive report item.

* `IframeAnswer`'s `renderLink` function needs to be bound.
* Wrap `IframeAnswer` links in a containing DIV so they're not treated as flex items which wrap to multiple lines.

Required by [this PR](https://github.com/concord-consortium/sensor-interactive/pull/118).