### PR TITLE
chore: change Class Response header text (CLASSDASH-70)

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -121,7 +121,7 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get("[data-cy=collapsed-activity-button]").click();
     });
   });
-  describe('Class Response Area', () => {
+  describe('Class Summary Area', () => {
     it('verify class response area is visible for multiple choice questions', () => {
       cy.get('[data-cy=student-answers-row]').eq(0).find('[data-cy=student-answer]').eq(1).click();
       cy.get('[data-cy=overlay-class-response-area]').should('be.visible');

--- a/js/components/portal-dashboard/overlay-class-response.tsx
+++ b/js/components/portal-dashboard/overlay-class-response.tsx
@@ -34,7 +34,7 @@ export class ClassResponse extends React.PureComponent<IProps, IState> {
     return (
       <div className={css.classResponse} data-cy="overlay-class-response-area">
         <div className={css.responseHeader}>
-          <div className={css.title} data-cy="class-response-title">Class Response</div>
+          <div className={css.title} data-cy="class-response-title">Class Summary</div>
           <div className={css.showHideButton} onClick={this.handleChevronClick} data-cy="show-hide-class-response-button">
             <ArrowIcon className={chevronClass} />
           </div>

--- a/js/components/portal-dashboard/question-overlay.tsx
+++ b/js/components/portal-dashboard/question-overlay.tsx
@@ -30,7 +30,7 @@ interface IProps {
 export class QuestionOverlay extends React.PureComponent<IProps> {
   render() {
     const { students, currentActivity, currentQuestion, isAnonymous, currentStudentId, trackEvent } = this.props;
-    // For now, we only show the Class Response section for multiple choice questions
+    // For now, we only show the Class Summary section for multiple choice questions
     const showClassResponse = currentQuestion?.get("type") === "multiple_choice";
 
     return (


### PR DESCRIPTION
[CLASSDASH-70](https://concord-consortium.atlassian.net/browse/CLASSDASH-70)

Changes the "Class Response" header text to "Class Summary". I decided to leave the class, variable, and component names the same (e.g., `classResponse`). That seemed to me to be a more apt description in the context of the code. I'm open to using "summary" in those things instead, though, if others think that'd be better?

[CLASSDASH-70]: https://concord-consortium.atlassian.net/browse/CLASSDASH-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ