### PR TITLE
fix: Pull manual scores from feedbacks and not higher level scores attribute [PT-187021319]

### DIFF
--- a/js/components/portal-dashboard/feedback/feedback-settings-modal.tsx
+++ b/js/components/portal-dashboard/feedback/feedback-settings-modal.tsx
@@ -7,7 +7,7 @@ import { Rubric } from "./rubric-utils";
 import { TrackEventFunction, updateActivityFeedbackSettings } from "../../../actions";
 import { connect } from "react-redux";
 import { AUTOMATIC_SCORE, MANUAL_SCORE, NO_SCORE, RUBRIC_SCORE } from "../../../util/scoring-constants";
-import { ScoreType, ScoringSettings, getScoredQuestions } from "../../../util/scoring";
+import { ScoreType, ScoringSettings, getCurrentScores, getScoredQuestions } from "../../../util/scoring";
 import { ScoreInput } from "./score-input";
 
 import css from "../../../../css/portal-dashboard/feedback/feedback-settings-modal.less";
@@ -167,7 +167,8 @@ class FeedbackSettingsModal extends PureComponent<IProps, IState> {
       const updates: any = { scoreType };
       if (maxScore !== undefined) {
         // check if scores above max score and confirm if they are
-        const scoresAboveMax = feedbacks.scores.reduce((acc: boolean, cur: number) => {
+        const scores = getCurrentScores(feedbacks);
+        const scoresAboveMax = scores.reduce((acc: boolean, cur: number) => {
           return acc || cur > maxScore;
         }, false);
         if (scoresAboveMax && (scoreType === MANUAL_SCORE) && !confirmMaxScore) {

--- a/js/util/scoring.ts
+++ b/js/util/scoring.ts
@@ -71,7 +71,7 @@ export const computeAvgScore = (scoringSettings: ScoringSettings, rubric: Rubric
       break;
 
     case MANUAL_SCORE:
-      const manualScores = feedbacks.scores;
+      const manualScores = getCurrentScores(feedbacks);
       if (manualScores.length > 0) {
         const totalScore = manualScores.reduce((acc: number, cur: number) => acc + cur, 0);
         avgScore = totalScore / manualScores.length;
@@ -81,6 +81,16 @@ export const computeAvgScore = (scoringSettings: ScoringSettings, rubric: Rubric
   }
 
   return {avgScore, avgScoreMax};
+};
+
+export const getCurrentScores = (feedbacks: any) => {
+  return feedbacks.feedbacks.reduce((acc: any, cur: any) => {
+    const score = cur.get("score");
+    if (score !== undefined) {
+      acc.push(score);
+    }
+    return acc;
+  }, []);
 };
 
 export const getCompletedRubricScores = (rubric: Rubric, feedbacks: any) => {


### PR DESCRIPTION
The feedbacks.scores attribute is not updated in the selector when the question changes so the scores need to be pulled from the individual student feedback which does change when the question is changed.