### PR TITLE
feat: Support top-level multiple_answers on MC questions [CLASSDASH-114]

### DIFF
--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -163,6 +163,24 @@ context("Portal Dashboard Question Details Panel", () => {
       cy.get('[data-cy=overlay-class-response-area] [data-cy=multiple-choice-answers]')
         .should('have.text', 'Question doesn\'t have any choices');
     });
+    it('renders multi-answer icons when question has top-level multiple_answers (CLASSDASH-114)', () => {
+      // multiple_choice_22 (Q3) has top-level multiple_answers:true in the fixture.
+      cy.get('[data-cy="activity-question-button"]').eq(2).click();
+      cy.get('[data-cy=question-overlay]').should('contain', 'Question #3');
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=multi-answer-choice-icon]')
+        .should('have.length.greaterThan', 0);
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=single-answer-choice-icon]')
+        .should('not.exist');
+    });
+    it('falls back to authored_state.multipleAnswers when no top-level field (CLASSDASH-114)', () => {
+      // multiple_choice_19 (Q2) has authored_state.multipleAnswers:true but no top-level field.
+      cy.get('[data-cy="activity-question-button"]').eq(1).click();
+      cy.get('[data-cy=question-overlay]').should('contain', 'Question #2');
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=multi-answer-choice-icon]')
+        .should('have.length.greaterThan', 0);
+      cy.get('[data-cy=overlay-class-response-area] [data-cy=single-answer-choice-icon]')
+        .should('not.exist');
+    });
     it('verify show/hide button behaves correctly', () => {
       cy.get('[data-cy=overlay-class-response-area] [data-cy=show-hide-class-response-button]').should('be.visible').click();
       cy.get('[data-cy=overlay-class-response-area] [data-cy=class-response-content]').should('not.be.visible');

--- a/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
+++ b/cypress/integration/portal-dashboard/portal-dashboard-question-details.spec.js
@@ -165,7 +165,7 @@ context("Portal Dashboard Question Details Panel", () => {
     });
     it('renders multi-answer icons when question has top-level multiple_answers (CLASSDASH-114)', () => {
       // multiple_choice_22 (Q3) has top-level multiple_answers:true in the fixture.
-      cy.get('[data-cy="activity-question-button"]').eq(2).click();
+      cy.get('[data-cy=activity-question-button]').eq(2).click();
       cy.get('[data-cy=question-overlay]').should('contain', 'Question #3');
       cy.get('[data-cy=overlay-class-response-area] [data-cy=multi-answer-choice-icon]')
         .should('have.length.greaterThan', 0);
@@ -174,7 +174,7 @@ context("Portal Dashboard Question Details Panel", () => {
     });
     it('falls back to authored_state.multipleAnswers when no top-level field (CLASSDASH-114)', () => {
       // multiple_choice_19 (Q2) has authored_state.multipleAnswers:true but no top-level field.
-      cy.get('[data-cy="activity-question-button"]').eq(1).click();
+      cy.get('[data-cy=activity-question-button]').eq(1).click();
       cy.get('[data-cy=question-overlay]').should('contain', 'Question #2');
       cy.get('[data-cy=overlay-class-response-area] [data-cy=multi-answer-choice-icon]')
         .should('have.length.greaterThan', 0);

--- a/js/components/portal-dashboard/choice.tsx
+++ b/js/components/portal-dashboard/choice.tsx
@@ -94,7 +94,7 @@ const Choice: React.FC<IProps> = (props) => {
   return (
     <div className={css.choice}>
       <div className={css.choiceDetails}>
-        <div className={css.choiceIcon} data-cy="multiple-choice-choice-icon">
+        <div className={css.choiceIcon} data-cy={multipleAnswer ? "multi-answer-choice-icon" : "single-answer-choice-icon"}>
           {icon}
         </div>
         <div className={css.choiceContent}>

--- a/js/components/portal-dashboard/multiple-choice-choices.tsx
+++ b/js/components/portal-dashboard/multiple-choice-choices.tsx
@@ -98,7 +98,7 @@ const MultipleChoiceChoices: React.FC<IProps> = (props) => {
   const {answers, choices: _choices, inQuestionDetailsPanel, question, showStats = false, studentAnswer, students } = props;
   const choices = List(_choices || question.get("choices") || []) as List<Map<string, any>>;
   const choiceData = buildChoiceData(choices, answers, students, studentAnswer, inQuestionDetailsPanel);
-  const multipleAnswer = question?.get("authoredState")?.get("multipleAnswers");
+  const multipleAnswer = question?.get("multipleAnswers") ?? question?.get("authoredState")?.get("multipleAnswers");
   const correctAnswerDefined = question.get("scored");
 
   return (

--- a/js/data/activity-structure.json
+++ b/js/data/activity-structure.json
@@ -130,7 +130,7 @@
                   "question_number": 6,
                   "show_in_featured_question_report": true,
                   "type": "multiple_choice",
-                  "multi_answer": true
+                  "multiple_answers": true
                 }
           ]
         },

--- a/js/data/sequence-structure.json
+++ b/js/data/sequence-structure.json
@@ -54,7 +54,10 @@
                   "prompt": "<p>Multiple choice question prompt (no correct answer defined)</p>",
                   "question_number": 2,
                   "show_in_featured_question_report": true,
-                  "type": "multiple_choice"
+                  "type": "multiple_choice",
+                  "authored_state": {
+                    "multipleAnswers": true
+                  }
                 },
                 {
                   "choices": [
@@ -78,7 +81,8 @@
                   "prompt": "<p>Multiple choice prompt (correct answer defined)</p>",
                   "question_number": 3,
                   "show_in_featured_question_report": true,
-                  "type": "multiple_choice"
+                  "type": "multiple_choice",
+                  "multiple_answers": true
                 },
                 {
                   "id": "open_response_61",


### PR DESCRIPTION
## Summary
- Read a new top-level `multipleAnswers` field on multiple-choice questions and fall back to `authoredState.multipleAnswers` so old report-structure documents keep working without a Firestore migration. (See [CLASSDASH-114](https://concord-consortium.atlassian.net/browse/CLASSDASH-114).)
- Encode multi-answer vs single-answer state into the choice icon's `data-cy` value (`multi-answer-choice-icon` / `single-answer-choice-icon`) so Cypress can verify which icon style rendered without inspecting SVG internals.
- Rename the dead `multi_answer` field in `activity-structure.json` to the new `multiple_answers` name (it was previously read by nothing).

## Background
LARA publishes the report structure as a single Firestore document and writes `authored_state` as a native Firestore object. Some valid JSON shapes aren't expressible as Firestore objects, which can break publishing (CLASSDASH-112 / LARA-212). LARA will start publishing `multiple_answers` at the top level of multiple-choice questions so the Class Dashboard doesn't need to crack open `authored_state` to find it. The portal-report's only read site for that field is [`multiple-choice-choices.tsx:101`](js/components/portal-dashboard/multiple-choice-choices.tsx#L101); this PR updates it to prefer the new field.

`??` (nullish coalescing) is used rather than `||` so an authored top-level `false` wins over a stale truthy value in `authoredState`.

## Test plan
- [x] Existing Cypress specs in `cypress/integration/portal-dashboard/*` and `cypress/integration/dashboard-multiple-choice.spec.js` all pass locally (130 tests, 129 passing, 1 pre-existing skip).
- [x] Two new Cypress assertions in `portal-dashboard-question-details.spec.js` cover both branches of the `??`:
  - top-level `multiple_answers: true` on `multiple_choice_22` (Q3) — verifies the new read path
  - `authored_state: { multipleAnswers: true }` on `multiple_choice_19` (Q2) — verifies the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLASSDASH-114]: https://concord-consortium.atlassian.net/browse/CLASSDASH-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ