### PR TITLE
fix: ensure QuestionFeedbackPanel gets prop values [CLASSDASH-96]

### DIFF
--- a/js/components/portal-dashboard/response-details/response-details.tsx
+++ b/js/components/portal-dashboard/response-details/response-details.tsx
@@ -200,7 +200,9 @@ export class ResponseDetails extends React.PureComponent<IProps, IState> {
                   answers={answers}
                   currentQuestion={currentQuestion || firstQuestion}
                   currentStudentId={currentStudentId}
+                  hideLastRun={hideLastRun}
                   isAnonymous={isAnonymous}
+                  isCompact={compactReport}
                   listViewMode={listViewMode}
                   feedbackLevel={feedbackLevel}
                   isResearcher={isResearcher}


### PR DESCRIPTION
[CLASSDASH-96](https://concord-consortium.atlassian.net/browse/CLASSDASH-96)

The [previous fix for this issue](https://github.com/concord-consortium/portal-report/pull/505) wasn't quite complete. The Last Run column was appearing correctly, but it wasn't getting hidden when the "Hide Last Run column" option was selected in the question-level feedback view.

This change ensures `hideLastRun` is properly set on `QuestionFeedbackPanel` when it's rendered by its parent.

[CLASSDASH-96]: https://concord-consortium.atlassian.net/browse/CLASSDASH-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ