### PR TITLE
feat: Add secondary researcher header element [PT-187325112]

### DIFF
--- a/css/portal-dashboard/header.less
+++ b/css/portal-dashboard/header.less
@@ -269,3 +269,9 @@
   }
 }
 
+.researcherHeader {
+  background-color: #0592af;
+  padding: 5px 15px;
+  color: white;
+}
+

--- a/js/components/portal-dashboard/header.tsx
+++ b/js/components/portal-dashboard/header.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Map, List } from "immutable";
 
 import ccLogoSrc from "../../../img/cc-logo.png";
 import { HeaderMenuContainer } from "./header-menu";
@@ -10,6 +11,7 @@ import GroupIcon from "../../../img/svg-icons/group-icon.svg";
 import FeedbackIcon from "../../../img/svg-icons/feedback-icon.svg";
 import { ColorTheme, DashboardViewMode } from "../../util/misc";
 import { TrackEventFunction } from "../../actions";
+import { ITeacherData } from "../../core/transform-json-response";
 
 import css from "../../../css/portal-dashboard/header.less";
 
@@ -22,34 +24,46 @@ interface IProps {
   setDashboardViewMode: (mode: DashboardViewMode) => void;
   viewMode: DashboardViewMode;
   colorTheme?: ColorTheme;
+  isResearcher: boolean;
+  clazzName: string;
+  teachers?: List<Map<string, ITeacherData>>;
 }
 
 export class Header extends React.PureComponent<IProps> {
   render() {
-    const { colorTheme, userName, setCompact, setHideFeedbackBadges, trackEvent } = this.props;
+    const { colorTheme, userName, setCompact, setHideFeedbackBadges, trackEvent, isResearcher, clazzName, teachers } = this.props;
     const colorClass = colorTheme ? css[colorTheme] : "";
+    const teacherNames = teachers && teachers.map((teacher: any) => teacher.get("name")).join(", ");
+
     return (
-      <div className={`${css.dashboardHeader} ${colorClass}`} data-cy="dashboard-header">
-        <div className={css.appInfo}>
-          <img src={ccLogoSrc} className={css.logo} data-cy="header-logo"/>
-          {this.renderNavigationSelect()}
-        </div>
-        <div className={css.headerCenter}>
-          <div className={css.assignmentTitle}>
-            Assignment:
+      <>
+        <div className={`${css.dashboardHeader} ${colorClass}`} data-cy="dashboard-header">
+          <div className={css.appInfo}>
+            <img src={ccLogoSrc} className={css.logo} data-cy="header-logo"/>
+            {this.renderNavigationSelect()}
           </div>
-          {this.renderAssignmentSelect()}
+          <div className={css.headerCenter}>
+            <div className={css.assignmentTitle}>
+              Assignment:
+            </div>
+            {this.renderAssignmentSelect()}
+          </div>
+          <div className={css.headerRight}>
+            <AccountOwnerDiv userName={userName} colorTheme={colorTheme} />
+            <HeaderMenuContainer
+              setCompact={setCompact}
+              setHideFeedbackBadges={setHideFeedbackBadges}
+              colorTheme={colorTheme}
+              trackEvent={trackEvent}
+            />
+          </div>
         </div>
-        <div className={css.headerRight}>
-          <AccountOwnerDiv userName={userName} colorTheme={colorTheme} />
-          <HeaderMenuContainer
-            setCompact={setCompact}
-            setHideFeedbackBadges={setHideFeedbackBadges}
-            colorTheme={colorTheme}
-            trackEvent={trackEvent}
-          />
-        </div>
-      </div>
+        {isResearcher &&
+          <div className={css.researcherHeader}>
+            <strong>Researcher View</strong> for {clazzName}{teacherNames && ` / ${teacherNames}`}
+          </div>
+        }
+      </>
     );
   }
 

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -23,6 +23,7 @@ import { ColorTheme, DashboardViewMode, FeedbackLevel, ListViewMode } from "../.
 import { ScoringSettings, getScoredQuestions, getScoringSettings, getScoringSettingsInState } from "../../util/scoring";
 import { computeRubricMaxScore } from "../../selectors/activity-feedback-selectors";
 import { Rubric } from "../../components/portal-dashboard/feedback/rubric-utils";
+import { getSortedTeachers } from "../../selectors/report";
 
 import css from "../../../css/portal-dashboard/portal-dashboard-app.less";
 
@@ -51,6 +52,7 @@ interface IProps {
   studentCount: number;
   studentProgress: Map<any, any>;
   students: any;
+  teachers: any;
   sortedQuestionIds?: string[];
   scoringSettings: ScoringSettings;
   // from mapDispatchToProps
@@ -262,7 +264,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
   }
 
   private renderHeader = (assignmentName: string, headerViewMode: DashboardViewMode) => {
-    const { sequenceTree, userName, setCompactReport, setHideFeedbackBadges, trackEvent } = this.props;
+    const { sequenceTree, userName, setCompactReport, setHideFeedbackBadges, trackEvent, isResearcher, clazzName, teachers } = this.props;
     const { viewMode} = this.state;
     const color: ColorTheme = headerViewMode === "ProgressDashboard"
       ? "progress"
@@ -279,6 +281,9 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
           setDashboardViewMode={this.setDashboardViewMode}
           viewMode={viewMode}
           colorTheme={color}
+          isResearcher={isResearcher}
+          clazzName={clazzName}
+          teachers={teachers}
         />
     );
   }
@@ -369,6 +374,7 @@ function mapStateToProps(state: RootState): Partial<IProps> {
     sortByMethod: getDashboardSortBy(state),
     sortedQuestionIds,
     students: dataDownloaded && getSortedStudents(state),
+    teachers: dataDownloaded && getSortedTeachers(state),
     studentProgress: dataDownloaded && getStudentProgress(state),
     userName: dataDownloaded ? state.getIn(["report", "platformUserName"]) : undefined,
     scoringSettings,

--- a/js/core/transform-json-response.ts
+++ b/js/core/transform-json-response.ts
@@ -63,6 +63,7 @@ export interface IPortalData {
     name: string;
     classHash: string;
     students: IStudentData[];
+    teachers: ITeacherData[];
   };
   userType: "teacher" | "learner" | "researcher";
   platformUserId: string;
@@ -74,6 +75,13 @@ export interface IPortalData {
 export interface IStudentData {
   name: string;
   realName: string;
+  firstName: string;
+  lastName: string;
+  id: string;
+  userId: number;
+}
+export interface ITeacherData {
+  name: string;
   firstName: string;
   lastName: string;
   id: string;
@@ -209,6 +217,10 @@ export function preprocessPortalDataJSON(portalData: IPortalRawData): IPortalDat
     student.name = `${student.firstName} ${student.lastName}`;
     // Provide additional property in student hash, it's useful for anonymization.
     student.realName = student.name;
+  });
+  camelizedJson.classInfo.teachers.forEach(teacher => {
+    teacher.id = teacher.userId.toString();
+    teacher.name = `${teacher.firstName} ${teacher.lastName}`;
   });
   return camelizedJson;
 }

--- a/js/data/small-class-data.json
+++ b/js/data/small-class-data.json
@@ -33,5 +33,12 @@
       "first_name": "Jerome",
       "last_name": "Wu"
     }
+  ],
+  "teachers": [
+    {
+      "user_id": 100,
+      "first_name": "Kristen",
+      "last_name": "Teachername"
+    }
   ]
 }

--- a/js/reducers/report-reducer.ts
+++ b/js/reducers/report-reducer.ts
@@ -37,6 +37,7 @@ export interface IReportState {
   clazzName: string;
   clazzId: number;
   students: Map<any, any>;
+  teachers: Map<any, any>;
   answers: Map<any, any>;
   sequences: Map<any, any>;
   activities: Map<any, any>;
@@ -71,6 +72,7 @@ const INITIAL_REPORT_STATE = RecordFactory<IReportState>({
   clazzName: "",
   clazzId: -1,
   students: Map({}),
+  teachers: Map({}),
   answers: Map({}),
   sequences: Map({}),
   activities: Map({}),
@@ -109,6 +111,7 @@ export class ReportState extends INITIAL_REPORT_STATE implements IReportState {
   clazzName: string;
   clazzId: number;
   students: Map<any, any>;
+  teachers: Map<any, any>;
   answers: Map<any, any>;
   sequences: Map<any, any>;
   activities: Map<any, any>;
@@ -179,6 +182,7 @@ export default function report(state = new ReportState({}), action?: any) {
         .set("clazzName", data.classInfo.name)
         .set("clazzId", data.classInfo.id)
         .set("students", Map(data.classInfo.students.map(student => [student.id, Map(student)])))
+        .set("teachers", Map(data.classInfo.teachers.map(teacher => [teacher.id, Map(teacher)])))
         .set("platformUserId", data.platformUserId)
         .set("platformUserName",data.offering.teacher)
         .set("loggingUserName", getLoggingUserName(data))

--- a/js/selectors/activity-feedback-selectors.js
+++ b/js/selectors/activity-feedback-selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from "reselect";
 import { fromJS, Map as IMap } from "immutable";
-import { compareStudentsByName, feedbackValidForAnswer } from "../util/misc";
+import { compareStudentsOrTeachersByName, feedbackValidForAnswer } from "../util/misc";
 import { getStudentProgress } from "./dashboard-selectors";
 import {
   AUTOMATIC_SCORE,
@@ -63,7 +63,7 @@ const activityFeedbackFor = (activity, student, feedbacks, progress) => {
 };
 
 const formatStudents = (students) => students
-  .sort((student1, student2) => compareStudentsByName(student1, student2))
+  .sort((student1, student2) => compareStudentsOrTeachersByName(student1, student2))
   .map(s => addRealName(s));
 
 const getActivitySettings = (feedbackSettings, activity) =>

--- a/js/selectors/compare-view-data.js
+++ b/js/selectors/compare-view-data.js
@@ -1,6 +1,6 @@
 import { createSelector } from "reselect";
 import { getAnswerTrees } from "./report-tree";
-import { compareStudentsByName } from "../util/misc";
+import { compareStudentsOrTeachersByName } from "../util/misc";
 
 // Inputs
 const getCompareViewAnswers = state => state.get("report").get("compareViewAnswers");
@@ -11,7 +11,7 @@ const getCompareViewData = createSelector(
   (compareViewAnswers, answerTrees) =>
     compareViewAnswers
       .map(id => answerTrees.get(id))
-      .sort((ans1, ans2) => compareStudentsByName(ans1.get("student"), ans2.get("student")))
+      .sort((ans1, ans2) => compareStudentsOrTeachersByName(ans1.get("student"), ans2.get("student")))
 );
 
 export default getCompareViewData;

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -2,7 +2,7 @@ import { createSelector } from "reselect";
 import { getActivityTrees, getQuestionTrees, getAnswersByQuestion } from "./report-tree";
 import { SORT_BY_NAME, SORT_BY_MOST_PROGRESS, SORT_BY_LEAST_PROGRESS,
          SORT_BY_FEEDBACK_NAME, SORT_BY_FEEDBACK_PROGRESS } from "../actions/dashboard";
-import { compareStudentsByName } from "../util/misc";
+import { compareStudentsOrTeachersByName } from "../util/misc";
 import { fromJS } from "immutable";
 
 const kSortGroupFirst = 1;
@@ -130,7 +130,7 @@ export const getSortedStudents = createSelector(
     switch (sortBy) {
       case SORT_BY_NAME:
         return students.toList().sort((student1, student2) =>
-          compareStudentsByName(student1, student2),
+          compareStudentsOrTeachersByName(student1, student2),
         );
       case SORT_BY_LEAST_PROGRESS:
       case SORT_BY_MOST_PROGRESS:
@@ -143,7 +143,7 @@ export const getSortedStudents = createSelector(
           if (progressComp !== 0) {
             return progressComp;
           } else {
-            return compareStudentsByName(student1, student2);
+            return compareStudentsOrTeachersByName(student1, student2);
           }
         });
       default:
@@ -159,7 +159,7 @@ export const getActivityFeedbackSortedStudents = createSelector(
     switch (feedbackSortBy) {
       case SORT_BY_FEEDBACK_NAME:
         return students.toList().sort((student1, student2) =>
-          compareStudentsByName(student1, student2),
+          compareStudentsOrTeachersByName(student1, student2),
         );
       case SORT_BY_FEEDBACK_PROGRESS:
         return students.toList().sort((student1, student2) => {
@@ -193,7 +193,7 @@ export const getQuestionFeedbackSortedStudents = createSelector(
     switch (feedbackSortBy) {
       case SORT_BY_FEEDBACK_NAME:
         return students.toList().sort((student1, student2) =>
-          compareStudentsByName(student1, student2),
+          compareStudentsOrTeachersByName(student1, student2),
         );
       case SORT_BY_FEEDBACK_PROGRESS:
         // TODO: change to sort by question feedback

--- a/js/selectors/report.js
+++ b/js/selectors/report.js
@@ -1,11 +1,17 @@
 import { createSelector } from "reselect";
-import { compareStudentsByName } from "../util/misc";
+import { compareStudentsOrTeachersByName } from "../util/misc";
 
 // Inputs
 const getStudents = state => state.getIn(["report", "students"]);
+const getTeachers = state => state.getIn(["report", "teachers"]);
 
 // Selectors
 export const getSortedStudents = createSelector(
   [ getStudents ],
-  (students) => students.toList().sort((student1, student2) => compareStudentsByName(student1, student2))
+  (students) => students.toList().sort((student1, student2) => compareStudentsOrTeachersByName(student1, student2))
+);
+
+export const getSortedTeachers = createSelector(
+  [ getTeachers ],
+  (teachers) => teachers.toList().sort((teacher1, teacher2) => compareStudentsOrTeachersByName(teacher1, teacher2))
 );

--- a/js/util/misc.ts
+++ b/js/util/misc.ts
@@ -14,14 +14,14 @@ export const parseUrl = (url: string) => {
 };
 
 // A comparison function to sort students by last and then first name
-export const compareStudentsByName = (student1: Map<string, any>, student2: Map<string, any>) => {
-  const lastNameCompare = student1.get("lastName").toLocaleLowerCase().localeCompare(
-    student2.get("lastName").toLocaleLowerCase(),
+export const compareStudentsOrTeachersByName = (studentOrTeacher1: Map<string, any>, studentOrTeacher2: Map<string, any>) => {
+  const lastNameCompare = studentOrTeacher1.get("lastName").toLocaleLowerCase().localeCompare(
+    studentOrTeacher2.get("lastName").toLocaleLowerCase(),
   );
   if (lastNameCompare !== 0) {
     return lastNameCompare;
   } else {
-    return student1.get("firstName").localeCompare(student2.get("firstName"));
+    return studentOrTeacher1.get("firstName").localeCompare(studentOrTeacher2.get("firstName"));
   }
 };
 


### PR DESCRIPTION
This adds a secondary header element if the user is a researcher.  This new element displays under the main header and shows that the interface is in researcher mode and displays the class name and teacher names.

The teachers of the class were previously not storied in the state so most of the work of this commit is adding that to the state and drilling it down as a prop.