### PR TITLE
chore: base menu item selected state on props (CLASSDASH-67)

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-header.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-header.spec.js
@@ -45,6 +45,36 @@ context("Portal Dashboard Header", () => {
         cy.get("[data-cy=last-run-header]").should("be.visible");
         cy.get("[data-cy=last-run-row]").should("be.visible").and("have.length", 6);
       });
+      it("verify 'Hide Last Run column' option's selected state is maintained across all views", () => {
+        cy.get("[data-cy=header-menu]").click();
+        cy.get("[data-cy=last-run-menu-item]").should("be.visible").click();
+        cy.get("[data-cy=header-menu]").click();
+        cy.get("[data-cy=last-run-menu-item]").find("svg").should("have.attr", "class").and("match", /header--selected--/);
+        cy.get("[data-cy=navigation-select]").click();
+        cy.get("[data-cy=list-item-response-details]").click();
+        cy.get("[data-cy=header-menu]").click();
+        cy.get("[data-cy=last-run-menu-item]").find("svg").should("have.attr", "class").and("match", /header--selected--/);
+        cy.get("[data-cy=navigation-select]").click();
+        cy.get("[data-cy=list-item-feedback-report]").click();
+        cy.get("[data-cy=header-menu]").click();
+        cy.get("[data-cy=last-run-menu-item]").find("svg").should("have.attr", "class").and("match", /header--selected--/);
+        cy.get("[data-cy=navigation-select]").click();
+        cy.get("[data-cy=list-item-progress-dashboard]").click();
+        cy.get("[data-cy=header-menu]").click();
+        cy.get("[data-cy=last-run-menu-item]").find("svg").should("have.attr", "class").and("match", /header--selected--/);
+        cy.get("[data-cy=last-run-menu-item]").click();
+        cy.get("[data-cy=last-run-menu-item]").find("svg").should("have.attr", "class").and("not.match", /header--selected--/);
+        cy.get("[data-cy=navigation-select]").click();
+        cy.get("[data-cy=list-item-response-details]").click();
+        cy.get("[data-cy=header-menu]").click();
+        cy.get("[data-cy=last-run-menu-item]").find("svg").should("have.attr", "class").and("not.match", /header--selected--/);
+        cy.get("[data-cy=navigation-select]").click();
+        cy.get("[data-cy=list-item-feedback-report]").click();
+        cy.get("[data-cy=header-menu]").click();
+        cy.get("[data-cy=last-run-menu-item]").find("svg").should("have.attr", "class").and("not.match", /header--selected--/);
+        cy.get("[data-cy=navigation-select]").click();
+        cy.get("[data-cy=list-item-progress-dashboard]").click();
+      });
     });
     describe("Hide Feedback Badges setting", () => {
       it("verify badge legends are grayed out when menu item is checked", () => {

--- a/js/components/portal-dashboard/header-menu-item.tsx
+++ b/js/components/portal-dashboard/header-menu-item.tsx
@@ -5,21 +5,14 @@ import { ColorTheme } from "../../util/misc";
 
 import css from "../../../css/portal-dashboard/header.less";
 
-interface IState {
-  selected: boolean;
-}
-
 interface IProps {
   menuItem: MenuItemWithState;
   colorTheme?: ColorTheme;
 }
 
-export class HeaderMenuItem extends React.PureComponent<IProps, IState> {
+export class HeaderMenuItem extends React.PureComponent<IProps> {
   constructor(props: IProps) {
     super(props);
-    this.state = {
-      selected: false
-    };
     this.handleSelect = this.handleSelect.bind(this);
   }
 
@@ -28,15 +21,13 @@ export class HeaderMenuItem extends React.PureComponent<IProps, IState> {
     const colorClass = colorTheme ? css[colorTheme] : "";
     return (
       <div className={`${css.menuItem} ${colorClass}`} onClick={this.handleSelect} data-cy={menuItem.dataCy}>
-        <CheckIcon className={`${css.check} ${colorClass} ${this.state.selected ? css.selected : ""}`} />
+        <CheckIcon className={`${css.check} ${colorClass} ${menuItem.selected ? css.selected : ""}`} />
         <div className={css.menuItemName}>{menuItem.name}</div>
       </div>
     );
   }
 
   private handleSelect() {
-    this.props.menuItem.onSelect(!this.state.selected);
-    this.setState({ selected: !this.state.selected });
+    this.props.menuItem.onSelect(!this.props.menuItem.selected);
   }
-
 }

--- a/js/components/portal-dashboard/header-menu.tsx
+++ b/js/components/portal-dashboard/header-menu.tsx
@@ -23,12 +23,16 @@ interface IProps {
   setHideFeedbackBadges?: (value: boolean) => void;
   colorTheme?: ColorTheme;
   trackEvent: TrackEventFunction;
+  compactStudentList?: boolean;
+  hideLastRun?: boolean;
+  hideFeedbackBadges?: boolean;
 }
 
 export interface MenuItemWithState {
   name: string;
   onSelect: (selected: boolean) => void;
   dataCy: string;
+  selected: boolean;
 }
 
 interface MenuItemWithIcon {
@@ -118,11 +122,11 @@ export class HeaderMenuContainer extends React.PureComponent<IProps, IState> {
       trackEvent("Portal-Dashboard", "HideFeedbackBadges", {label: value.toString()});
     };
     this.props.setCompact && itemsWithState.push(
-      { name: "Compact student list", onSelect: setCompact, dataCy: "compact-menu-item" });
+      { name: "Compact student list", onSelect: setCompact, dataCy: "compact-menu-item", selected: !!this.props.compactStudentList });
     this.props.setHideLastRun && itemsWithState.push(
-      { name: "Hide Last Run column", onSelect: setHideLastRun, dataCy: "last-run-menu-item" });
+      { name: "Hide Last Run column", onSelect: setHideLastRun, dataCy: "last-run-menu-item", selected: !!this.props.hideLastRun });
     this.props.setHideFeedbackBadges && itemsWithState.push(
-      { name: "Hide feedback badges", onSelect: setHideFeedbackBadges, dataCy: "feedback-menu-item" });
+      { name: "Hide feedback badges", onSelect: setHideFeedbackBadges, dataCy: "feedback-menu-item", selected: !!this.props.hideFeedbackBadges });
     return (
       <div className={`${css.menuList} ${(this.state.showMenuItems ? css.show : "")}`} data-cy="menu-list">
         <div className={css.topMenu}>

--- a/js/components/portal-dashboard/header.tsx
+++ b/js/components/portal-dashboard/header.tsx
@@ -29,12 +29,15 @@ interface IProps {
   clazzName: string;
   setStudentSort: (sort: SortOption) => void;
   sortByMethod: SortOption;
+  compactStudentList?: boolean;
+  hideLastRun?: boolean;
+  hideFeedbackBadges?: boolean;
 }
 
 export class Header extends React.PureComponent<IProps> {
   render() {
     const { colorTheme, userName, setCompact, setHideLastRun, setHideFeedbackBadges, trackEvent,
-            isResearcher, clazzName } = this.props;
+            isResearcher, clazzName, compactStudentList, hideLastRun, hideFeedbackBadges } = this.props;
     const colorClass = colorTheme ? css[colorTheme] : "";
 
     return (
@@ -58,6 +61,9 @@ export class Header extends React.PureComponent<IProps> {
               setHideFeedbackBadges={setHideFeedbackBadges}
               colorTheme={colorTheme}
               trackEvent={trackEvent}
+              compactStudentList={compactStudentList}
+              hideLastRun={hideLastRun}
+              hideFeedbackBadges={hideFeedbackBadges}
             />
           </div>
         </div>

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -288,7 +288,7 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
 
   private renderHeader = (assignmentName: string, headerViewMode: DashboardViewMode, setStudentSort: (value: string) => void) => {
     const { sequenceTree, userName, setCompactReport, setHideLastRun, setHideFeedbackBadges, trackEvent, isResearcher,
-            clazzName, sortByMethod } = this.props;
+            clazzName, sortByMethod, compactReport, hideLastRun, hideFeedbackBadges } = this.props;
     const { viewMode} = this.state;
     const color: ColorTheme = headerViewMode === "ProgressDashboard"
       ? "progress"
@@ -310,6 +310,9 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
           clazzName={clazzName}
           setStudentSort={setStudentSort}
           sortByMethod={sortByMethod}
+          compactStudentList={compactReport}
+          hideLastRun={hideLastRun}
+          hideFeedbackBadges={hideFeedbackBadges}
         />
     );
   }


### PR DESCRIPTION
[CLASSDASH-67](https://concord-consortium.atlassian.net/browse/CLASSDASH-67)

This fixes an issue where the "Hide Last Run column" item in the header menu's selected state wasn't properly maintained across all views.

[CLASSDASH-67]: https://concord-consortium.atlassian.net/browse/CLASSDASH-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ