### PR TITLE
feat: Add rubric icon and details dialog [PT-187021082]

### DIFF
--- a/css/portal-dashboard/feedback/feedback-legend.less
+++ b/css/portal-dashboard/feedback/feedback-legend.less
@@ -61,14 +61,11 @@
 
       .feedbackBadgeLegend__rubric_summary {
         display: flex;
+        gap: 7px;
         flex-wrap: nowrap;
         justify-content: end;
-
-        .feedbackBadgeLegend__rubric_summary_icon {
-          margin-left: 5px;
-        }
+        align-items: center;
       }
-
     }
   }
 }

--- a/css/portal-dashboard/feedback/rubric-summary-icon.less
+++ b/css/portal-dashboard/feedback/rubric-summary-icon.less
@@ -1,0 +1,34 @@
+@import "../variables";
+
+.rubricSummaryIcon {
+
+  .rubricSummaryIconRows {
+    border: solid 1.5px @cc-charcoal-light1;
+    border-radius: 5px;
+    overflow: hidden;
+
+    .rubricSummaryIconRow {
+      display: flex;
+      background-color: #d8d8d8;
+      overflow: hidden;
+      border-bottom: solid 1px @cc-charcoal-light1;
+
+      &:last-of-type {
+        border-bottom: initial;
+      }
+    }
+
+    &:hover {
+      box-shadow:0 0 0 3px #BDDFC2;
+    }
+
+    &.active {
+      box-shadow:0 0 0 3px @feedback-green;
+      border: solid 1.5px #fff;
+
+      .rubricSummaryIconRow {
+        border-bottom: solid 1px #fff;
+      }
+    }
+  }
+}

--- a/css/portal-dashboard/feedback/rubric-summary-modal.less
+++ b/css/portal-dashboard/feedback/rubric-summary-modal.less
@@ -1,0 +1,92 @@
+@import "../variables";
+
+.lightbox {
+  background-color: white;
+  border-radius: 8px !important;
+  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.35);
+  height: auto;
+  left: 50px;
+  top: 135px;
+  width: 777px;
+
+  .lightboxHeader {
+    border-radius: 8px 8px 0 0;
+    overflow: auto;
+    padding: 0;
+
+    .title {
+      color: @feedback-green;
+      font-weight: bold;
+      height: 24px;
+      line-height: 1.4;
+      margin: 20px 20px 0;
+      position: relative;
+      text-align: center;
+    }
+  }
+
+  .lightboxBody {
+
+    .contentArea {
+      padding: 0 20px 10px 20px;
+
+      .modalOption {
+        margin: 15px 0 10px 0;
+
+        &:first-of-type {
+          margin-top: 10px;
+        }
+
+        .modalOptionInfo {
+          display: flex;
+          flex-direction: column;
+          gap: 5px;
+          margin: 10px;
+        }
+
+        .maxScore {
+          display: flex;
+          align-items: center;
+          text-align: right;
+
+          &>div {
+            white-space: nowrap;
+            font-weight: bold;
+          }
+        }
+      }
+    }
+    .buttonContainer {
+      margin-top: 20px;
+      display: flex;
+      gap: 10px;
+      justify-content: flex-end;
+
+      .closeButton {
+        background-color:white;
+        border: solid 1.5px @cc-charcoal-light1;
+        border-radius: 4px;
+        color: @cc-charcoal;
+        cursor: pointer;
+        font-weight: bold;
+        display: inline-block;
+        padding: 5px 10px 6px;
+        text-align: center;
+
+        &.disabled {
+          cursor: not-allowed;
+          opacity: 0.35;
+        }
+
+        &:hover {
+          background: @feedback-green-light4;
+        }
+        &:active {
+          background: @feedback-green;
+          border-color: @feedback-green;
+          color: white;
+        }
+      }
+    }
+  }
+}

--- a/css/portal-dashboard/feedback/rubric-table.less
+++ b/css/portal-dashboard/feedback/rubric-table.less
@@ -7,6 +7,7 @@
   margin: 10px 0;
   width: 100%;
   font-size: 14px;
+  overflow: hidden;
 
   .columnHeaders {
     height: 45px;

--- a/js/components/portal-dashboard/feedback/feedback-legend.tsx
+++ b/js/components/portal-dashboard/feedback/feedback-legend.tsx
@@ -13,6 +13,7 @@ import { ScoringSettings, computeAvgScore } from "../../../util/scoring";
 import { MANUAL_SCORE, RUBRIC_SCORE } from "../../../util/scoring-constants";
 import { Rubric } from "./rubric-utils";
 import { makeGetStudentFeedbacks } from "../../../selectors/activity-feedback-selectors";
+import { RubricSummaryIcon } from "./rubric-summary-icon";
 
 import css from "../../../../css/portal-dashboard/feedback/feedback-legend.less";
 
@@ -23,10 +24,11 @@ interface IProps {
   rubric: Rubric;
   avgScore: number;
   avgScoreMax: number;
+  feedbacks: any;
 }
 
 const FeedbackLegend: React.FC<IProps> = (props) => {
-  const { feedbackLevel, activity, scoringSettings, avgScore, avgScoreMax } = props;
+  const { feedbackLevel, activity, scoringSettings, avgScore, avgScoreMax, rubric, feedbacks } = props;
   const { scoreType } = scoringSettings;
   const awaitingFeedbackIcon = feedbackLevel === "Activity"
                                ? <AwaitingFeedbackActivityBadgeIcon />
@@ -66,12 +68,10 @@ const FeedbackLegend: React.FC<IProps> = (props) => {
               Avg. Score:
               <div className={css.feedbackBadgeLegend__rubric_score_avg_value}>{formattedAvgScore} / {avgScoreMax}</div>
             </div>}
-            <div className={css.feedbackBadgeLegend__rubric_summary}>
-              Summary:
-              <div className={css.feedbackBadgeLegend__rubric_summary_icon}>
-                TBD
-              </div>
-            </div>
+            {rubric && <div className={css.feedbackBadgeLegend__rubric_summary}>
+              Rubric Summary:
+              <RubricSummaryIcon rubric={rubric} feedbacks={feedbacks} />
+            </div>}
           </div>
         </div>
       }
@@ -86,7 +86,7 @@ function mapStateToProps() {
     const {avgScoreMax, avgScore} = computeAvgScore(ownProps.scoringSettings, ownProps.rubric, feedbacks);
 
     return {
-      avgScoreMax, avgScore
+      avgScoreMax, avgScore, feedbacks
     };
   };
 }

--- a/js/components/portal-dashboard/feedback/rubric-summary-icon.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-summary-icon.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useState }  from "react";
+import classNames from "classnames";
 import { Rubric, getFeedbackColor } from "./rubric-utils";
+import { RubricSummaryModal } from "./rubric-summary-modal";
 
 import css from "../../../../css/portal-dashboard/feedback/rubric-summary-icon.less";
-import classNames from "classnames";
-import { RubricSummaryModal } from "./rubric-summary-modal";
 
 interface IProps {
   rubric: Rubric;

--- a/js/components/portal-dashboard/feedback/rubric-summary-icon.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-summary-icon.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo, useState }  from "react";
+import { Rubric, getFeedbackColor } from "./rubric-utils";
+
+import css from "../../../../css/portal-dashboard/feedback/rubric-summary-icon.less";
+import classNames from "classnames";
+import { RubricSummaryModal } from "./rubric-summary-modal";
+
+interface IProps {
+  rubric: Rubric;
+  feedbacks: any;
+}
+
+type RatingsCounts = Record<string, number>;
+export interface ICriteriaCount {
+  id: string;
+  numStudents: number;
+  ratings: RatingsCounts;
+}
+
+type PartialRubricFeedback = Record<string, {
+  id: string;
+  score: number;
+}>
+
+const iconWidth = 80;
+const maxIconHeight = Math.round(iconWidth / 1.66); // keep rectangular
+const defaultIconRowHeight = 18;
+
+export const RubricSummaryIcon: React.FC<IProps> = (props) => {
+  const { rubric, feedbacks: { rubricFeedbacks } } = props;
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleToggleModal = () => setModalOpen(prev => !prev);
+
+  const { hasRubricFeedback, criteriaCounts } = useMemo(() => {
+    const criteriaCounts: ICriteriaCount[] = [];
+    const hasRubricFeedback = rubricFeedbacks.length > 0;
+
+    if (hasRubricFeedback) {
+      const ratingsCounts = rubric.ratings.reduce<RatingsCounts>((acc, cur) => {
+        acc[cur.id] = 0;
+        return acc;
+      }, {});
+
+      rubric.criteria.forEach(criteria => {
+        const criteriaCount: ICriteriaCount = {
+          id: criteria.id,
+          numStudents: 0,
+          ratings: {...ratingsCounts},
+        };
+        criteriaCounts.push(criteriaCount);
+
+        rubricFeedbacks.forEach((rubricFeedback: PartialRubricFeedback) => {
+          const criteriaFeedback = rubricFeedback[criteria.id];
+          if (criteriaFeedback?.score > 0) {
+            criteriaCount.numStudents++;
+            criteriaCount.ratings[criteriaFeedback.id]++;
+          }
+        });
+      });
+    }
+
+    return { hasRubricFeedback, criteriaCounts };
+  }, [rubricFeedbacks, rubric]);
+
+  const renderIcon = () => {
+    const rowHeight = Math.min(Math.round(maxIconHeight / criteriaCounts.length), defaultIconRowHeight);
+
+    return (
+      <div className={classNames(css.rubricSummaryIconRows, {[css.active]: modalOpen})} style={{width: iconWidth}}>
+        {criteriaCounts.map(({id, numStudents, ratings}) => {
+          const rowStyle: React.CSSProperties = {
+            height: rowHeight,
+          };
+          return (
+            <div className={css.rubricSummaryIconRow} key={id} style={rowStyle}>
+              {rubric.ratings.map(rating => {
+                const percentage = (ratings[rating.id] / numStudents) * 100;
+                const title = `${Math.round(percentage)}% ${rating.label} - click for details`;
+                const ratingStyle: React.CSSProperties = {
+                  height: rowHeight,
+                  width: `${percentage}%`,
+                  backgroundColor: getFeedbackColor({rubric, score: rating.score}),
+                };
+                return <div key={rating.id} style={ratingStyle} title={title} />;
+              })}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <div
+        className={css.rubricSummaryIcon}
+        data-cy="rubric-summary-icon"
+        onClick={handleToggleModal}
+      >
+        {hasRubricFeedback ? renderIcon() : <>N/A</>}
+      </div>
+      {modalOpen && <RubricSummaryModal
+        onClose={handleToggleModal}
+        rubric={rubric}
+        criteriaCounts={criteriaCounts}
+      />}
+    </>
+  );
+};

--- a/js/components/portal-dashboard/feedback/rubric-summary-modal.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-summary-modal.tsx
@@ -1,0 +1,138 @@
+import React, { PureComponent } from "react";
+import { Modal } from "react-bootstrap";
+import Markdown from "markdown-to-jsx";
+import { Rubric, RubricCriterion, RubricRating, getFeedbackColor, getFeedbackTextColor } from "./rubric-utils";
+import { ICriteriaCount } from "./rubric-summary-icon";
+import LaunchIcon from "../../../../img/svg-icons/launch-icon.svg";
+
+import css from "../../../../css/portal-dashboard/feedback/rubric-summary-modal.less";
+import tableCss from "../../../../css/portal-dashboard/feedback/rubric-table.less";
+
+interface IProps {
+  onClose: () => void;
+  rubric: Rubric;
+  criteriaCounts: ICriteriaCount[];
+}
+
+export class RubricSummaryModal extends PureComponent<IProps> {
+
+  render() {
+    // const { rubric, criteriaCounts } = this.props;
+
+    return (
+      <Modal animation={false} centered dialogClassName={css.lightbox} onHide={this.handleClose} show={true} data-cy="rubric-summary-modal">
+        <Modal.Header className={css.lightboxHeader} data-cy="rubric-summary-modal-header">
+          <div className={css.title} data-cy="rubric-summary-modal-header-text">
+          Rubric Summary Details
+          </div>
+        </Modal.Header>
+        <Modal.Body className={css.lightboxBody}>
+          <div className={css.contentArea} data-cy="rubric-summary-modal-content-area">
+            {this.renderTable()}
+            <div className={css.buttonContainer}>
+              <div className={css.closeButton} onClick={this.handleClose} data-cy="rubric-summary-modal-close-button">
+                Close
+              </div>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
+    );
+  }
+
+  private renderTable() {
+    const { rubric } = this.props;
+    const { criteria } = rubric;
+
+    return (
+      <div className={tableCss.rubricContainer} data-cy="rubric-table">
+        {this.renderColumnHeaders(rubric)}
+        <div className={tableCss.rubricTable}>
+          {criteria.map(crit =>
+            <div className={tableCss.rubricTableRow} key={crit.id} id={crit.id}>
+              <div className={tableCss.rubricDescription}>
+                <Markdown>{crit.description}</Markdown>
+              </div>
+              {this.renderRatings(crit)}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  private renderColumnHeaders = (rubric: Rubric) => {
+    const { referenceURL } = rubric;
+    return (
+      <div className={tableCss.columnHeaders}>
+        <div className={tableCss.rubricDescriptionHeader}>
+          <div className={tableCss.scoringGuideArea}>
+            <a className={tableCss.launchButton} href={referenceURL} target="_blank" data-cy="scoring-guide-launch-icon">
+              <LaunchIcon className={tableCss.icon} />
+            </a>
+            Scoring Guide
+          </div>
+          <div className={tableCss.rubricDescriptionTitle}>{rubric.criteriaLabel}</div>
+        </div>
+        {rubric.ratings.map((rating: any) =>
+          <div className={tableCss.rubricScoreHeader} key={rating.id}>
+            <div className={tableCss.rubricScoreLevel}>{rating.label}</div>
+            {rubric.scoreUsingPoints && <div className={tableCss.rubricScoreNumber}>({rating.score})</div>}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  private renderRatings = (crit: RubricCriterion) => {
+    const { rubric } = this.props;
+    const { ratings } = rubric;
+    return (
+      <div className={tableCss.ratingsGroup}>
+        {ratings.map(rating => this.renderRating(crit, rating))}
+      </div>
+    );
+  }
+
+  private renderRating = (crit: RubricCriterion, rating: RubricRating) => {
+    const critId = crit.id;
+    const ratingId = rating.id;
+    const key = `${critId}-${ratingId}`;
+    const ratingDescription = crit.ratingDescriptions?.[ratingId];
+    const isApplicableRating = crit.nonApplicableRatings === undefined || crit.nonApplicableRatings.indexOf(ratingId) < 0;
+    const style: React.CSSProperties = {
+      color: getFeedbackTextColor({rubric: this.props.rubric, score: rating.score}),
+      backgroundColor: getFeedbackColor({rubric: this.props.rubric, score: rating.score})
+    };
+
+    return (
+      <div className={tableCss.rubricScoreBox} style={style} key={key}>
+        <div className={tableCss.rubricButton} title={(isApplicableRating) ? ratingDescription : "Not Applicable"}>
+          { !isApplicableRating
+            ? <span className={tableCss.noRating}>N/A</span>
+            : this.renderPercentage(critId, ratingId)
+          }
+        </div>
+      </div>
+    );
+  }
+
+  private renderPercentage = (critId: string, ratingId: string) => {
+    let percentage = 0;
+
+    const criteriaCount = this.props.criteriaCounts.find(cc => cc.id === critId);
+    if (criteriaCount && criteriaCount?.numStudents > 0) {
+      const ratingCount = criteriaCount.ratings[ratingId];
+      if (ratingCount) {
+        percentage = Math.round((ratingCount / criteriaCount.numStudents) * 100);
+      }
+    }
+
+    return (
+      <>{percentage}%</>
+    );
+  }
+
+  private handleClose = (e: React.MouseEvent) => this.props.onClose();
+
+}

--- a/js/components/portal-dashboard/feedback/rubric-summary-modal.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-summary-modal.tsx
@@ -17,7 +17,6 @@ interface IProps {
 export class RubricSummaryModal extends PureComponent<IProps> {
 
   render() {
-    // const { rubric, criteriaCounts } = this.props;
 
     return (
       <Modal animation={false} centered dialogClassName={css.lightbox} onHide={this.handleClose} show={true} data-cy="rubric-summary-modal">

--- a/js/components/portal-dashboard/feedback/rubric-utils.ts
+++ b/js/components/portal-dashboard/feedback/rubric-utils.ts
@@ -73,6 +73,13 @@ const endColorHSL = hexToHSL(endColorRGB);
 
 // Main function to get RGB color based on value within min and max range
 export const getFeedbackColor = ({rubric, score}: {rubric: Rubric; score: number}): string => {
+  const [h, s, l] = getFeedbackHSL({rubric, score});
+
+  // Convert HSL back to RGB
+  return hslToRGB(h, s, l);
+};
+
+const getFeedbackHSL = ({rubric, score}: {rubric: Rubric; score: number}): [number, number, number] => {
   const {min, max} = rubric.ratings.reduce((acc, rating) => {
     acc.min = Math.min(acc.min, rating.score);
     acc.max = Math.max(acc.max, rating.score);
@@ -81,7 +88,7 @@ export const getFeedbackColor = ({rubric, score}: {rubric: Rubric; score: number
 
   const range = max - min;
   if (range <= 0) {
-    return startColorRGB;
+    return startColorHSL;
   }
   const scale = (score - min) / range;
 
@@ -90,8 +97,13 @@ export const getFeedbackColor = ({rubric, score}: {rubric: Rubric; score: number
   const s = startColorHSL[1] + (endColorHSL[1] - startColorHSL[1]) * scale;
   const l = startColorHSL[2] + (endColorHSL[2] - startColorHSL[2]) * scale;
 
-  // Convert HSL back to RGB
-  return hslToRGB(h, s, l);
+  return [h, s, l];
 };
 
+export const getFeedbackTextColor = ({rubric, score}: {rubric: Rubric; score: number}): string => {
+  const [h, s, l] = getFeedbackHSL({rubric, score});
+
+  const highContrastLightness = l > 50 ? 0 : 100;
+  return hslToRGB(h, s, highContrastLightness);
+};
 


### PR DESCRIPTION
Features:

- Rubric summary icon shows the distribution of scores per aspect of proficiency across the class in the Feedback Panel
- Icon updates as scores are entered
- If no rubric scores are entered, show N/A in place of the rubric icon in the feedback panel
- Rubric summary icon has default, hover, and click states
- When clicked, display lightbox dialog of Rubric Summary Details that shows percentages across the class per rating