### PR TITLE
feat: Add support email to the missing-structure error message [CLASSDASH-112]

### DIFF
--- a/js/actions/index.ts
+++ b/js/actions/index.ts
@@ -286,8 +286,8 @@ function watchResourceStructure(db: firebase.firestore.Firestore,
         title: "This report isn't available yet",
         userMessage: "We couldn't load the Class Dashboard for this activity because the activity " +
           "hasn't finished publishing to the reporting system. This can happen when an activity was " +
-          "only recently created or changed. Please try again later, and let Concord Consortium know " +
-          "if the problem continues."
+          "only recently created or changed. Please try again later. If the problem continues, " +
+          "contact help@concord.org."
       }));
     });
 }


### PR DESCRIPTION
## Summary

Follow-up to #516. The "report isn't available yet" error shown to teachers when an activity's resource structure is missing now tells them who to contact.

Per a Slack request, the message ends with: *"If the problem continues, contact help@concord.org."* (previously "let Concord Consortium know if the problem continues").

## Notes

- `userMessage` is rendered as plain text in `DataFetchError`, so the address shows as readable text, not a clickable `mailto:` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)