### PR TITLE
fix: Fit n' finish fixes [PT-187186199]

### DIFF
--- a/js/components/portal-dashboard/feedback/feedback-settings-modal.tsx
+++ b/js/components/portal-dashboard/feedback/feedback-settings-modal.tsx
@@ -170,7 +170,7 @@ class FeedbackSettingsModal extends PureComponent<IProps, IState> {
         const scoresAboveMax = feedbacks.scores.reduce((acc: boolean, cur: number) => {
           return acc || cur > maxScore;
         }, false);
-        if (scoresAboveMax && !confirmMaxScore) {
+        if (scoresAboveMax && (scoreType === MANUAL_SCORE) && !confirmMaxScore) {
           this.setState({ confirmMaxScore: true });
           return;
         }

--- a/js/components/portal-dashboard/feedback/rubric-summary-icon.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-summary-icon.tsx
@@ -44,13 +44,16 @@ export const RubricSummaryIcon: React.FC<IProps> = (props) => {
 
   const { hasRubricFeedback, criteriaCounts } = useMemo(() => {
     const criteriaCounts: ICriteriaCount[] = [];
-    const numCompletedRubrics = rubricFeedbacks.reduce((acc: number, cur: PartialRubricFeedback) => {
-      const numNonZeroScores = Object.values(cur).reduce((acc2, cur2) => {
-        if (cur2.score > 0) {
-          acc2++;
+    const getNumNonZeroScores = (rubricFeedback: PartialRubricFeedback) => {
+      return Object.values(rubricFeedback).reduce((acc, cur) => {
+        if (cur.score > 0) {
+          acc++;
         }
-        return acc2;
+        return acc;
       }, 0);
+    };
+    const numCompletedRubrics = rubricFeedbacks.reduce((acc: number, cur: PartialRubricFeedback) => {
+      const numNonZeroScores = getNumNonZeroScores(cur);
       if (numNonZeroScores >= rubric.criteria.length) {
         acc++;
       }
@@ -73,10 +76,13 @@ export const RubricSummaryIcon: React.FC<IProps> = (props) => {
         criteriaCounts.push(criteriaCount);
 
         rubricFeedbacks.forEach((rubricFeedback: PartialRubricFeedback) => {
-          const criteriaFeedback = rubricFeedback[criteria.id];
-          if (criteriaFeedback?.score > 0) {
-            criteriaCount.numStudents++;
-            criteriaCount.ratings[criteriaFeedback.id]++;
+          const numNonZeroScores = getNumNonZeroScores(rubricFeedback);
+          if (numNonZeroScores >= rubric.criteria.length) {
+            const criteriaFeedback = rubricFeedback[criteria.id];
+            if (criteriaFeedback?.score > 0) {
+              criteriaCount.numStudents++;
+              criteriaCount.ratings[criteriaFeedback.id]++;
+            }
           }
         });
       });


### PR DESCRIPTION
- Only display max score modal when the user switches to the Manual score setting
- Rubric summary should only display student scores from complete rubrics