### PR TITLE
fix: Lifted feedback level state up to app state [PT-187132915]

### DIFF
--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -50,12 +50,13 @@ interface IProps {
   viewMode: DashboardViewMode;
   trackEvent: TrackEventFunction;
   rubric: Rubric;
+  feedbackLevel: FeedbackLevel;
+  setFeedbackLevel: (feedbackLevel: FeedbackLevel) => void;
 }
 interface IState {
   selectedStudents: SelectedStudent[];
   showSpotlightDialog: boolean;
   showSpotlightListDialog: boolean;
-  feedbackLevel: FeedbackLevel;
 }
 
 export class ResponseDetails extends React.PureComponent<IProps, IState> {
@@ -64,8 +65,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
     this.state = {
       selectedStudents: [],
       showSpotlightDialog: false,
-      showSpotlightListDialog: false,
-      feedbackLevel: "Activity"
+      showSpotlightListDialog: false
     };
   }
 
@@ -73,9 +73,9 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
     const { activities, anonymous, answers, currentActivity, currentStudentId, currentQuestion, hasTeacherEdition, isAnonymous,
       listViewMode, questions, setAnonymous, setCurrentActivity, setCurrentQuestion, setListViewMode,
       setStudentFilter, sortByMethod, sortedQuestionIds, studentCount, students, trackEvent, viewMode,
-      feedbackSortByMethod, setStudentFeebackFilter, rubric } = this.props;
+      feedbackSortByMethod, setStudentFeebackFilter, rubric, feedbackLevel } = this.props;
 
-    const { selectedStudents, showSpotlightDialog, showSpotlightListDialog, feedbackLevel } = this.state;
+    const { selectedStudents, showSpotlightDialog, showSpotlightListDialog } = this.state;
 
     const firstActivity = activities.first();
     const currentStudentIndex = students.findIndex((s: any) => s.get("id") === currentStudentId);
@@ -152,7 +152,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
             <div className={css.feedbackInfo} data-cy="feedback-info">
               <FeedbackInfo
                 feedbackLevel={feedbackLevel}
-                setFeedbackLevel={this.setFeedbackLevel}
+                setFeedbackLevel={this.props.setFeedbackLevel}
                 listViewMode={listViewMode}
                 rubric={rubric}
               />
@@ -285,7 +285,4 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
     this.props.trackEvent("Portal-Dashboard", "SelectStudentResponse", {parameters: {selectedStudents: updatedSelectedStudents.map(s => s.id)}});
   }
 
-  private setFeedbackLevel = (feedbackLevel: FeedbackLevel) => {
-    this.setState({ feedbackLevel });
-  }
 }

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -19,7 +19,7 @@ import { setStudentSort, setCurrentActivity, setCurrentQuestion, setCurrentStude
 import { RootState } from "../../reducers";
 import { QuestionOverlay } from "../../components/portal-dashboard/question-overlay";
 import { ResponseDetails } from "../../components/portal-dashboard/response-details/response-details";
-import { ColorTheme, DashboardViewMode, ListViewMode } from "../../util/misc";
+import { ColorTheme, DashboardViewMode, FeedbackLevel, ListViewMode } from "../../util/misc";
 
 import css from "../../../css/portal-dashboard/portal-dashboard-app.less";
 
@@ -71,6 +71,7 @@ interface IState {
   scrollLeft: number;
   viewMode: DashboardViewMode;
   listViewMode: ListViewMode;
+  feedbackLevel: FeedbackLevel;
 }
 
 class PortalDashboardApp extends React.PureComponent<IProps, IState> {
@@ -81,6 +82,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
       scrollLeft: 0,
       viewMode: "ProgressDashboard",
       listViewMode: "Student",
+      feedbackLevel: "Activity"
     };
   }
 
@@ -104,7 +106,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
       expandedActivities, setCurrentActivity, setCurrentQuestion, setCurrentStudent, sortByMethod, toggleCurrentActivity,
       toggleCurrentQuestion, trackEvent, hasTeacherEdition, questionFeedbacks, hideFeedbackBadges, feedbackSortByMethod,
       setStudentFeedbackSort} = this.props;
-    const { initialLoading, viewMode, listViewMode } = this.state;
+    const { initialLoading, viewMode, listViewMode, feedbackLevel } = this.state;
     const isAnonymous = report ? report.get("anonymous") : true;
     // In order to list the activities in the correct order,
     // they must be obtained via the child reference in the sequenceTree …
@@ -235,6 +237,8 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
                   trackEvent={trackEvent}
                   viewMode={viewMode}
                   rubric={rubric}
+                  feedbackLevel={feedbackLevel}
+                  setFeedbackLevel={this.setFeedbackLevel}
                 />
             </div>
           )
@@ -280,6 +284,10 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
     if (element && element.scrollLeft != null) {
       this.setState({ scrollLeft: -1 * element.scrollLeft });
     }
+  }
+
+  private setFeedbackLevel = (feedbackLevel: FeedbackLevel) => {
+    this.setState({ feedbackLevel });
   }
 }
 


### PR DESCRIPTION
This fixes the feedback level being reset to the initial state when the response details page is re-mounted by moving the feedback level up to the top app state.