### PR TITLE
fix: Average rubric score calculation [PT-187021319]

### DIFF
--- a/js/util/scoring.ts
+++ b/js/util/scoring.ts
@@ -57,7 +57,7 @@ export const computeAvgScore = (scoringSettings: ScoringSettings, rubric: Rubric
       const rubricScores = getRubricScores(rubric, feedbacks);
       const {totalScore, scoredQuestions} = rubricScores.reduce((acc, cur) => {
         let {totalScore, scoredQuestions} = acc;
-        if (cur !== null) {
+        if (cur) {
           totalScore += cur;
           scoredQuestions++;
         }


### PR DESCRIPTION
When a score is removed from the rubric the value is set to 0 and in that case the scored question count should not be increased.