### PR TITLE
Bar Graphs in Reports / Class Dashboard

### DIFF
--- a/js/components/report/iframe-answer.tsx
+++ b/js/components/report/iframe-answer.tsx
@@ -202,7 +202,7 @@ export class IframeAnswer extends PureComponent<IProps, IState> {
             {maybeAnswerTextOrLinks}
           </div>
         )}
-        {reportItemAnswerItems.map((item, index) => (
+        {!alwaysOpen && reportItemAnswerItems.map((item, index) => (
           <IframeAnswerReportItem
             key={index}
             item={item}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183454493

[#183454493]

This change addresses an issue identified by QA. See the last point in Saravanan's last comment of 9/21. 

It makes it so only the actual answer is shown in the compare view. (The compare view sets `alwaysOpen` to `true`.)

Currently, graph answers will be shown like this in the compare view:
<img width="860" alt="image" src="https://user-images.githubusercontent.com/367459/192862861-9b599738-b671-4b86-9dde-894b3f162530.png">

This change makes it look like so:
<img width="863" alt="image" src="https://user-images.githubusercontent.com/367459/192863089-fa072fae-4b22-419c-b464-f53408d45fed.png">