### PR TITLE
fix: Disable pointer events for dashboard badges

### DIFF
--- a/css/portal-dashboard/answer-compact.less
+++ b/css/portal-dashboard/answer-compact.less
@@ -45,6 +45,7 @@
     position: absolute;
     left: 25px;
     top: 10px;
+    pointer-events: none;
   }
 
   .audioAttachmentBadge {
@@ -53,5 +54,6 @@
     position: absolute;
     left: 0;
     top: 10px;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
After the audio feedback badge was added I noticed the the new badge and the old feedback badge accepted pointer events which causes the hover styling of the parent answer to be disabled.