### PR TITLE
fix: Student feedback not showing rubric score [PT-188024567]

### DIFF
--- a/js/components/report/activity-feedback-for-student.js
+++ b/js/components/report/activity-feedback-for-student.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from "react";
 import FeedbackPanelForStudent from "./feedback-panel-for-student";
+import { RUBRIC_SCORE } from "../../util/scoring-constants";
+import { computeRubricMaxScore } from "../../selectors/activity-feedback-selectors";
 
 export default class ActivityFeedbackForStudent extends PureComponent {
   render() {
@@ -10,7 +12,7 @@ export default class ActivityFeedbackForStudent extends PureComponent {
       useRubric,
       rubric,
       showScore,
-      maxScore,
+      scoreType,
       showText,
       autoScore,
     } = this.props;
@@ -20,10 +22,23 @@ export default class ActivityFeedbackForStudent extends PureComponent {
       feedback = feedback.toJS();
     }
     const showFeedback = feedback && feedback.hasBeenReviewed;
-    const score = (autoScore != null) ? autoScore : feedback && feedback.score;
     const textFeedback = feedback && feedback.feedback;
     const hasBeenReviewed = feedback && feedback.hasBeenReviewed;
     const rubricFeedback = feedback && feedback.rubricFeedback;
+
+    let score = (autoScore != null) ? autoScore : feedback && feedback.score;
+    let maxScore = this.props.maxScore;
+
+    // re-score the rubric if needed due the teacher dashboard not setting the scoreType and/or score correctly when there is a rubric
+    if ((scoreType === undefined || (scoreType === RUBRIC_SCORE && score === undefined)) && rubricFeedback && rubric) {
+      const scoredValues = Object.values(rubricFeedback).filter((v) => v.score > 0);
+      const numCriteria = rubric.criteriaGroups.reduce((acc, cur) => acc + cur.criteria.length, 0);
+      if (scoredValues.length === numCriteria) {
+        score = scoredValues.reduce((acc, cur) => acc + cur.score, 0);
+        maxScore = computeRubricMaxScore(rubric);
+      }
+    }
+
     return (
       <FeedbackPanelForStudent
         student={student}

--- a/js/containers/report/activity.js
+++ b/js/containers/report/activity.js
@@ -98,6 +98,7 @@ class Activity extends PureComponent {
               student={reportFor}
               feedbacks={feedbacks}
               showScore={showScore}
+              scoreType={scoreType}
               maxScore={maxScore}
               showText={showText}
               useRubric={useRubric}


### PR DESCRIPTION
The rubric score was not being shown when the teacher in the dashboard used the default score setting, which was to score using the rubric when the rubric was present.

This commit re-scores the rubric before it is shown to the student if there is no score type set or the score type is rubric and no score is set.

Further work needs to be done in the future to update the teacher dashboard to set the score by default.