### PR TITLE
feat: Add rubric summary tag table [PT-188404153]

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The following query params can be used during development or when debugging issu
 - `debug:rubricSummaryTableOverride` - overrides the rubric summary table option for the loaded rubric.  Possible values are:
   `none`, `above`, `below`, and `onlySummary`.  Useful for testing the placement of the summary table without having to create multiple rubrics.
 
+- `debug:rubricUrlOverride` - overrides the rubric url specified in the activity json or saved in the offering data.  This can either be one of the built-in rubrics in the `public` folder or a full url.  Example built-in rubrics include: `sample-rubric-no-tags.json`, `sample-rubric-all-dci-na.json`, and `sample-v1-rubric.json`.  Useful for testing rubric features during development.
+
 ## License
 
 [MIT](https://github.com/concord-consortium/grasp-seasons/blob/master/LICENSE)

--- a/css/portal-dashboard/feedback/rubric-summary-modal.less
+++ b/css/portal-dashboard/feedback/rubric-summary-modal.less
@@ -6,7 +6,6 @@
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.35);
   height: auto;
   left: 50px;
-  top: 135px;
   width: 777px;
 
   .lightboxHeader {
@@ -29,6 +28,12 @@
 
     .contentArea {
       padding: 0 20px 10px 20px;
+
+      .contents {
+        display: flex;
+        gap: 10px;
+        flex-direction: column;
+      }
 
       .modalOption {
         margin: 15px 0 10px 0;

--- a/css/portal-dashboard/feedback/rubric-table.less
+++ b/css/portal-dashboard/feedback/rubric-table.less
@@ -64,7 +64,13 @@
 
       .rubricDescriptionTitle {
         justify-content: center;
-        width: 75%
+        width: 75%;
+
+        &.fullWidth {
+          width: 100%;
+          text-align: left;
+          margin-left: 10px;
+        }
       }
     }
     .rubricScoreHeader {
@@ -111,6 +117,10 @@
           flex: 1;
           align-items: stretch;
 
+          p {
+            margin-top: 0;
+          }
+
           &:first-child {
             border: none;
           }
@@ -119,6 +129,11 @@
             padding: 5px 10px;
             font-weight: normal;
             flex: auto;
+
+            &.separateImage {
+              display: flex;
+              align-items: center;
+            }
 
             img {
               padding-right: 10px;

--- a/js/api.ts
+++ b/js/api.ts
@@ -8,6 +8,7 @@ import { parseUrl, validFsId, urlParam, urlHashParam } from "./util/misc";
 import { getActivityStudentFeedbackKey } from "./util/activity-feedback-helper";
 import { getFirebaseAppName, signInWithToken } from "./db";
 import migrate from "./core/rubric-migrations";
+import { rubricUrlOverride } from "./util/debug-flags";
 
 const PORTAL_AUTH_PATH = "/auth/oauth_authorize";
 let accessToken: string | null = null;
@@ -409,6 +410,9 @@ export function updateActivityFeedbacks(data: any, reportState: IStateReportPart
 const rubricUrlCache: any = {};
 
 export function fetchRubric(rubricUrl: string) {
+  // check for override
+  rubricUrl = rubricUrlOverride ?? rubricUrl;
+
   return new Promise((resolve, reject) => {
     if (!rubricUrlCache[rubricUrl]) {
       fetch(rubricUrl)

--- a/js/components/portal-dashboard/feedback/rubric-summary-modal.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-summary-modal.tsx
@@ -1,11 +1,13 @@
 import React, { PureComponent } from "react";
 import { Modal } from "react-bootstrap";
 import Markdown from "markdown-to-jsx";
-import { Rubric, RubricCriterion, RubricRating, getFeedbackColor, getFeedbackTextColor } from "./rubric-utils";
+import classNames from "classnames";
+import { Rubric, getFeedbackColor, getFeedbackTextColor } from "./rubric-utils";
 import { ICriteriaCount } from "./rubric-summary-icon";
 import LaunchIcon from "../../../../img/svg-icons/launch-icon.svg";
 import { ScoringSettings } from "../../../util/scoring";
 import { RUBRIC_SCORE } from "../../../util/scoring-constants";
+import { getRubricSummary, IRubricSummary, IRubricSummaryRow } from "../../../util/rubric-summary";
 
 import css from "../../../../css/portal-dashboard/feedback/rubric-summary-modal.less";
 import tableCss from "../../../../css/portal-dashboard/feedback/rubric-table.less";
@@ -21,6 +23,7 @@ interface IProps {
 export class RubricSummaryModal extends PureComponent<IProps> {
 
   render() {
+    const summary = getRubricSummary(this.props.rubric, this.props.criteriaCounts);
 
     return (
       <Modal animation={false} centered dialogClassName={css.lightbox} onHide={this.handleClose} show={true} data-cy="rubric-summary-modal">
@@ -31,7 +34,9 @@ export class RubricSummaryModal extends PureComponent<IProps> {
         </Modal.Header>
         <Modal.Body className={css.lightboxBody}>
           <div className={css.contentArea} data-cy="rubric-summary-modal-content-area">
-            {this.renderTable()}
+            <div className={css.contents}>
+              {this.renderSummary(summary)}
+            </div>
             <div className={css.buttonContainer}>
               <div className={css.closeButton} onClick={this.handleClose} data-cy="rubric-summary-modal-close-button">
                 Close
@@ -43,28 +48,47 @@ export class RubricSummaryModal extends PureComponent<IProps> {
     );
   }
 
-  private renderTable() {
+  private renderSummary(summary: IRubricSummary) {
+    switch (this.props.rubric.tagSummaryDisplay) {
+      case "above":
+        return <>{this.renderTagSummary(summary)}{this.renderCriteriaTable(summary)}</>;
+      case "below":
+        return <>{this.renderCriteriaTable(summary)}{this.renderTagSummary(summary)}</>;
+      case "onlySummary":
+        return this.renderTagSummary(summary);
+      case "none":
+      default:
+        return this.renderCriteriaTable(summary);
+    }
+  }
+
+  private renderTagSummary({tagSummaryRows, tagSummaryTitle}: IRubricSummary) {
+    const { rubric, rubricDocUrl } = this.props;
+
+    return (
+      <div className={tableCss.rubricContainer} data-cy="rubric-table">
+        {this.renderColumnHeaders(rubric, rubricDocUrl, {title: tagSummaryTitle, hideScoringGuide: true})}
+        <div className={tableCss.rubricTable}>
+          <div className={tableCss.rubricTableGroup}>
+            {this.renderRows(tagSummaryRows)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  private renderCriteriaTable({tableRows}: IRubricSummary) {
     const { rubric, rubricDocUrl } = this.props;
     const { criteriaGroups } = rubric;
 
     return (
       <div className={tableCss.rubricContainer} data-cy="rubric-table">
-        {this.renderColumnHeaders(rubric, rubricDocUrl)}
+        {this.renderColumnHeaders(rubric, rubricDocUrl, {title: rubric.criteriaLabel})}
         <div className={tableCss.rubricTable}>
           {criteriaGroups.map((criteriaGroup, index) => (
             <div className={tableCss.rubricTableGroup} key={index}>
               {criteriaGroup.label.length > 0 && <div className={tableCss.rubricTableGroupLabel}>{criteriaGroup.label}</div>}
-              <div className={tableCss.rubricTableRows}>
-                {criteriaGroup.criteria.map(criterion =>
-                  <div className={tableCss.rubricTableRow} key={criterion.id} id={criterion.id}>
-                    <div className={tableCss.rubricDescription}>
-                      {criterion.iconUrl && <img src={criterion.iconUrl} title={criterion.iconPhrase} />}
-                      <Markdown>{criterion.description}</Markdown>
-                    </div>
-                    {this.renderRatings(criterion)}
-                  </div>
-                )}
-              </div>
+              {this.renderRows(tableRows.filter(r => r.criteriaGroupIndex === index))}
             </div>
           ))}
         </div>
@@ -72,20 +96,21 @@ export class RubricSummaryModal extends PureComponent<IProps> {
     );
   }
 
-  private renderColumnHeaders = (rubric: Rubric, rubricDocUrl: string) => {
+  private renderColumnHeaders = (rubric: Rubric, rubricDocUrl: string, options: {title: string; hideScoringGuide?: boolean}) => {
     const hasRubricDocUrl = rubricDocUrl.trim().length > 0;
-
     const showScore = this.props.scoringSettings.scoreType === RUBRIC_SCORE;
+    const titleClassName = classNames(tableCss.rubricDescriptionTitle, tableCss.fullWidth);
+
     return (
       <div className={tableCss.columnHeaders}>
         <div className={tableCss.rubricDescriptionHeader}>
-          {hasRubricDocUrl && <div className={tableCss.scoringGuideArea}>
+          {hasRubricDocUrl && !options.hideScoringGuide && <div className={tableCss.scoringGuideArea}>
             <a className={tableCss.launchButton} href={rubricDocUrl} target="_blank" data-cy="scoring-guide-launch-icon">
               <LaunchIcon className={tableCss.icon} />
             </a>
             Scoring Guide
           </div>}
-          <div className={tableCss.rubricDescriptionTitle}>{rubric.criteriaLabel}</div>
+          <div className={titleClassName}>{options.title}</div>
         </div>
         {rubric.ratings.map((rating: any) =>
           <div className={tableCss.rubricScoreHeader} key={rating.id}>
@@ -97,55 +122,40 @@ export class RubricSummaryModal extends PureComponent<IProps> {
     );
   }
 
-  private renderRatings = (crit: RubricCriterion) => {
-    const { rubric } = this.props;
-    const { ratings } = rubric;
+  private renderRows(rows: IRubricSummaryRow[]) {
+    const {rubric} = this.props;
+
     return (
-      <div className={tableCss.ratingsGroup}>
-        {ratings.map(rating => this.renderRating(crit, rating))}
+      <div className={tableCss.rubricTableRows}>
+        {rows.map(({text, ratings, iconUrl, iconPhrase}, index) => (
+        <div className={tableCss.rubricTableRow} key={index}>
+          <div className={classNames(tableCss.rubricDescription, tableCss.separateImage)}>
+            {iconUrl && <img src={iconUrl} title={iconPhrase} /> }
+            <Markdown>{text}</Markdown>
+          </div>
+          <div className={tableCss.ratingsGroup}>
+            {ratings.map(({score, isApplicableRating, label, percentage}, index) => {
+              const style: React.CSSProperties = {
+                color: getFeedbackTextColor({rubric, score}),
+                backgroundColor: getFeedbackColor({rubric, score})
+              };
+              return (
+                <div className={tableCss.rubricScoreBox} style={style} key={index}>
+                  <div className={tableCss.rubricButton} title={label}>
+                  { !isApplicableRating
+                    ? <span className={tableCss.noRating}>N/A</span>
+                    : <>{percentage}%</>
+                  }
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>))}
       </div>
-    );
-  }
-
-  private renderRating = (criterion: RubricCriterion, rating: RubricRating) => {
-    const critId = criterion.id;
-    const ratingId = rating.id;
-    const key = `${critId}-${ratingId}`;
-    const ratingDescription = criterion.ratingDescriptions?.[ratingId];
-    const isApplicableRating = criterion.nonApplicableRatings === undefined || criterion.nonApplicableRatings.indexOf(ratingId) < 0;
-    const style: React.CSSProperties = {
-      color: getFeedbackTextColor({rubric: this.props.rubric, score: rating.score}),
-      backgroundColor: getFeedbackColor({rubric: this.props.rubric, score: rating.score})
-    };
-
-    return (
-      <div className={tableCss.rubricScoreBox} style={style} key={key}>
-        <div className={tableCss.rubricButton} title={(isApplicableRating) ? ratingDescription : "Not Applicable"}>
-          { !isApplicableRating
-            ? <span className={tableCss.noRating}>N/A</span>
-            : this.renderPercentage(critId, ratingId)
-          }
-        </div>
-      </div>
-    );
-  }
-
-  private renderPercentage = (critId: string, ratingId: string) => {
-    let percentage = 0;
-
-    const criteriaCount = this.props.criteriaCounts.find(cc => cc.id === critId);
-    if (criteriaCount && criteriaCount?.numStudents > 0) {
-      const ratingCount = criteriaCount.ratings[ratingId];
-      if (ratingCount) {
-        percentage = Math.round((ratingCount / criteriaCount.numStudents) * 100);
-      }
-    }
-
-    return (
-      <>{percentage}%</>
     );
   }
 
   private handleClose = (e: React.MouseEvent) => this.props.onClose();
-
 }
+

--- a/js/components/portal-dashboard/feedback/rubric-table.tsx
+++ b/js/components/portal-dashboard/feedback/rubric-table.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Map } from "immutable";
 import Markdown from "markdown-to-jsx";
 import ReactTooltip from "react-tooltip";
+import classNames from "classnames";
 import LaunchIcon from "../../../../img/svg-icons/launch-icon.svg";
 import { Rubric, RubricCriterion, RubricRating, getFeedbackColor } from "./rubric-utils";
 import { ScoringSettings } from "../../../util/scoring";
@@ -36,7 +37,7 @@ export class RubricTableContainer extends React.PureComponent<IProps> {
               <div className={css.rubricTableRows}>
                 {criteriaGroup.criteria.map(criterion =>
                   <div className={css.rubricTableRow} key={criterion.id} id={criterion.id}>
-                    <div className={css.rubricDescription}>
+                    <div className={classNames(css.rubricDescription, css.separateImage)}>
                       {criterion.iconUrl && <img src={criterion.iconUrl} />}
                       <Markdown>{criterion.description}</Markdown>
                     </div>

--- a/js/core/rubric-migrations.js
+++ b/js/core/rubric-migrations.js
@@ -1,8 +1,7 @@
 import semver from "semver";
-import queryString from "query-string";
+import {rubricSummaryTableOverride} from "../util/debug-flags";
 
 function getSummaryTableOverride(currentValue) {
-  const rubricSummaryTableOverride = queryString.parse(window.location.search)['debug:rubricSummaryTableOverride'];
   return rubricSummaryTableOverride ?? currentValue;
 }
 
@@ -58,14 +57,6 @@ function createCriteriaGroups(rubric) {
   delete rubric.scoreUsingPoints;
 }
 
-function fixUndefinedIconPhrase(rubric) {
-  rubric.criteriaGroups.forEach(criteriaGroup => {
-    criteriaGroup.criteria.forEach(criteria => {
-      criteria.iconPhrase = criteria.iconPhrase ?? "";
-    });
-  });
-}
-
 const migrations = [
   { version: "1.0.0",
     migrations: [],
@@ -80,7 +71,6 @@ const migrations = [
     version: "1.2.0",
     migrations: [
       createCriteriaGroups,
-      fixUndefinedIconPhrase,
     ],
   },
 ];
@@ -112,6 +102,13 @@ export default function migrate(rubric) {
       runMigration(rubric, m);
     }
   }
+
+  // the iconPhrase was added in version 1.2.0 without a version bump
+  rubric.criteriaGroups.forEach(criteriaGroup => {
+    criteriaGroup.criteria.forEach(criteria => {
+      criteria.iconPhrase = criteria.iconPhrase ?? "";
+    });
+  });
 
   // allow the user to set the summary table option via a query parameter
   rubric.tagSummaryDisplay = getSummaryTableOverride(rubric.tagSummaryDisplay) ?? "none";

--- a/js/util/debug-flags.js
+++ b/js/util/debug-flags.js
@@ -1,0 +1,7 @@
+const params = new URLSearchParams(window.location.search);
+
+export const disableRubric = params.get("debug:disableRubric") === "true";
+
+export const rubricSummaryTableOverride = params.get("debug:rubricSummaryTableOverride");
+
+export const rubricUrlOverride = params.get("debug:rubricUrlOverride");

--- a/js/util/debug-flags.ts
+++ b/js/util/debug-flags.ts
@@ -1,3 +1,0 @@
-const params = new URLSearchParams(window.location.search);
-
-export const disableRubric = params.get("debug:disableRubric") === "true";

--- a/js/util/rubric-summary.ts
+++ b/js/util/rubric-summary.ts
@@ -1,0 +1,101 @@
+import { ICriteriaCount } from "../components/portal-dashboard/feedback/rubric-summary-icon";
+import { Rubric, RubricRating } from "../components/portal-dashboard/feedback/rubric-utils";
+
+export interface IRubricSummaryRowRating {
+  score: number;
+  label: string;
+  percentage: number;
+  isApplicableRating: boolean;
+}
+
+export interface IRubricSummaryRow {
+  text: string;
+  ratings: IRubricSummaryRowRating[];
+  iconUrl?: string;
+  iconPhrase?: string;
+  criteriaGroupIndex?: number;
+}
+
+export interface IRubricSummary {
+  tableRows: IRubricSummaryRow[];
+  tagSummaryRows: IRubricSummaryRow[];
+  tagSummaryTitle: string;
+}
+
+const getRubricSummaryRowRatings = (rows: IRubricSummaryRow[], ratings: RubricRating[]) => {
+  const summaryRowRatings: IRubricSummaryRowRating[] = [];
+
+  ratings.forEach(({score, label}, index) => {
+    const {sum, count, hasApplicableRating} = rows.reduce((acc, row) => {
+      const {isApplicableRating, percentage} = row.ratings[index];
+      acc.count++;
+      if (isApplicableRating) {
+        acc.sum += percentage;
+        acc.hasApplicableRating = true;
+      }
+      return acc;
+    }, {sum: 0, count: 0, hasApplicableRating: false});
+    if (count > 0 && hasApplicableRating) {
+      summaryRowRatings.push({isApplicableRating: true, percentage: Math.round(sum / count), score, label});
+    } else {
+      summaryRowRatings.push({isApplicableRating: false, percentage: 0, score, label});
+    }
+  });
+
+  return summaryRowRatings;
+};
+
+export const getRubricSummary = (rubric: Rubric, criteriaCounts: ICriteriaCount[]): IRubricSummary => {
+  const {criteriaGroups, ratings} = rubric;
+  const tableRows: IRubricSummaryRow[] = [];
+  const tagSummaryRows: IRubricSummaryRow[] = [];
+  const tags = new Map<string, string>();
+
+  criteriaGroups.forEach((criteriaGroup, criteriaGroupIndex) => {
+    criteriaGroup.criteria.forEach(criterion => {
+      const {iconUrl, iconPhrase} = criterion;
+      const row: IRubricSummaryRow = {criteriaGroupIndex, ratings: [], iconUrl, iconPhrase, text: criterion.description};
+      ratings.forEach(rating => {
+        const {id, score} = rating;
+        const isApplicableRating = criterion.nonApplicableRatings === undefined || criterion.nonApplicableRatings.indexOf(id) < 0;
+        const label = isApplicableRating ? criterion.ratingDescriptions?.[id] : "Not Applicable";
+        let percentage = 0;
+        if (isApplicableRating) {
+          const criteriaCount = criteriaCounts.find(cc => cc.id === criterion.id);
+          if (criteriaCount && criteriaCount?.numStudents > 0) {
+            const ratingCount = criteriaCount.ratings[id];
+            if (ratingCount) {
+              percentage = Math.round((ratingCount / criteriaCount.numStudents) * 100);
+            }
+          }
+        }
+        row.ratings.push({score, percentage, label, isApplicableRating});
+      });
+      tableRows.push(row);
+
+      if (iconUrl && !tags.has(iconUrl) && iconPhrase) {
+        tags.set(iconUrl, iconPhrase);
+      }
+    });
+  });
+
+  const hasTags = tags.size > 0;
+  const tagSummaryTitle = hasTags ? "Average Result by Tag" : "Summary of Rubric Score";
+
+  if (hasTags) {
+    const sortedKeys = Array.from(tags.keys()).sort();
+    sortedKeys.forEach(iconUrl => {
+      const tagRows = tableRows.filter(r => r.iconUrl === iconUrl);
+      const iconPhrase = tags.get(iconUrl) ?? "";
+      tagSummaryRows.push({text: iconPhrase, ratings: getRubricSummaryRowRatings(tagRows, ratings), iconUrl, iconPhrase});
+    });
+    const nonTagRows = tableRows.filter(r => !r.iconUrl);
+    if (nonTagRows.length > 0) {
+      tagSummaryRows.push({text: "No tag applied", ratings: getRubricSummaryRowRatings(nonTagRows, ratings)});
+    }
+  } else {
+    tagSummaryRows.push({text: "Class Results", ratings: getRubricSummaryRowRatings(tableRows, ratings)});
+  }
+
+  return {tableRows, tagSummaryRows, tagSummaryTitle};
+};

--- a/public/sample-rubric-all-dci-na.json
+++ b/public/sample-rubric-all-dci-na.json
@@ -1,0 +1,108 @@
+{
+    "id": "",
+    "version": "1.2.0",
+    "versionNumber": "",
+    "updatedMsUTC": 0,
+    "originUrl": "",
+    "showRatingDescriptions": false,
+    "hideRubricFromStudentsInStudentReport": false,
+    "criteriaLabel": "Aspects of Proficiency",
+    "criteriaLabelForStudent": "Your answer should",
+    "feedbackLabelForStudent": "Feedback",
+    "criteriaGroups": [
+        {
+            "label": "Group 1",
+            "labelForStudent": "",
+            "criteria": [
+                {
+                    "id": "0_C1",
+                    "description": "Make a claim, _**supported by evidence**_ that indicates that when the population of one organism changes, the pattern of impact on other organisms is based on the types of interactions between the organisms.",
+                    "descriptionForStudent": "",
+                    "nonApplicableRatings": [
+                        "R2"
+                    ],
+                    "ratingDescriptions": {
+                        "R1": "Student makes a claim _supported_ by evidence that indicates the pattern of impact on both ladybugs and aphids when the population of fire ants changes.",
+                        "R2": "Student makes a claim **supported** by evidence that indicates the pattern of impact on either ladybugs or aphids when the population of fire ants changes.",
+                        "R3": "Student makes a claim _**not supported**_ by evidence or does not make a claim that indicates the pattern of  impact on EITHER ladybugs or aphids when the population of fire ants changes."
+                    },
+                    "ratingDescriptionsForStudent": {},
+                    "iconUrl": "https://ngss-assessment-resources.concord.org/FABLES-stuff/0-DCI.png",
+                    "iconPhrase": "Disciplinary Core Ideas"
+                },
+                {
+                    "id": "0_C2",
+                    "description": "Provide reasoning:\n\n* by stating that interactions between organisms (i.e., competitive and predator-prey)\n\n\n* and how they are distinguished by patterns in data.",
+                    "descriptionForStudent": "Student specific C2 criteria description",
+                    "nonApplicableRatings": [],
+                    "ratingDescriptions": {
+                        "R1": "Student provides reasoning that describes  predator-prey AND mutually beneficial interactions between fire ants/ladybugs and fire ants/aphids, respectively.",
+                        "R2": "Student provides reasoning that describes predator-prey OR mutually beneficial interactions between fire ants/ladybugs and fire ants/aphids, respectively.",
+                        "R3": "Student does not provide reasoning that describes predator-prey OR mutually beneficial  interactions between fire ants/ladybugs and fire ants/aphids, respectively."
+                    },
+                    "ratingDescriptionsForStudent": {
+                        "R1": "Student Specific: R1",
+                        "R2": "Student Specific: R2",
+                        "R3": "Specific: R3"
+                    },
+                    "iconUrl": "https://ngss-assessment-resources.concord.org/FABLES-stuff/2-CCC.png",
+                    "iconPhrase": "Crosscutting Concepts"
+                }
+            ]
+        },
+        {
+            "label": "Group 2",
+            "labelForStudent": "",
+            "criteria": [
+                {
+                    "id": "1_C1",
+                    "description": "C1 Teacher Description here...",
+                    "descriptionForStudent": "",
+                    "nonApplicableRatings": [
+                        "R2"
+                    ],
+                    "ratingDescriptions": {
+                        "R1": "R1 description here",
+                        "R2": "R2 description here",
+                        "R3": "R3 description here"
+                    },
+                    "ratingDescriptionsForStudent": {},
+                    "iconUrl": "https://ngss-assessment-resources.concord.org/FABLES-stuff/0-DCI.png",
+                    "iconPhrase": "Disciplinary Core Ideas"
+                },
+                {
+                    "id": "1_C2",
+                    "description": "C2 Teacher Description here...",
+                    "descriptionForStudent": "",
+                    "nonApplicableRatings": [],
+                    "ratingDescriptions": {
+                        "R1": "R1 description here",
+                        "R2": "R2 description here",
+                        "R3": "R3 description here"
+                    },
+                    "ratingDescriptionsForStudent": {},
+                    "iconUrl": "",
+                    "iconPhrase": ""
+                }
+            ]
+        }
+    ],
+    "ratings": [
+        {
+            "id": "R1",
+            "label": "Proficient",
+            "score": 3
+        },
+        {
+            "id": "R2",
+            "label": "Developing",
+            "score": 2
+        },
+        {
+            "id": "R3",
+            "label": "Beginning",
+            "score": 1
+        }
+    ],
+    "tagSummaryDisplay": "none"
+}

--- a/public/sample-rubric-no-tags.json
+++ b/public/sample-rubric-no-tags.json
@@ -1,0 +1,106 @@
+{
+    "id": "",
+    "version": "1.2.0",
+    "versionNumber": "",
+    "updatedMsUTC": 0,
+    "originUrl": "",
+    "showRatingDescriptions": false,
+    "hideRubricFromStudentsInStudentReport": false,
+    "criteriaLabel": "Aspects of Proficiency",
+    "criteriaLabelForStudent": "Your answer should",
+    "feedbackLabelForStudent": "Feedback",
+    "criteriaGroups": [
+        {
+            "label": "Group 1",
+            "labelForStudent": "",
+            "criteria": [
+                {
+                    "id": "0_C1",
+                    "description": "Make a claim, _**supported by evidence**_ that indicates that when the population of one organism changes, the pattern of impact on other organisms is based on the types of interactions between the organisms.",
+                    "descriptionForStudent": "",
+                    "nonApplicableRatings": [
+                        "R2"
+                    ],
+                    "ratingDescriptions": {
+                        "R1": "Student makes a claim _supported_ by evidence that indicates the pattern of impact on both ladybugs and aphids when the population of fire ants changes.",
+                        "R2": "Student makes a claim **supported** by evidence that indicates the pattern of impact on either ladybugs or aphids when the population of fire ants changes.",
+                        "R3": "Student makes a claim _**not supported**_ by evidence or does not make a claim that indicates the pattern of  impact on EITHER ladybugs or aphids when the population of fire ants changes."
+                    },
+                    "ratingDescriptionsForStudent": {},
+                    "iconUrl": "",
+                    "iconPhrase": ""
+                },
+                {
+                    "id": "0_C2",
+                    "description": "Provide reasoning:\n\n* by stating that interactions between organisms (i.e., competitive and predator-prey)\n\n\n* and how they are distinguished by patterns in data.",
+                    "descriptionForStudent": "Student specific C2 criteria description",
+                    "nonApplicableRatings": [],
+                    "ratingDescriptions": {
+                        "R1": "Student provides reasoning that describes  predator-prey AND mutually beneficial interactions between fire ants/ladybugs and fire ants/aphids, respectively.",
+                        "R2": "Student provides reasoning that describes predator-prey OR mutually beneficial interactions between fire ants/ladybugs and fire ants/aphids, respectively.",
+                        "R3": "Student does not provide reasoning that describes predator-prey OR mutually beneficial  interactions between fire ants/ladybugs and fire ants/aphids, respectively."
+                    },
+                    "ratingDescriptionsForStudent": {
+                        "R1": "Student Specific: R1",
+                        "R2": "Student Specific: R2",
+                        "R3": "Specific: R3"
+                    },
+                    "iconUrl": "",
+                    "iconPhrase": ""
+                }
+            ]
+        },
+        {
+            "label": "Group 2",
+            "labelForStudent": "",
+            "criteria": [
+                {
+                    "id": "1_C1",
+                    "description": "C1 Teacher Description here...",
+                    "descriptionForStudent": "",
+                    "nonApplicableRatings": [],
+                    "ratingDescriptions": {
+                        "R1": "R1 description here",
+                        "R2": "R2 description here",
+                        "R3": "R3 description here"
+                    },
+                    "ratingDescriptionsForStudent": {},
+                    "iconUrl": "",
+                    "iconPhrase": ""
+                },
+                {
+                    "id": "1_C2",
+                    "description": "C2 Teacher Description here...",
+                    "descriptionForStudent": "",
+                    "nonApplicableRatings": [],
+                    "ratingDescriptions": {
+                        "R1": "R1 description here",
+                        "R2": "R2 description here",
+                        "R3": "R3 description here"
+                    },
+                    "ratingDescriptionsForStudent": {},
+                    "iconUrl": "",
+                    "iconPhrase": ""
+                }
+            ]
+        }
+    ],
+    "ratings": [
+        {
+            "id": "R1",
+            "label": "Proficient",
+            "score": 3
+        },
+        {
+            "id": "R2",
+            "label": "Developing",
+            "score": 2
+        },
+        {
+            "id": "R3",
+            "label": "Beginning",
+            "score": 1
+        }
+    ],
+    "tagSummaryDisplay": "none"
+}

--- a/test/util/rubric-summary_spec.ts
+++ b/test/util/rubric-summary_spec.ts
@@ -1,0 +1,76 @@
+import sampleRubric from "../../public/sample-rubric.json";
+import sampleRubricNoTags from "../../public/sample-rubric-no-tags.json";
+import {getRubricSummary} from "../../js/util/rubric-summary";
+import { Rubric } from "../../js/components/portal-dashboard/feedback/rubric-utils";
+import { ICriteriaCount } from "../../js/components/portal-dashboard/feedback/rubric-summary-icon";
+
+const criteriaCounts: ICriteriaCount[] = [
+  {
+    "id": "0_C1",
+    "numStudents": 2,
+    "ratings": {
+      "R1": 1,
+      "R2": 0,
+      "R3": 1
+    }
+  },
+  {
+    "id": "0_C2",
+    "numStudents": 2,
+    "ratings": {
+      "R1": 0,
+      "R2": 1,
+      "R3": 1
+    }
+  },
+  {
+    "id": "1_C1",
+    "numStudents": 2,
+    "ratings": {
+      "R1": 1,
+      "R2": 0,
+      "R3": 1
+    }
+  },
+  {
+    "id": "1_C2",
+    "numStudents": 2,
+    "ratings": {
+      "R1": 1,
+      "R2": 1,
+      "R3": 0
+    }
+  }
+];
+
+describe("util/rubric-summary", () => {
+  describe("getRubricSummary", () => {
+    it("should generate the correct rows for the sample rubric", () => {
+      const summary = getRubricSummary(sampleRubric as Rubric, criteriaCounts);
+
+      expect(summary.tableRows.length).toBe(4);
+      expect(summary.tableRows[0].iconPhrase).toBe("Disciplinary Core Ideas");
+      expect(summary.tableRows[1].iconPhrase).toBe("Crosscutting Concepts");
+      expect(summary.tableRows[2].iconPhrase).toBe("Disciplinary Core Ideas");
+      expect(summary.tableRows[3].iconPhrase).toBe("");
+
+      expect(summary.tagSummaryRows.length).toBe(3);
+      expect(summary.tagSummaryRows[0].text).toBe("Disciplinary Core Ideas");
+      expect(summary.tagSummaryRows[1].text).toBe("Crosscutting Concepts");
+      expect(summary.tagSummaryRows[2].text).toBe("No tag applied");
+    });
+
+    it("should generate the correct rows for the sample rubric with no tags", () => {
+      const summary = getRubricSummary(sampleRubricNoTags as Rubric, criteriaCounts);
+
+      expect(summary.tableRows.length).toBe(4);
+      expect(summary.tableRows[0].iconPhrase).toBe("");
+      expect(summary.tableRows[1].iconPhrase).toBe("");
+      expect(summary.tableRows[2].iconPhrase).toBe("");
+      expect(summary.tableRows[3].iconPhrase).toBe("");
+
+      expect(summary.tagSummaryRows.length).toBe(1);
+      expect(summary.tagSummaryRows[0].text).toBe("Class Results");
+    });
+  });
+});


### PR DESCRIPTION
Also:

1. Added debug:rubricUrlOverride parameter.
2. Added test rubrics.
3. Fixed non-version number change migration for iconPhrase.

**Sample branch urls for testing:**

- https://portal-report.concord.org/branch/add-tag-summary-table/?portal-dashboard=true&debug:rubricSummaryTableOverride=above
- https://portal-report.concord.org/branch/add-tag-summary-table/?portal-dashboard=true&debug:rubricSummaryTableOverride=below&debug:rubricUrlOverride=sample-rubric-no-tags.json
- https://portal-report.concord.org/branch/add-tag-summary-table/?portal-dashboard=true&debug:rubricSummaryTableOverride=onlySummary&debug:rubricUrlOverride=sample-rubric-all-dci-na.json