### PR TITLE
fix: Show an error when the activity structure is missing [CLASSDASH-112]

### DIFF
--- a/css/report/data-fetch-error.less
+++ b/css/report/data-fetch-error.less
@@ -15,4 +15,17 @@
     margin-block-start: 1em;
     margin-block-end: 0.5em;
   }
+
+  .user-message {
+    margin-block-end: 1.25em;
+  }
+
+  .error-details {
+    font-size: 0.8em;
+    color: #777;
+
+    div {
+      margin-block-end: 0.25em;
+    }
+  }
 }

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -259,6 +259,9 @@ function watchResourceStructure(db: firebase.firestore.Firestore,
   // Setup Firebase observer. It will fire each time the resource structure is updated.
   const query = db.collection(`sources/${source}/resources`)
     .where("url", "==", resourceUrl);
+  // onSnapshot can fire more than once (e.g. a cached snapshot followed by the
+  // server snapshot), so only surface the missing-structure error once.
+  let resourceStructureMissingReported = false;
   addSnapshotDispatchListener(query, RECEIVE_RESOURCE_STRUCTURE, dispatch,
     snapshot => snapshot.docs[0].data(),
     // If the resource structure document is missing, the snapshot is empty, so
@@ -266,6 +269,10 @@ function watchResourceStructure(db: firebase.firestore.Firestore,
     // stuck on the loading spinner forever with no feedback. Surface an error
     // instead so DataFetchError is shown. See CLASSDASH-112.
     () => {
+      if (resourceStructureMissingReported) {
+        return;
+      }
+      resourceStructureMissingReported = true;
       // Technical detail for developers; the teacher sees `userMessage` instead.
       const technicalDetail =
         `Resource structure not found in Firebase app "${getFirebaseAppName()}" at ` +

--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -1,4 +1,4 @@
-import { getFirestore } from "../db";
+import { getFirestore, getFirebaseAppName } from "../db";
 import fakeSequenceStructure from "../data/sequence-structure.json";
 import fakeActivityStructure from "../data/activity-structure.json";
 import fakeAnswers from "../data/answers.json";
@@ -240,13 +240,16 @@ type SnapshotHandler = (snapshot: firebase.firestore.QuerySnapshot) => any;
 
 function addSnapshotDispatchListener(query: firebase.firestore.Query, receiveMsg: string,
   dispatch: Dispatch,
-  handler: SnapshotHandler) {
+  handler: SnapshotHandler,
+  onEmpty?: () => void) {
   query.onSnapshot(snapshot => {
     if (!snapshot.empty) {
       dispatch({
         type: receiveMsg,
         response: handler(snapshot)
       });
+    } else {
+      onEmpty?.();
     }
   }, fireStoreError(receiveMsg, dispatch));
 }
@@ -257,7 +260,29 @@ function watchResourceStructure(db: firebase.firestore.Firestore,
   const query = db.collection(`sources/${source}/resources`)
     .where("url", "==", resourceUrl);
   addSnapshotDispatchListener(query, RECEIVE_RESOURCE_STRUCTURE, dispatch,
-    snapshot => snapshot.docs[0].data());
+    snapshot => snapshot.docs[0].data(),
+    // If the resource structure document is missing, the snapshot is empty, so
+    // RECEIVE_RESOURCE_STRUCTURE would never be dispatched and the report would be
+    // stuck on the loading spinner forever with no feedback. Surface an error
+    // instead so DataFetchError is shown. See CLASSDASH-112.
+    () => {
+      // Technical detail for developers; the teacher sees `userMessage` instead.
+      const technicalDetail =
+        `Resource structure not found in Firebase app "${getFirebaseAppName()}" at ` +
+        `sources/${source}/resources for url "${resourceUrl}". ` +
+        `The activity may not have been published to the report service.`;
+      console.error(technicalDetail);
+      dispatch(fetchError({
+        status: 404,
+        statusText: technicalDetail,
+        url: resourceUrl,
+        title: "This report isn't available yet",
+        userMessage: "We couldn't load the Class Dashboard for this activity because the activity " +
+          "hasn't finished publishing to the reporting system. This can happen when an activity was " +
+          "only recently created or changed. Please try again later, and let Concord Consortium know " +
+          "if the problem continues."
+      }));
+    });
 }
 
 function watchFireStoreReportSettings(db: firebase.firestore.Firestore, rawPortalData: IPortalRawData, dispatch: Dispatch) {

--- a/js/api.ts
+++ b/js/api.ts
@@ -61,6 +61,11 @@ export interface IResponse {
   url?: string;
   status: number;
   statusText: string;
+  // Optional fields rendered by the DataFetchError component. `title` is the
+  // heading; `userMessage` is a friendly explanation shown to teachers, with the
+  // technical `statusText` displayed below it in smaller print.
+  title?: string;
+  userMessage?: string;
 }
 
 export interface IFirebaseJWT {

--- a/js/components/report/data-fetch-error.js
+++ b/js/components/report/data-fetch-error.js
@@ -73,7 +73,25 @@ export default class DataFetchError extends PureComponent {
     );
   }
 
+  // A friendly explanation for the user, with the technical details shown
+  // below it in smaller print.
+  renderUserMessage(error) {
+    return (
+      <div>
+        <div className="user-message">{error.userMessage}</div>
+        <div className="error-details">
+          {error.url && <div>URL: {error.url}</div>}
+          <div>Status: {error.status}</div>
+          <div>Details: {error.statusText}</div>
+        </div>
+      </div>
+    );
+  }
+
   renderError(error) {
+    if (error.userMessage) {
+      return this.renderUserMessage(error);
+    }
     if (this.state.errorBodyText) {
       return this.renderGenericMessage(this.state.errorBodyText);
     }

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -48,7 +48,9 @@ interface IProps {
   questions?: Map<string, any>;
   questionFeedbacks: Map<any, any>;
   report: any;
-  sequenceTree: Map<any, any>;
+  // `false` when the data failed to load - see mapStateToProps. Typing it
+  // honestly makes TypeScript enforce the guards before Immutable calls.
+  sequenceTree: Map<any, any> | false;
   hideFeedbackBadges: boolean;
   hideLastRun: boolean;
   sortByMethod: SortOption;

--- a/js/containers/portal-dashboard/portal-dashboard-app.tsx
+++ b/js/containers/portal-dashboard/portal-dashboard-app.tsx
@@ -114,8 +114,10 @@ class PortalDashboardApp extends React.PureComponent<IProps, IState> {
       this.setState({ initialLoading: false });
 
       // Set the first activity as the current activity after initial data load.
-      const activityTrees = sequenceTree?.get("children");
-      if (activityTrees?.size > 0) {
+      // sequenceTree is `false` (not undefined) when data failed to load, so it
+      // can't be guarded with `?.` - that would call `.get` on the boolean.
+      const activityTrees = sequenceTree && sequenceTree.get("children");
+      if (activityTrees && activityTrees.size > 0) {
         const firstActivity = activityTrees.first();
         setCurrentActivity(firstActivity.get("id"));
       }

--- a/test/components/report/data-fetch-error_spec.js
+++ b/test/components/report/data-fetch-error_spec.js
@@ -29,6 +29,32 @@ describe("<DataFetchError />", () => {
     });
   });
 
+  describe("when the error has a userMessage", () => {
+    beforeEach(() => {
+      dataFetchError = mount(<DataFetchError
+        error={{
+          title: "This report isn't available yet",
+          userMessage: "We couldn't load the Class Dashboard for this activity.",
+          url: "http://example.com/activities/123",
+          status: 404,
+          statusText: "Resource structure not found"
+        }}
+      />);
+    });
+
+    it("should render the teacher-friendly message", () => {
+      expect(dataFetchError.text())
+        .toEqual(expect.stringContaining("We couldn't load the Class Dashboard for this activity."));
+    });
+
+    it("should render the technical details block", () => {
+      const text = dataFetchError.text();
+      expect(text).toEqual(expect.stringContaining("URL: http://example.com/activities/123"));
+      expect(text).toEqual(expect.stringContaining("Status: 404"));
+      expect(text).toEqual(expect.stringContaining("Resource structure not found"));
+    });
+  });
+
   // <div>URL: {error.url}</div>
   // <div>Status: {error.status}</div>
   // <div>Status text: {error.statusText}</div>


### PR DESCRIPTION
Previously the Class Dashboard would spin forever with no console error when an activity's structure document was not found in the report-service Firestore: empty Firestore snapshots were silently ignored, so isFetching was never cleared.

- watchResourceStructure now dispatches a fetch error on an empty resource-structure snapshot, so DataFetchError is shown instead.
- Fix a crash in PortalDashboardApp.componentDidUpdate: sequenceTree is `false` (not undefined) on the error path, and `?.` does not short-circuit on `false`.
- DataFetchError shows a teacher-friendly message with the technical details (including the Firebase app name) below in smaller print.

---

Here is what the friendly error message looks like:

<img width="711" height="445" alt="image" src="https://github.com/user-attachments/assets/2c177f2f-653e-4457-bfbb-81b64cbdebc4" />
