### PR TITLE
Do not show interactive iframe links when report item is available

### DIFF
--- a/js/components/report/iframe-answer.tsx
+++ b/js/components/report/iframe-answer.tsx
@@ -173,7 +173,7 @@ export class IframeAnswer extends PureComponent<IProps, IState> {
 
     // if there are no report answer items, show the answer text or the links to view the interactive
     let maybeAnswerTextOrLinks: JSX.Element | false = false;
-    if (reportItemAnswerItems.length === 0) {
+    if (!hasReportItemUrl) {
       maybeAnswerTextOrLinks = answerText
         ? <div data-cy="answerText">{ renderHTML(answerText) }</div>
         : !alwaysOpen && this.renderLink(); /* This assumes only scaffolded, fill in the blank, and open response questions have answerTexts */


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186970929

I believe `if (!hasReportItemUrl) {` is better than `if (reportItemAnswerItems.length === 0) {`, as the `reportItemAnswerItems` array is empty when the report item is still loading and before the parent receives an answer with items. `!hasReportItemUrl` ensures that links are never shown when the report item is available.