### PR TITLE
fix: Autoselect the question feedback when the response details view is set to question [PT-187132915]

### DIFF
--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -75,7 +75,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
     const { activities, anonymous, answers, currentActivity, currentStudentId, currentQuestion, hasTeacherEdition, isAnonymous,
       listViewMode, questions, setAnonymous, setCurrentActivity, setCurrentQuestion, setListViewMode,
       setStudentFilter, sortByMethod, sortedQuestionIds, studentCount, students, trackEvent, viewMode,
-      feedbackSortByMethod, setStudentFeebackFilter, feedbackLevel, scoringSettings } = this.props;
+      feedbackSortByMethod, setStudentFeebackFilter, feedbackLevel, scoringSettings, setFeedbackLevel } = this.props;
 
     const { selectedStudents, showSpotlightDialog, showSpotlightListDialog } = this.state;
 
@@ -116,6 +116,7 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
             studentCount={studentCount}
             trackEvent={trackEvent}
             viewMode={viewMode}
+            setFeedbackLevel={setFeedbackLevel}
           />
           <div className={`${css.responsePanel}`} data-cy="response-panel">
             { isSequence || feedbackLevel === "Activity"

--- a/js/containers/portal-dashboard/popup-class-nav.tsx
+++ b/js/containers/portal-dashboard/popup-class-nav.tsx
@@ -45,6 +45,7 @@ interface IProps {
   studentCount: number;
   trackEvent: TrackEventFunction;
   viewMode: DashboardViewMode;
+  setFeedbackLevel: (feedbackLevel: FeedbackLevel) => void;
 }
 
 class PopupClassNav extends React.PureComponent<IProps>{
@@ -161,16 +162,26 @@ class PopupClassNav extends React.PureComponent<IProps>{
   }
 
   private renderViewListOptions() {
-    const { feedbackLevel, listViewMode, setListViewMode, viewMode } = this.props;
+    const { feedbackLevel, listViewMode, setListViewMode, viewMode, setFeedbackLevel } = this.props;
     const listByStudentClasses = `${css.toggle} ${css.listByStudents} ${listViewMode==="Student" ? css.selected : ""}`;
     const disableListByQuestions = feedbackLevel === "Activity" && viewMode === "FeedbackReport" ? true : false;
     const listByQuestionsClasses = `${css.toggle} ${css.listByQuestions} ${listViewMode==="Question" ? css.selected : ""}  ${disableListByQuestions ? css.disabled : ""}`;
+
+    const handleClick = (value: ListViewMode) => {
+      setListViewMode(value);
+
+      // we also set the feedback level here to avoid have a disabled feedback level option displayed in the feedback page
+      if (viewMode === "ResponseDetails" && value === "Question") {
+        setFeedbackLevel("Question");
+      }
+    };
+
     return (
       <div className={`${css.viewListOption} ${css.columnHeader}`}>View list by:
-        <button className={listByStudentClasses} data-cy="list-by-student-toggle" onClick={() => setListViewMode("Student")}>
+        <button className={listByStudentClasses} data-cy="list-by-student-toggle" onClick={() => handleClick("Student")}>
           <StudentViewIcon className={css.optionIcon} />
         </button>
-        <button className={listByQuestionsClasses} data-cy="list-by-questions-toggle" onClick={() => setListViewMode("Question")} disabled={disableListByQuestions}>
+        <button className={listByQuestionsClasses} data-cy="list-by-questions-toggle" onClick={() => handleClick("Question")} disabled={disableListByQuestions}>
           <QuestionViewIcon className={css.optionIcon} />
         </button>
       </div>


### PR DESCRIPTION
This ensures we don't have a disabled view shown when we switch to the feedback view.