### PR TITLE
feat: first activity is open by default (CLASSDASH-69)

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-activity-score.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-activity-score.spec.js
@@ -65,7 +65,6 @@ context("Portal Dashboard Anonymous Mode",() =>{
       score.verifyScoreNotDisplayedInRubricScoreHeader();
       cy.get('[data-cy=navigation-select]').click();
       cy.get('[data-cy="list-item-progress-dashboard"]').should('be.visible').click();
-      cy.get('[data-cy="collapsed-activity-button"]').find('[class^=level-viewer--activityInnerButton--]').eq(0).click();
       cy.get('[data-cy="activity-score"]')
       .should("contain", "No")
       .should("contain", "Score");
@@ -109,7 +108,6 @@ context("Portal Dashboard Anonymous Mode",() =>{
       cy.get("[class^='feedback-legend--feedbackBadgeLegend__rubric_score_avg--']").should("contain", "7.5 / 10");
       cy.get('[data-cy=navigation-select]').click();
       cy.get('[data-cy="list-item-progress-dashboard"]').should('be.visible').click();
-      cy.get('[data-cy="collapsed-activity-button"]').find('[class^=level-viewer--activityInnerButton--]').eq(0).click();
       cy.get('[data-cy="activity-score"]')
       .should("contain", "Manual")
       .should("contain", "Score");
@@ -156,7 +154,6 @@ context("Portal Dashboard Anonymous Mode",() =>{
       cy.get('[class^=rubric-summary-icon--rubricSummaryIconRows--]').should("exist");
       cy.get('[data-cy=navigation-select]').click();
       cy.get('[data-cy="list-item-progress-dashboard"]').should('be.visible').click();
-      cy.get('[data-cy="collapsed-activity-button"]').find('[class^=level-viewer--activityInnerButton--]').eq(0).click();
       cy.get('[data-cy="activity-score"]')
       .should("contain", "Rubric")
       .should("contain", "Score");
@@ -187,7 +184,6 @@ context("Portal Dashboard Anonymous Mode",() =>{
       score.verifyScoreNotDisplayedInRubricScoreHeader();
       cy.get('[data-cy=navigation-select]').click();
       cy.get('[data-cy="list-item-progress-dashboard"]').should('be.visible').click();
-      cy.get('[data-cy="collapsed-activity-button"]').find('[class^=level-viewer--activityInnerButton--]').eq(0).click();
       cy.get('[data-cy="activity-score"]')
       .should("contain", "MC Qs")
       .should("contain", "Score");

--- a/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-expand-activities.spec.js
@@ -5,43 +5,43 @@ context("Portal Dashboard Activity Buttons",() =>{
         cy.visit("/?portal-dashboard");
     });
 
-    it('verify we start with the the right number of closed activity buttons',() =>{
-      cy.get('[data-cy=collapsed-activity-button]').should('be.visible');
-      cy.get('[data-cy=collapsed-activity-button]').should('have.length', 2);
+    it('verify we start with the the right number of open and closed activity buttons',() =>{
+      // The first activity button should be expanded by default. Additional buttons should be collapsed.
+      cy.get('[data-cy=expanded-activity-button]').should('have.length', 1);
+      cy.get('[data-cy=collapsed-activity-button]').should('have.length', 1);
+      cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 1: Report Test Activity 1");
+      cy.get('[data-cy=collapsed-activity-button]').first().should("contain", "Report Test Activity 2");
+    });
+
+    it('verify we can click to open a collapsed activity button, and any already-expanded button collapses',() =>{
+      cy.get('[data-cy=activity-question-button]').should('be.visible');
+      cy.get('[data-cy=activity-question-button]').should('have.length', 7);
+      cy.get('[data-cy=activity-question-button]').first().should("contain", "Q1");
+      cy.get('[data-cy=collapsed-activity-button]').first().click();
+      cy.get('[data-cy=collapsed-activity-button]').should('have.length', 1);
+      cy.get('[data-cy=collapsed-activity-button]').first().should("contain", "Report Test Activity 1");
+      cy.get('[data-cy=expanded-activity-button]').should('have.length', 1);
+      cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
+      cy.get('[data-cy=activity-question-button]').should('be.visible');
+      cy.get('[data-cy=activity-question-button]').should('have.length', 12);
+      cy.get('[data-cy=activity-question-button]').first().should("contain", "Q1");
     });
 
     it('verify the preview (external link) buttons are working',() =>{
+      // Preview buttons are only available when the activity button is collapsed. So we check the collapsed button first,
+      // then we expand that button, and check the newly-collapsed button for its preview link.
       cy.get('[data-cy=collapsed-activity-button]')
-        .eq(0)
+        .first()
         .find('[data-cy=external-link-button]')
         .should('have.attr', 'href')
         .and('include', 'http://app.lara.docker/activities/9');
 
+      cy.get('[data-cy=collapsed-activity-button]').first().click();
+
       cy.get('[data-cy=collapsed-activity-button]')
-        .eq(1)
+        .first()
         .find('[data-cy=external-link-button]')
         .should('have.attr', 'href')
         .and('include', 'http://activity-player.concord.org?activity=http://app.lara.docker/activities/10&preview');
-    });
-
-    describe('when clicking on activity buttons', () =>{
-      it('verify we can click to open an activity button and see it expanded',() =>{
-        cy.get('[data-cy=collapsed-activity-button]').first().click();
-        cy.get('[data-cy=expanded-activity-button]').should('have.length', 1);
-        cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 1: Report Test Activity 1");
-        cy.get('[data-cy=collapsed-activity-button]').should('have.length', 1);
-        cy.get('[data-cy=activity-question-button]').should('be.visible');
-        cy.get('[data-cy=activity-question-button]').should('have.length', 7);
-        cy.get('[data-cy=activity-question-button]').first().should("contain", "Q1");
-      });
-
-      it('verify we can click to open the other activity button and the first collapses',() =>{
-        cy.get('[data-cy=collapsed-activity-button]').first().click();
-        cy.get('[data-cy=expanded-activity-button]').should('have.length', 1);
-        cy.get('[data-cy=expanded-activity-button]').first().should("contain", "Activity 2: Report Test Activity 2");
-        cy.get('[data-cy=collapsed-activity-button]').should('have.length', 1);
-        cy.get('[data-cy=activity-question-button]').should('be.visible');
-        cy.get('[data-cy=activity-question-button]').should('have.length', 12);
-      });
     });
 });

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -6,7 +6,6 @@ context("Portal Dashboard Question Details Panel", () => {
   describe('opening and closing the question details panel', () => {
     it('verify we can click to open a question and see the question tab expanded', () => {
       cy.get('[data-cy=question-overlay-header]').should('not.exist');
-      cy.get('[data-cy=collapsed-activity-button]').first().click();
       cy.get('[data-cy=activity-question-button]').first().click();
       cy.get('[data-cy=question-overlay-header]').should('be.visible');
       cy.get('[data-cy=question-overlay]').should("contain", "Question #1");

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-details.spec.js
@@ -4,7 +4,6 @@ context("Portal Dashboard Question Details Panel", () => {
   });
   context('All Responses Header', () => {
     it('verify popup opens from question overlay', () => {
-      cy.get('[data-cy=collapsed-activity-button]').first().click();
       cy.get('[data-cy=activity-question-button]').first().click();
       cy.get('[data-cy=question-overlay-header]').should('be.visible');
       cy.get('[data-cy=view-all-student-responses-button]').should('be.visible').click();
@@ -88,7 +87,6 @@ context("Portal Dashboard Question Details Panel", () => {
     before( function() {
       // Start from a known location
       cy.visit("/?portal-dashboard");
-      cy.get('[data-cy=collapsed-activity-button]').first().click();
       cy.get('[data-cy=activity-question-button]').eq(3).click();
       cy.get('[data-cy=question-overlay] [data-cy=question-overlay-title]').invoke('text').as('questionOverlayTitle');
       cy.get('[data-cy=question-overlay] [data-cy=question-title]').invoke('text').as('questionTitle');
@@ -118,7 +116,7 @@ context("Portal Dashboard Question Details Panel", () => {
       before( function() {
         // Start from a known location
         cy.visit("/?portal-dashboard");
-        cy.get('[data-cy=collapsed-activity-button]').eq(1).click();
+        cy.get('[data-cy=collapsed-activity-button]').first().click();
         // open sidebar focused on the first question
         cy.get('[data-cy=activity-question-button]').first().click();
         // go into response details
@@ -138,7 +136,6 @@ context("Portal Dashboard Question Details Panel", () => {
     before( function() {
       // Start from a known location
       cy.visit("/?portal-dashboard");
-      cy.get('[data-cy=collapsed-activity-button]').first().click();
       // open sidebar focused on the 4th question
       cy.get('[data-cy=activity-question-button]').eq(3).click();
       // go into response details

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
@@ -136,10 +136,12 @@ context("Feedback badges in response table", () => {
 
   it("Activity feedback badge appears in response table when there is feedback given", () => {
     cy.get("[data-cy=collapsed-activity-button]").eq(0).click();
+    cy.wait(500);
     cy.get("[data-cy=activity-feedback-badge]").should("be.visible");
   });
   it("Question feedback badge appears in response table when there is feedback given", () => {
     cy.get("[data-cy=collapsed-activity-button]").eq(0).click();
+    cy.wait(500);
     cy.get("[data-cy=question-feedback-badge]").should("be.visible");
   });
 });

--- a/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-response-table.spec.js
@@ -9,6 +9,7 @@ context("Portal Dashboard Response Table",()=>{
   });
 
   it('verify we display the correct student progress',()=>{
+    cy.get("[data-cy=collapsed-activity-button]").eq(0).click();
     cy.get('[data-cy=student-answers-row]')
       .eq(2)
       .should("contain", "2/7")
@@ -134,6 +135,7 @@ context("Feedback badges in response table", () => {
   });
 
   it("Activity feedback badge appears in response table when there is feedback given", () => {
+    cy.get("[data-cy=collapsed-activity-button]").eq(0).click();
     cy.get("[data-cy=activity-feedback-badge]").should("be.visible");
   });
   it("Question feedback badge appears in response table when there is feedback given", () => {

--- a/cypress/integration/portal-dashboard/portal-dashboard-scrolling.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-scrolling.spec.js
@@ -5,8 +5,6 @@ context("Portal Dashboard Content Scrolling",() =>{
 
   it('verify we scroll and display proper content',()=>{
     cy.viewport(750, 750);
-    cy.get('[data-cy=collapsed-activity-button]').first().click();
-    cy.wait(1000);
 
     cy.get('[data-cy=progress-table]').scrollTo('right');
 

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -103,9 +103,18 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
 
   componentDidUpdate(prevProps: IProps) {
     const { initialLoading } = this.state;
-    const { isFetching } = this.props;
+    const { isFetching, sequenceTree, setCurrentActivity } = this.props;
+
     if (initialLoading && !isFetching && prevProps.isFetching) {
       this.setState({ initialLoading: false });
+
+      // After initial loading, set `currentActivity` to the first activity.
+      if (sequenceTree) {
+        const activityTrees = sequenceTree.get("children");
+        if (activityTrees?.size > 0) {
+          setCurrentActivity(activityTrees.first().get("id"));
+        }
+      }
     }
   }
 

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -108,12 +108,11 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
     if (initialLoading && !isFetching && prevProps.isFetching) {
       this.setState({ initialLoading: false });
 
-      // After initial loading, set `currentActivity` to the first activity.
-      if (sequenceTree) {
-        const activityTrees = sequenceTree.get("children");
-        if (activityTrees?.size > 0) {
-          setCurrentActivity(activityTrees.first().get("id"));
-        }
+      // Set the first activity as the current activity after initial data load.
+      const activityTrees = sequenceTree?.get("children");
+      if (activityTrees?.size > 0) {
+        const firstActivity = activityTrees.first();
+        setCurrentActivity(firstActivity.get("id"));
       }
     }
   }

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -98,7 +98,7 @@ export const getStudentAverageProgress = createSelector(
 export const getCurrentActivity = createSelector(
   [ getActivities, getCurrentActivityId ],
   (activities, currentActivityId) => {
-    return activities.find(activity => activity.get("id") === currentActivityId) || activities.first();
+    return activities.find(activity => activity.get("id") === currentActivityId);
   }
 );
 

--- a/js/selectors/dashboard-selectors.js
+++ b/js/selectors/dashboard-selectors.js
@@ -98,7 +98,7 @@ export const getStudentAverageProgress = createSelector(
 export const getCurrentActivity = createSelector(
   [ getActivities, getCurrentActivityId ],
   (activities, currentActivityId) => {
-    return activities.find(activity => activity.get("id") === currentActivityId);
+    return activities.find(activity => activity.get("id") === currentActivityId) || activities.first();
   }
 );
 


### PR DESCRIPTION
[CLASSDASH-69](https://concord-consortium.atlassian.net/browse/CLASSDASH-69)

If `currentActivity` is not set, we set it to be the first activity. This ensures the first activity is open by default.

Most of the files changed are Cypress test files that needed to be adjusted after the main change in `js/containers/portal-dashboard/portal-dashboard-app.tsx`.

[CLASSDASH-69]: https://concord-consortium.atlassian.net/browse/CLASSDASH-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ